### PR TITLE
Add check that scope is vaild

### DIFF
--- a/src/Symfony2/Rector/MethodCall/AddFlashRector.php
+++ b/src/Symfony2/Rector/MethodCall/AddFlashRector.php
@@ -74,6 +74,10 @@ CODE_SAMPLE
     {
         /** @var Scope $scope */
         $scope = $node->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
+            return null;
+        }
+
         $classReflection = $scope->getClassReflection();
         if (! $classReflection instanceof ClassReflection) {
             return null;


### PR DESCRIPTION
When i run rector, i have the following error:
```
[ERROR] Could not process "src/SomeMyNamespace/SomeMyClass.php" file by
         "Rector\Symfony2\Rector\MethodCall\AddFlashRector", due to:
         "Call to a member function getClassReflection() on null".
```