### PR TITLE
[Symfony] Skip SimplifyWebTestCaseAssertionsRector on no PHPUnit\Framework\TestCase class

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -38,6 +38,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'Twig_*',
             'Swift_*',
             'Doctrine\*',
+            'PHPUnit\Framework\TestCase',
         ]);
 
     $containerConfigurator->import(LevelSetList::UP_TO_PHP_81);

--- a/src/Rector/MethodCall/SimplifyWebTestCaseAssertionsRector.php
+++ b/src/Rector/MethodCall/SimplifyWebTestCaseAssertionsRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -34,6 +35,11 @@ final class SimplifyWebTestCaseAssertionsRector extends AbstractRector
     private const ASSERT_SAME = 'assertSame';
 
     private ?MethodCall $getStatusCodeMethodCall = null;
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -144,6 +150,10 @@ CODE_SAMPLE
 
         $classReflection = $scope->getClassReflection();
         if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        if (! $this->reflectionProvider->hasClass('PHPUnit\Framework\TestCase')) {
             return false;
         }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector-symfony/issues/123