### PR TITLE
[Symfony] Only Increment property name when different object on ContainerGetToConstructorInjectionRector

### DIFF
--- a/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
@@ -44,15 +44,17 @@ final class DependencyInjectionMethodCallAnalyzer
             return null;
         }
 
-        $propertyName = $this->propertyNaming->fqnToVariableName($serviceType);
         $resolvedPropertyNameByType = $this->propertyManipulator->resolveExistingClassPropertyNameByType(
             $class,
             $serviceType
         );
 
-        $propertyName = is_string($resolvedPropertyNameByType)
-            ? $resolvedPropertyNameByType
-            : $this->resolveNewPropertyNameWhenExists($class, $propertyName, $propertyName);
+        if (is_string($resolvedPropertyNameByType)) {
+            $propertyName = $resolvedPropertyNameByType;
+        } else {
+            $propertyName = $this->propertyNaming->fqnToVariableName($serviceType);
+            $propertyName = $this->resolveNewPropertyNameWhenExists($class, $propertyName, $propertyName);
+        }
 
         $propertyMetadata = new PropertyMetadata($propertyName, $serviceType, Class_::MODIFIER_PRIVATE);
         $this->propertyToAddCollector->addPropertyToClass($class, $propertyMetadata);

--- a/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
@@ -76,12 +76,7 @@ final class DependencyInjectionMethodCallAnalyzer
         foreach ($promotedPropertyParams as $promotedPropertyParam) {
             if ($this->nodeNameResolver->isName($promotedPropertyParam->var, $propertyName)) {
                 $propertyName = $this->resolveIncrementPropertyName($originalPropertyName, $count);
-                return $this->resolveNewPropertyNameWhenExists(
-                    $class,
-                    $originalPropertyName,
-                    $propertyName,
-                    $count
-                );
+                return $this->resolveNewPropertyNameWhenExists($class, $originalPropertyName, $propertyName, $count);
             }
         }
 

--- a/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
@@ -69,7 +69,7 @@ final class DependencyInjectionMethodCallAnalyzer
             $class,
             $objectType
         );
-        if ($resolvedPropertyNameByType) {
+        if (is_string($resolvedPropertyNameByType)) {
             return $propertyName;
         }
 

--- a/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
@@ -45,7 +45,12 @@ final class DependencyInjectionMethodCallAnalyzer
         }
 
         $propertyName = $this->propertyNaming->fqnToVariableName($serviceType);
-        $propertyName = $this->resolveNewPropertyNameWhenExistsWithType($class, $propertyName, $propertyName, $serviceType);
+        $propertyName = $this->resolveNewPropertyNameWhenExistsWithType(
+            $class,
+            $propertyName,
+            $propertyName,
+            $serviceType
+        );
 
         $propertyMetadata = new PropertyMetadata($propertyName, $serviceType, Class_::MODIFIER_PRIVATE);
         $this->propertyToAddCollector->addPropertyToClass($class, $propertyMetadata);
@@ -60,7 +65,10 @@ final class DependencyInjectionMethodCallAnalyzer
         ObjectType $objectType,
         int $count = 1
     ): string {
-        $resolvedPropertyNameByType = $this->propertyManipulator->resolveExistingClassPropertyNameByType($class, $objectType);
+        $resolvedPropertyNameByType = $this->propertyManipulator->resolveExistingClassPropertyNameByType(
+            $class,
+            $objectType
+        );
         if ($resolvedPropertyNameByType) {
             return $propertyName;
         }
@@ -75,7 +83,13 @@ final class DependencyInjectionMethodCallAnalyzer
         foreach ($promotedPropertyParams as $promotedPropertyParam) {
             if ($this->nodeNameResolver->isName($promotedPropertyParam->var, $propertyName)) {
                 $propertyName = $this->resolveIncrementPropertyName($originalPropertyName, $count);
-                return $this->resolveNewPropertyNameWhenExistsWithType($class, $originalPropertyName, $propertyName, $objectType, $count);
+                return $this->resolveNewPropertyNameWhenExistsWithType(
+                    $class,
+                    $originalPropertyName,
+                    $propertyName,
+                    $objectType,
+                    $count
+                );
             }
         }
 
@@ -85,7 +99,13 @@ final class DependencyInjectionMethodCallAnalyzer
         }
 
         $propertyName = $this->resolveIncrementPropertyName($originalPropertyName, $count);
-        return $this->resolveNewPropertyNameWhenExistsWithType($class, $originalPropertyName, $propertyName, $objectType, $count);
+        return $this->resolveNewPropertyNameWhenExistsWithType(
+            $class,
+            $originalPropertyName,
+            $propertyName,
+            $objectType,
+            $count
+        );
     }
 
     private function resolveIncrementPropertyName(string $originalPropertyName, int $count): string

--- a/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/DependencyInjectionMethodCallAnalyzer.php
@@ -51,7 +51,7 @@ final class DependencyInjectionMethodCallAnalyzer
         );
 
         $propertyName = is_string($resolvedPropertyNameByType)
-            ? $propertyName
+            ? $resolvedPropertyNameByType
             : $this->resolveNewPropertyNameWhenExists($class, $propertyName, $propertyName);
 
         $propertyMetadata = new PropertyMetadata($propertyName, $serviceType, Class_::MODIFIER_PRIVATE);

--- a/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_different_object.php.inc
+++ b/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_different_object.php.inc
@@ -2,10 +2,10 @@
 
 namespace Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Fixture;
 
-use Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator;
+use Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Source\SomeTranslator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-final class SomeTranslatorExists extends AbstractController
+final class SomeTranslatorDifferentObject extends AbstractController
 {
     private SomeTranslator $someTranslator;
 
@@ -28,23 +28,23 @@ final class SomeTranslatorExists extends AbstractController
 
 namespace Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Fixture;
 
-use Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator;
+use Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Source\SomeTranslator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-final class SomeTranslatorExists extends AbstractController
+final class SomeTranslatorDifferentObject extends AbstractController
 {
     private SomeTranslator $someTranslator;
 
-    public function __construct(SomeTranslator $someTranslator)
+    public function __construct(SomeTranslator $someTranslator, private \Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator $someTranslator2)
     {
         $this->someTranslator = $someTranslator;
     }
 
     protected function execute()
     {
-        $someService = $this->someTranslator;
+        $someService = $this->someTranslator2;
 
-        $someService = $this->someTranslator->translateSomething();
+        $someService = $this->someTranslator2->translateSomething();
     }
 }
 

--- a/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_exists.php.inc
+++ b/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_exists.php.inc
@@ -30,15 +30,15 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 final class SomeTranslatorExists extends AbstractController
 {
-    public function __construct(private readonly SomeTranslator $someTranslator, private \Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator $someTranslator2)
+    public function __construct(private readonly SomeTranslator $someTranslator)
     {
     }
 
     protected function execute()
     {
-        $someService = $this->someTranslator2;
+        $someService = $this->someTranslator;
 
-        $someService = $this->someTranslator2->translateSomething();
+        $someService = $this->someTranslator->translateSomething();
     }
 }
 

--- a/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_exists3.php.inc
+++ b/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_exists3.php.inc
@@ -38,7 +38,7 @@ final class SomeTranslatorExists3 extends AbstractController
     private SomeTranslator $someTranslator;
     private SomeTranslator $someTranslator2;
 
-    public function __construct(SomeTranslator $someTranslator, SomeTranslator $someTranslator2, private \Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator $someTranslator3)
+    public function __construct(SomeTranslator $someTranslator, SomeTranslator $someTranslator2)
     {
         $this->someTranslator = $someTranslator;
         $this->someTranslator2 = $someTranslator2;
@@ -46,9 +46,9 @@ final class SomeTranslatorExists3 extends AbstractController
 
     protected function execute()
     {
-        $someService = $this->someTranslator3;
+        $someService = $this->someTranslator;
 
-        $someService = $this->someTranslator3->translateSomething();
+        $someService = $this->someTranslator->translateSomething();
     }
 }
 

--- a/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_exists_different_name.php.inc
+++ b/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Fixture/some_translator_exists_different_name.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Fixture;
+
+use Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class SomeTranslatorExistsDifferentName extends AbstractController
+{
+    public function __construct(private readonly SomeTranslator $this_is_a_translator)
+    {
+    }
+
+    protected function execute()
+    {
+        $someService = $this->getContainer()->get('translator');
+
+        $someService = $this->getContainer()->get('translator')->translateSomething();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Fixture;
+
+use Rector\Symfony\Tests\Rector\MethodCall\AbstractToConstructorInjectionRectorSource\SomeTranslator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class SomeTranslatorExistsDifferentName extends AbstractController
+{
+    public function __construct(private readonly SomeTranslator $this_is_a_translator)
+    {
+    }
+
+    protected function execute()
+    {
+        $someService = $this->this_is_a_translator;
+
+        $someService = $this->this_is_a_translator->translateSomething();
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Source/SomeTanslator.php
+++ b/tests/Rector/MethodCall/ContainerGetToConstructorInjectionRector/Source/SomeTanslator.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\ContainerGetToConstructorInjectionRector\Source;
+
+final class SomeTranslator
+{
+}


### PR DESCRIPTION
Make `ContainerGetToConstructorInjectionRector` only increment naming for new property when name is equal but different object, use existing when exists.

- [x] Same name generation, object type is equal? -> use as is
- [x] Different name generation, object type is equal? -> use as is
- [x] Same name generation, object type is different ? -> increment naming