### PR TITLE
[Symfony] Avoid error Argument #1 ($scope) must be of type PHPStan\Analyser\Scope, null given

### DIFF
--- a/src/Bridge/NodeAnalyzer/ControllerMethodAnalyzer.php
+++ b/src/Bridge/NodeAnalyzer/ControllerMethodAnalyzer.php
@@ -6,6 +6,7 @@ namespace Rector\Symfony\Bridge\NodeAnalyzer;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -26,6 +27,9 @@ final class ControllerMethodAnalyzer
         }
 
         $scope = $node->getAttribute(AttributeKey::SCOPE);
+        if (! $scope instanceof Scope) {
+            return null;
+        }
 
         $parentClassName = (string) $this->parentClassScopeResolver->resolveParentClassName($scope);
         if (\str_ends_with($parentClassName, 'Controller')) {

--- a/src/Bridge/NodeAnalyzer/ControllerMethodAnalyzer.php
+++ b/src/Bridge/NodeAnalyzer/ControllerMethodAnalyzer.php
@@ -28,7 +28,7 @@ final class ControllerMethodAnalyzer
 
         $scope = $node->getAttribute(AttributeKey::SCOPE);
         if (! $scope instanceof Scope) {
-            return null;
+            return false;
         }
 
         $parentClassName = (string) $this->parentClassScopeResolver->resolveParentClassName($scope);


### PR DESCRIPTION
Like in https://github.com/rectorphp/rector-src/pull/1120#issue-1041017838