### PR TITLE
Overzealous string to array conversion

### DIFF
--- a/src/Rector/New_/StringToArrayArgumentProcessRector.php
+++ b/src/Rector/New_/StringToArrayArgumentProcessRector.php
@@ -32,7 +32,7 @@ final class StringToArrayArgumentProcessRector extends AbstractRector
     /**
      * @var string[]
      */
-    private const EXCLUDED_PROCESS_METHOD_CALLS = ['setWorkingDirectory'];
+    private const EXCLUDED_PROCESS_METHOD_CALLS = ['setWorkingDirectory', 'addOutput', 'addErrorOutput'];
 
     public function __construct(
         private NodeTransformer $nodeTransformer

--- a/tests/Rector/New_/StringToArrayArgumentProcessRector/Fixture/do_not_convert_to_array_after_instantiation.php.inc
+++ b/tests/Rector/New_/StringToArrayArgumentProcessRector/Fixture/do_not_convert_to_array_after_instantiation.php.inc
@@ -8,6 +8,8 @@ function doNotConvertToArrayCallSetWorkingDirectory()
 {
     $process = new Process('git log --tags --simplify-by-decoration --pretty="format:%ai %d"');
     $process->setWorkingDirectory('/some/other/path');
+    $process->addOutput('Test output');
+    $process->addErrorOutput('Test output');
 }
 
 ?>
@@ -22,6 +24,8 @@ function doNotConvertToArrayCallSetWorkingDirectory()
 {
     $process = new Process(['git', 'log', '--tags', '--simplify-by-decoration', '--pretty=format:%ai %d']);
     $process->setWorkingDirectory('/some/other/path');
+    $process->addOutput('Test output');
+    $process->addErrorOutput('Test output');
 }
 
 ?>


### PR DESCRIPTION
Relates to #67 and #70

I went through to check that #70 covered all the cases and it looks like at least 2 methods are missed with this approach. I have added those methods here. 