### PR TITLE
[Dep] Remove stringy as replaced with symfony/string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php": ">=8.1",
         "ext-xml": "*",
-        "danielstjules/stringy": "^3.1",
         "symfony/string": "^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
@TomasVotruba Looking at other rector packages, eg:

https://github.com/rectorphp/rector-nette/commit/1e3b3ab4e1248623b020ce9c8e744ad89e942e74

The `danielstjules/stringy` was removed, I think it should be removed as well.