### PR TITLE
Move Renaming of UserProviderInterface::loadUserByUsername() from Symfony 5.3 to Symfony 6.0

### DIFF
--- a/config/sets/symfony/symfony53.php
+++ b/config/sets/symfony/symfony53.php
@@ -44,11 +44,6 @@ return static function (RectorConfig $rectorConfig): void {
                 'getUserIdentifier',
             ),
             new MethodCallRename(
-                'Symfony\Component\Security\Core\User\UserProviderInterface',
-                'loadUserByUsername',
-                'loadUserByIdentifier',
-            ),
-            new MethodCallRename(
                 'Symfony\Component\Security\Core\Exception\UsernameNotFoundException',
                 'getUsername',
                 'getUserIdentifier'

--- a/config/sets/symfony/symfony60.php
+++ b/config/sets/symfony/symfony60.php
@@ -62,6 +62,11 @@ return static function (RectorConfig $rectorConfig): void {
                 'loadUserByUsername',
                 'loadUserByIdentifier'
             ),
+            new MethodCallRename(
+                'Symfony\Component\Security\Core\User\UserProviderInterface',
+                'loadUserByUsername',
+                'loadUserByIdentifier',
+            ),
             // @see https://github.com/rectorphp/rector-symfony/issues/112
             new MethodCallRename(
                 'Symfony\Component\Security\Core\User\UserInterface',


### PR DESCRIPTION
Hi there!

UserProviderInterface::loadUserByUsername() is deprected in Symfony 5.3, but it is still defined in the interface and will be removed in the next Symfony Major Release (6.0). Prior to Symfony 6.0 rector would create broken code.

Compare UserProviderInterface in [Symfony 5.3](https://github.com/symfony/security-core/blob/5.3/User/UserProviderInterface.php#L68) and [Symfony 6.0](https://github.com/symfony/security-core/blob/6.0/User/UserProviderInterface.php#L63).

Cheers!