### PR TITLE
Added missing import to usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ composer require rector/rector --dev
 To add a set to your config, use `Rector\Symfony\Set\SymfonySetList` class and pick one of constants:
 
 ```php
+use Rector\Core\Configuration\Option;
 use Rector\Symfony\Set\SymfonySetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 


### PR DESCRIPTION
Added missing `use Rector\Core\Configuration\Option` statement to code example "Use Sets" section of the README.md to avoid  `[ERROR] Class 'Option' not found` error. 