### PR TITLE
[Symfony] Using NodesToAddCollector on call addNodesAfterNode()

### DIFF
--- a/src/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
+++ b/src/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
@@ -318,7 +318,7 @@ CODE_SAMPLE
         $thisRenderMethodCall->args[1] = new Arg($responseVariable);
 
         $returnThisRender = new Return_($thisRenderMethodCall);
-        $this->addNodesAfterNode([$assign, $if, $returnThisRender], $return);
+        $this->nodesToAddCollector->addNodesAfterNode([$assign, $if, $returnThisRender], $return);
     }
 
     private function removeDoctrineAnnotationTagValueNode(ClassMethod $classMethod): void


### PR DESCRIPTION
Based on https://github.com/rectorphp/rector-src/pull/812 as this direct call is deprecated.