### PR TITLE
Should ignore DependencyInjectionMethodCallAnalyzer when used inside traits

### DIFF
--- a/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\Node\NodeFactory;
 use Rector\Naming\Naming\PropertyNaming;

--- a/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
@@ -35,7 +35,7 @@ final class DependencyInjectionMethodCallAnalyzer
 
         $class = $this->betterNodeFinder->findParentType($methodCall, Class_::class);
         if (! $class instanceof Class_) {
-            throw new ShouldNotHappenException();
+            return null;
         }
 
         $propertyName = $this->propertyNaming->fqnToVariableName($serviceType);

--- a/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/skip_trait.php.inc
+++ b/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/skip_trait.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Fixture;
+
+trait SkipTrait
+{
+    protected function traitMethod()
+    {
+        $someService = $this->getContainer()->get('some_service');
+    }
+}


### PR DESCRIPTION
Currently rector fails hardly when trying to analyze my Create Traits which I use in tests and access dependency over `getContainer` method of the KernelTestCase. As following the books advice we should always ignore instead of fail.

fixes #53