### PR TITLE
fix infinite loop on ContainerGetToConstructorInjectionRector

### DIFF
--- a/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
@@ -57,6 +57,12 @@ final class DependencyInjectionMethodCallAnalyzer
         string $propertyName,
         int $count = 1
     ): string {
+        $lastCount = substr($propertyName, strlen($originalPropertyName));
+
+        if (is_numeric($lastCount)) {
+            $count = (int) $lastCount;
+        }
+
         $promotedPropertyParams = $this->promotedPropertyResolver->resolveFromClass($class);
         foreach ($promotedPropertyParams as $promotedPropertyParam) {
             if ($this->nodeNameResolver->isName($promotedPropertyParam->var, $propertyName)) {

--- a/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_exists3.php.inc
+++ b/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_exists3.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Fixture;
+
+use Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class SomeTranslatorExists3 extends AbstractController
+{
+    private SomeTranslator $someTranslator;
+    private SomeTranslator $someTranslator2;
+
+    public function __construct(SomeTranslator $someTranslator, SomeTranslator $someTranslator2)
+    {
+        $this->someTranslator = $someTranslator;
+        $this->someTranslator2 = $someTranslator2;
+    }
+
+    protected function execute()
+    {
+        $someService = $this->getContainer()->get('translator');
+
+        $someService = $this->getContainer()->get('translator')->translateSomething();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Fixture;
+
+use Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class SomeTranslatorExists3 extends AbstractController
+{
+    private SomeTranslator $someTranslator;
+    private SomeTranslator $someTranslator2;
+
+    public function __construct(SomeTranslator $someTranslator, SomeTranslator $someTranslator2, private \Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator $someTranslator3)
+    {
+        $this->someTranslator = $someTranslator;
+        $this->someTranslator2 = $someTranslator2;
+    }
+
+    protected function execute()
+    {
+        $someService = $this->someTranslator3;
+
+        $someService = $this->someTranslator3->translateSomething();
+    }
+}
+
+?>


### PR DESCRIPTION
Continue of https://github.com/rectorphp/rector-symfony/pull/117, given the following code cause infinite loop:

```php

final class SomeTranslatorExists3 extends AbstractController
{
    private SomeTranslator $someTranslator;
    private SomeTranslator $someTranslator2;

    public function __construct(SomeTranslator $someTranslator, SomeTranslator $someTranslator2)
    {
        $this->someTranslator = $someTranslator;
        $this->someTranslator2 = $someTranslator2;
    }

    protected function execute()
    {
        $someService = $this->getContainer()->get('translator');

        $someService = $this->getContainer()->get('translator')->translateSomething();
    }
}
```

This PR fix it.