### PR TITLE
[Symfony] Add Test for skip Flash Assign not from Request object on AddFlashRector

### DIFF
--- a/tests/Rector/MethodCall/AddFlashRector/Fixture/skip_flash_assign_not_from_request_object.php.inc
+++ b/tests/Rector/MethodCall/AddFlashRector/Fixture/skip_flash_assign_not_from_request_object.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\AddFlashRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+final class SkipFlashAssignNotFromRequestObject extends Controller
+{
+    public function run()
+    {
+        $session = $this->get('session');
+        $session->getFlashBag()->add('warning', 'Provided card doesn\'t belong to you');
+    }
+}


### PR DESCRIPTION
Added test based on https://github.com/rectorphp/rector-src/pull/1026 that previously make TypeError.