### PR TITLE
StringToArrayArgumentProcessRector breaks Process instance method calls

### DIFF
--- a/tests/Rector/New_/StringToArrayArgumentProcessRector/Fixture/skip_process_instance_methods.php.inc
+++ b/tests/Rector/New_/StringToArrayArgumentProcessRector/Fixture/skip_process_instance_methods.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\New_\StringToArrayArgumentProcessRector\Fixture;
+
+use Symfony\Component\Process\Process;
+
+function skipProcessInstanceMethods()
+{
+    $process = new Process('git log --tags --simplify-by-decoration --pretty="format:%ai %d"');
+    $process->setWorkingDirectory('/some/other/path');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\New_\StringToArrayArgumentProcessRector\Fixture;
+
+use Symfony\Component\Process\Process;
+
+function skipProcessInstanceMethods()
+{
+    $process = new Process(['git', 'log', '--tags', '--simplify-by-decoration', '--pretty=format:%ai %d']);
+    $process->setWorkingDirectory('/some/other/path');
+}
+
+?>


### PR DESCRIPTION
This is a failing test to show the issue. Basically I think it is overzealous with the instance methods of the Process class.

The Process class API for `setWorkingDirectory` is
```
public function setWorkingDirectory(string $cwd)
```

The StringToArrayArgumentProcessRector changes the proper `string` argument to an `array` argument when it should not.