### PR TITLE
Add missing annotations to symfony52-validator-attributes set

### DIFF
--- a/config/sets/symfony/symfony52-validator-attributes.php
+++ b/config/sets/symfony/symfony52-validator-attributes.php
@@ -73,6 +73,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Url'),
             new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Uuid'),
             new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Valid'),
+            new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\DiscriminatorMap'),
             new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\Groups'),
+            new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\Ignore'),
+            new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\MaxDepth'),
+            new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\SerializedName'),
         ]);
 };


### PR DESCRIPTION
Support for all theses attributes was added in Symfony 5.2, together with the already present Groups attribute
see https://github.com/symfony/symfony/pull/38525

there is only one missing Serializer annotation, but it was added in Symfony 5.4, so I left that one out
https://github.com/symfony/symfony/pull/38525