### PR TITLE
Failing test to demostrate desired behavior for extending a class still needing parents constructor.

### DIFF
--- a/stubs/Symfony/Bundle/FrameworkBundle/Controller/BaseController.php
+++ b/stubs/Symfony/Bundle/FrameworkBundle/Controller/BaseController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+if (class_exists('Symfony\Bundle\FrameworkBundle\Controller\BaseController')) {
+    return;
+}
+
+class BaseController
+{
+    public function createForm(): FormInterface
+    {
+        return $this->get('form.factory')->createNamed('', 'FoobarClass');
+    }
+
+    public function render($path, $params = []): Response
+    {
+    }
+
+    public function redirect($url, $status = 302)
+    {
+    }
+}

--- a/tests/Rector/MethodCall/GetToConstructorInjectionRector/Fixture/fixure3.php.inc
+++ b/tests/Rector/MethodCall/GetToConstructorInjectionRector/Fixture/fixure3.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\GetToConstructorInjectionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\BaseController;
+
+class ClassWithNamedService extends BaseController
+{
+    public function render()
+    {
+        $someService = $this->get('some_service');
+
+        $this->renderTwig([
+            'posts' => $this->get('some_service')->callMe()
+        ]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\GetToConstructorInjectionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\BaseController;
+
+class ClassWithNamedService extends BaseController
+{
+    public function __construct(private \stdClass $stdClass, private \stdClass $formFactory)
+    {
+    }
+    public function render()
+    {
+        $someService = $this->stdClass;
+
+        $this->renderTwig([
+            'posts' => $this->stdClass->callMe()
+        ]);
+    }
+}
+
+?>


### PR DESCRIPTION
Based on conversation from twitter.

I expect this is not actually a problem for rector to attempt to solve actually so we may just close it but i'll give the case below and we can discuss. 

We have a legacy symfony app that uses base controllers grabbing services out of the container extensively for certain behaviors used across controllers throughout our application. This was the norm for a long time obviously but now with the smaller service locator container passed into the `AbstractController` I need to be able to move these services to constructor injection. Rector handles anything the concrete controllers are using but the base controllers dependencies are ignored. 

The other option would be to use a SubscriberService method to provide services to add to the service locator, the issue is symfony requires these to be class names which all of our dependencies are not (things like service classes with multiple definitions) so thats a no go mostly as well. 

I have a feeling the "proper" way will be to suck it up and refactor out most of the "base controllers" functionality out and do dependency injection more pointedly but figured a failing test with the outline above can at least spark a conversation and worst case is you close this and I can get to work on the refactor a different way. 