### PR TITLE
Remove obsolete ArgumentAdder

### DIFF
--- a/config/sets/symfony/symfony42.php
+++ b/config/sets/symfony/symfony42.php
@@ -61,17 +61,6 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig
         ->ruleWithConfiguration(ArgumentAdderRector::class, [
-            // https://github.com/symfony/symfony/commit/fa2063efe43109aea093d6fbfc12d675dba82146
-            // https://github.com/symfony/symfony/commit/e3aa90f852f69040be19da3d8729cdf02d238ec7
-            new ArgumentAdder(
-                'Symfony\Component\BrowserKit\Client',
-                'submit',
-                2,
-                'serverParameters',
-                [],
-                null,
-                ArgumentAddingScope::SCOPE_METHOD_CALL
-            ),
             new ArgumentAdder(
                 'Symfony\Component\DomCrawler\Crawler',
                 'children',


### PR DESCRIPTION
Upstream projected reverted the backward-compatibility breaking change.

Fixes #160.