### PR TITLE
Add Set Constants that are directed towards the future

### DIFF
--- a/src/NodeAnalyzer/FormInstanceToFormClassConstFetchConverter.php
+++ b/src/NodeAnalyzer/FormInstanceToFormClassConstFetchConverter.php
@@ -115,9 +115,9 @@ final class FormInstanceToFormClassConstFetchConverter
         }
 
         $classReflection = $this->reflectionProvider->getClass($className);
-        $reflectionClass = $classReflection->getNativeReflection();
+        $nativeReflection = $classReflection->getNativeReflection();
 
-        $constructorReflectionMethod = $reflectionClass->getConstructor();
+        $constructorReflectionMethod = $nativeReflection->getConstructor();
         if (! $constructorReflectionMethod instanceof ReflectionMethod) {
             return [];
         }

--- a/src/Set/SymfonyLevelSetList.php
+++ b/src/Set/SymfonyLevelSetList.php
@@ -97,4 +97,39 @@ final class SymfonyLevelSetList implements SetListInterface
      * @var string
      */
     final public const UP_TO_SYMFONY_60 = __DIR__ . '/../../config/sets/symfony/level/up-to-symfony-60.php';
+
+    /**
+     * @var string
+     */
+    final public const SYMFONY_LATEST_V2 = self::UP_TO_SYMFONY_28;
+
+    /**
+     * @var string
+     */
+    final public const SYMFONY_LATEST_V3 = self::UP_TO_SYMFONY_34;
+
+    /**
+     * @var string
+     */
+    final public const SYMFONY_LATEST_V4 = self::UP_TO_SYMFONY_44;
+
+    /**
+     * @var string
+     */
+    final public const SYMFONY_LATEST_V5 = self::UP_TO_SYMFONY_54;
+
+    /**
+     * @var string
+     */
+    final public const SYMFONY_LATEST_V6 = self::UP_TO_SYMFONY_60;
+
+    /**
+     * @var string
+     */
+    final public const SYMFONY_LATEST_LTS = self::UP_TO_SYMFONY_54;
+
+    /**
+     * @var string
+     */
+    final public const SYMFONY_LATEST = self::UP_TO_SYMFONY_60;
 }


### PR DESCRIPTION
The current SymfonySetList Constants target the current point in time. With these you can update to the current Symfony version at max.
With this PR I added future directed constants, so that Users don't have to update their rector config if a new Symfony version comes out.

My use-case is:
I have a maintenance bot that does composer updates for me. I would like to see it try Symfony updates as well.