### PR TITLE
Migration: SwiftMailer to Symfony/Mailer

### DIFF
--- a/config/sets/swiftmailer/swiftmailer-to-symfony-mailer.php
+++ b/config/sets/swiftmailer/swiftmailer-to-symfony-mailer.php
@@ -3,16 +3,19 @@
 declare(strict_types=1);
 
 use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Symfony\Rector\MethodCall\SwiftCreateMessageToNewEmailRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 // @see https://symfony.com/blog/the-end-of-swiftmailer
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
+    $services->set(SwiftCreateMessageToNewEmailRector::class);
     $services->set(RenameClassRector::class)
         ->call('configure', [[
             RenameClassRector::OLD_TO_NEW_CLASSES => [
                 '\Swift_Mailer' => 'Symfony\Component\Mailer\MailerInterface',
+                '\Swift_Message' => 'Symfony\Component\Mime\Email',
             ],
         ]]);
 };

--- a/config/sets/swiftmailer/swiftmailer-to-symfony-mailer.php
+++ b/config/sets/swiftmailer/swiftmailer-to-symfony-mailer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+// @see https://symfony.com/blog/the-end-of-swiftmailer
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(RenameClassRector::class)
+        ->call('configure', [[
+            RenameClassRector::OLD_TO_NEW_CLASSES => [
+                '\Swift_Mailer' => 'Symfony\Component\Mailer\MailerInterface',
+            ],
+        ]]);
+};

--- a/src/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
+++ b/src/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
@@ -42,7 +42,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class TemplateAnnotationToThisRenderRector extends AbstractRector
 {
     /**
-     * @var string
+     * @var class-string
      */
     private const RESPONSE_CLASS = 'Symfony\Component\HttpFoundation\Response';
 

--- a/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
+++ b/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
@@ -33,8 +33,6 @@ final class SwiftCreateMessageToNewEmailRector extends AbstractRector
             return null;
         }
 
-        $newEmail = new Node\Expr\New_(new Node\Name\FullyQualified('Symfony\Component\Mime\Email'));
-
-        return new Node\Expr\MethodCall($newEmail, 'subject');
+        return new Node\Expr\New_(new Node\Name\FullyQualified('Symfony\Component\Mime\Email'));
     }
 }

--- a/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
+++ b/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
@@ -6,7 +6,9 @@ declare(strict_types=1);
 namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
 use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class SwiftCreateMessageToNewEmailRector extends AbstractRector
@@ -14,20 +16,40 @@ final class SwiftCreateMessageToNewEmailRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('', []);
-    }
+        return new RuleDefinition(
+            'Changes SwiftMailer\'s createMessage into a new Symfony\Component\Mime\Email',
+            [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+public function createMessage()
+{
+    $email = $this->swift->createMessage('message');
+}
+CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+public function createMessage()
+{
+    $email = new \Symfony\Component\Mime\Email();
+}
+CODE_SAMPLE
 
-    public function getNodeTypes(): array
-    {
-        return [
-            Node\Expr\MethodCall::class
-        ];
+
+            )
+        ]);
     }
 
     /**
-     * @var Node\Expr\MethodCall $node
+     * @return array<class-string<Node>>
      */
-    public function refactor(Node $node)
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
     {
         if (!$this->isName($node->name, 'createMessage')) {
             return null;

--- a/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
+++ b/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
@@ -7,6 +7,8 @@ namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name\FullyQualified;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -55,6 +57,6 @@ CODE_SAMPLE
             return null;
         }
 
-        return new Node\Expr\New_(new Node\Name\FullyQualified('Symfony\Component\Mime\Email'));
+        return new New_(new FullyQualified('Symfony\Component\Mime\Email'));
     }
 }

--- a/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
+++ b/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
@@ -2,42 +2,50 @@
 
 declare(strict_types=1);
 
-
 namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\PropertyProperty;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
+/**
+ * @see \Rector\Symfony\Tests\Rector\MethodCall\SwiftCreateMessageToNewEmailRector\SwiftCreateMessageToNewEmailRectorTest
+ */
 final class SwiftCreateMessageToNewEmailRector extends AbstractRector
 {
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
             'Changes SwiftMailer\'s createMessage into a new Symfony\Component\Mime\Email',
             [
-            new CodeSample(
-                <<<'CODE_SAMPLE'
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
 public function createMessage()
 {
     $email = $this->swift->createMessage('message');
 }
-CODE_SAMPLE,
-                <<<'CODE_SAMPLE'
+CODE_SAMPLE
+,
+                    <<<'CODE_SAMPLE'
 public function createMessage()
 {
     $email = new \Symfony\Component\Mime\Email();
 }
 CODE_SAMPLE
-
-
-            )
-        ]);
+                ),
+            ]
+        );
     }
 
     /**
@@ -53,10 +61,68 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (!$this->isName($node->name, 'createMessage')) {
+        if ($this->shouldSkip($node)) {
             return null;
         }
 
         return new New_(new FullyQualified('Symfony\Component\Mime\Email'));
+    }
+
+    private function shouldSkip(MethodCall $methodCall): bool
+    {
+        if (! $this->isName($methodCall->name, 'createMessage')) {
+            return true;
+        }
+
+        // If there is no property with a SwiftMailer type we should skip this class
+        $swiftMailerProperty = $this->getSwiftMailerProperty($methodCall);
+        if ($swiftMailerProperty === null) {
+            return true;
+        }
+
+        /** @var PropertyFetch $var */
+        $var = $methodCall->var;
+        if (! $var instanceof PropertyFetch) {
+            return true;
+        }
+
+        $propertyName = $this->getPropertyIdentifier($swiftMailerProperty->props);
+        return ! $this->isName($var->name, $propertyName);
+    }
+
+    private function getSwiftMailerProperty(MethodCall $classMethod): ?Property
+    {
+        /** @var Class_ $class */
+        $class = $classMethod->getAttribute(AttributeKey::CLASS_NODE);
+
+        if (! $class instanceof Class_) {
+            return null;
+        }
+
+        $properties = $class->getProperties();
+        foreach ($properties as $property) {
+            /** @var ObjectType $resolved */
+            $resolved = $this->nodeTypeResolver->resolve($property);
+            if (! $resolved instanceof ObjectType) {
+                continue;
+            }
+            if ($resolved->getClassName() === 'Swift_Mailer') {
+                return $property;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param PropertyProperty[] $propertyProperties
+     */
+    private function getPropertyIdentifier(array $propertyProperties): string
+    {
+        foreach ($propertyProperties as $propertyProperty) {
+            return (string) $propertyProperty->name;
+        }
+
+        throw new ShouldNotHappenException();
     }
 }

--- a/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
+++ b/src/Rector/MethodCall/SwiftCreateMessageToNewEmailRector.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Rector\Symfony\Rector\MethodCall;
+
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class SwiftCreateMessageToNewEmailRector extends AbstractRector
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('', []);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\MethodCall::class
+        ];
+    }
+
+    /**
+     * @var Node\Expr\MethodCall $node
+     */
+    public function refactor(Node $node)
+    {
+        if (!$this->isName($node->name, 'createMessage')) {
+            return null;
+        }
+
+        $newEmail = new Node\Expr\New_(new Node\Name\FullyQualified('Symfony\Component\Mime\Email'));
+
+        return new Node\Expr\MethodCall($newEmail, 'subject');
+    }
+}

--- a/src/Set/SwiftmailerSetList.php
+++ b/src/Set/SwiftmailerSetList.php
@@ -12,4 +12,9 @@ final class SwiftmailerSetList implements SetListInterface
      * @var string
      */
     public const SWIFTMAILER_60 = __DIR__ . '/../../config/sets/swiftmailer/swiftmailer60.php';
+
+    /**
+     * @var string
+     */
+    public const SWIFTMAILER_TO_SYMFONY_MAILER = __DIR__ . '/../../config/sets/swiftmailer/swiftmailer-to-symfony-mailer.php';
 }

--- a/src/TypeDeclaration/ReturnTypeDeclarationUpdater.php
+++ b/src/TypeDeclaration/ReturnTypeDeclarationUpdater.php
@@ -14,13 +14,11 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\ValueObject\Type\FullyQualifiedIdentifierTypeNode;
 use Rector\Core\Php\PhpVersionProvider;
 use Rector\Core\ValueObject\PhpVersionFeature;
-use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 
 final class ReturnTypeDeclarationUpdater
 {
     public function __construct(
-        private NodeNameResolver $nodeNameResolver,
         private PhpVersionProvider $phpVersionProvider,
         private StaticTypeMapper $staticTypeMapper,
         private PhpDocInfoFactory $phpDocInfoFactory

--- a/stubs/SwiftMailer/Swift_Mailer.php
+++ b/stubs/SwiftMailer/Swift_Mailer.php
@@ -1,0 +1,3 @@
+<?php
+
+class Swift_Mailer{}

--- a/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/Fixture/fixture.php.inc
@@ -2,9 +2,13 @@
 
 namespace Rector\Symfony\Tests\Rector\MethodCall\SwiftCreateMessageToNewEmailRector\Fixture;
 
+use Swift_Mailer;
+
 class Fixture
 {
-    public function __construct(\Swift_Mailer $swift)
+    private $swift;
+
+    public function __construct(Swift_Mailer $swift)
     {
         $this->swift = $swift;
     }
@@ -21,9 +25,13 @@ class Fixture
 
 namespace Rector\Symfony\Tests\Rector\MethodCall\SwiftCreateMessageToNewEmailRector\Fixture;
 
+use Swift_Mailer;
+
 class Fixture
 {
-    public function __construct(\Swift_Mailer $swift)
+    private $swift;
+
+    public function __construct(Swift_Mailer $swift)
     {
         $this->swift = $swift;
     }

--- a/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/Fixture/fixture.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\SwiftCreateMessageToNewEmailRector\Fixture;
+
+class Fixture
+{
+    public function __construct(\Swift_Mailer $swift)
+    {
+        $this->swift = $swift;
+    }
+
+    public function createMessage()
+    {
+        $email = $this->swift->createMessage('message');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\SwiftCreateMessageToNewEmailRector\Fixture;
+
+class Fixture
+{
+    public function __construct(\Swift_Mailer $swift)
+    {
+        $this->swift = $swift;
+    }
+
+    public function createMessage()
+    {
+        $email = (new \Symfony\Component\Mime\Email())->subject('message');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/Fixture/fixture.php.inc
+++ b/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/Fixture/fixture.php.inc
@@ -30,7 +30,7 @@ class Fixture
 
     public function createMessage()
     {
-        $email = (new \Symfony\Component\Mime\Email())->subject('message');
+        $email = new \Symfony\Component\Mime\Email();
     }
 }
 

--- a/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/Fixture/skip_non_swift_mailer_create_message.php.inc
+++ b/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/Fixture/skip_non_swift_mailer_create_message.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\SwiftCreateMessageToNewEmailRector\Fixture;
+
+class SkipNonSwiftMailerCreateMessage
+{
+    private $swift;
+
+    public function __construct(\stdClass $swift)
+    {
+        $this->swift = $swift;
+    }
+
+    public function createMessage()
+    {
+        $email = $this->swift->createMessage('message');
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/SwiftCreateMessageToNewEmailRectorTest.php
+++ b/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/SwiftCreateMessageToNewEmailRectorTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace Rector\Symfony\Tests\Rector\MethodCall\SwiftCreateMessageToNewEmailRector;
 
 use Iterator;
@@ -11,7 +10,6 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class SwiftCreateMessageToNewEmailRectorTest extends AbstractRectorTestCase
 {
-
     /**
      * @dataProvider provideData()
      */

--- a/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/SwiftCreateMessageToNewEmailRectorTest.php
+++ b/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/SwiftCreateMessageToNewEmailRectorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\SwiftCreateMessageToNewEmailRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class SwiftCreateMessageToNewEmailRectorTest extends AbstractRectorTestCase
+{
+
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Symfony\Rector\MethodCall\SwiftCreateMessageToNewEmailRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../../../../../config/config.php');
+
+    $services = $containerConfigurator->services();
+
+    $services->set(SwiftCreateMessageToNewEmailRector::class);
+};


### PR DESCRIPTION
refs https://github.com/rectorphp/rector/issues/6654

This is just the beginning of the migration and a few more things need to be done like replacing
```php
        $this->swift->setSender($address, $name);
```
with
```php
        is_array($address)
            ? $this->email->sender(...$address)
            : $this->email->sender(new Address($address, (string) $name));
```

etc. but I figured this might be too big for one PR and should therefore be split up into more PRs.

I'm also not sure about the SetList (if we should already "release it" while it isn't complete yet)