### PR TITLE
[CI] add re-usable workflow

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -12,31 +12,4 @@ env:
 
 jobs:
     code_analysis:
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                actions:
-                    -
-                        name: 'PHPStan'
-                        run: composer phpstan
-                    -
-                        name: 'ECS'
-                        run: composer check-cs
-                    -
-                        name: 'Rector'
-                        run: vendor/bin/rector process --dry-run --ansi
-
-        name: ${{ matrix.actions.name }}
-
-        steps:
-            -   uses: actions/checkout@v2
-
-            -
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: 8.0
-                    coverage: none
-
-            -   uses: "ramsey/composer-install@v1"
-
-            -   run: ${{ matrix.actions.run }}
+        uses: rectorphp/reusable-workflows/.github/workflows/code_analysis.yaml@main


### PR DESCRIPTION
Testing new GitHub feature - re-usable workflows - https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#calling-a-reusable-workflow

from our main repository for workflows - https://github.com/rectorphp/reusable-workflows/blob/main/.github/workflows/code_analysis.yaml
