### PR TITLE
[Symfony 2.8] Add FormTypeWithDependencyToOptionsRector

### DIFF
--- a/config/sets/symfony/symfony30.php
+++ b/config/sets/symfony/symfony30.php
@@ -8,6 +8,7 @@ use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameClassConstFetch;
+use Rector\Symfony\Rector\Class_\FormTypeWithDependencyToOptionsRector;
 use Rector\Symfony\Rector\ClassMethod\FormTypeGetParentRector;
 use Rector\Symfony\Rector\ClassMethod\GetRequestRector;
 use Rector\Symfony\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector;
@@ -32,6 +33,7 @@ return static function (RectorConfig $rectorConfig): void {
 
         // forms
         FormTypeInstanceToClassConstRector::class,
+        FormTypeWithDependencyToOptionsRector::class,
         StringFormTypeToClassRector::class,
         CascadeValidationFormBuilderRector::class,
         RemoveDefaultGetBlockPrefixRector::class,

--- a/src/NodeFactory/FormType/BuildFormOptionAssignsFactory.php
+++ b/src/NodeFactory/FormType/BuildFormOptionAssignsFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\NodeFactory\FormType;
+
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Expression;
+
+final class BuildFormOptionAssignsFactory
+{
+    /**
+     * @param string[] $paramNames
+     * @return Expression[]
+     */
+    public function createDimFetchAssignsFromParamNames(array $paramNames): array
+    {
+        $expressions = [];
+
+        foreach ($paramNames as $paramName) {
+            $arrayDimFetch = new ArrayDimFetch(new Variable('options'), new String_($paramName));
+            $assign = new Assign(new Variable($paramName), $arrayDimFetch);
+
+            $expressions[] = new Expression($assign);
+        }
+
+        return $expressions;
+    }
+}

--- a/src/NodeRemover/ConstructorDependencyRemover.php
+++ b/src/NodeRemover/ConstructorDependencyRemover.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\NodeRemover;
+
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use Rector\NodeNameResolver\NodeNameResolver;
+
+final class ConstructorDependencyRemover
+{
+    public function __construct(
+        private readonly NodeNameResolver $nodeNameResolver,
+    ) {
+    }
+
+    /**
+     * @param string[] $paramNames
+     */
+    public function removeParamsByName(ClassMethod $classMethod, array $paramNames): ClassMethod
+    {
+        $this->removeParams($classMethod, $paramNames);
+
+        return $this->removeAssigns($classMethod, $paramNames);
+    }
+
+    /**
+     * @param string[] $paramNames
+     */
+    private function removeParams(ClassMethod $classMethod, array $paramNames): void
+    {
+        foreach ($classMethod->params as $key => $param) {
+            if (! $this->nodeNameResolver->isNames($param, $paramNames)) {
+                continue;
+            }
+
+            unset($classMethod->params[$key]);
+        }
+    }
+
+    /**
+     * @param string[] $paramNames
+     */
+    private function removeAssigns(ClassMethod $classMethod, array $paramNames): ClassMethod
+    {
+        // remove assign
+        foreach ((array) $classMethod->stmts as $stmtKey => $stmt) {
+            if (! $stmt instanceof Expression) {
+                continue;
+            }
+
+            if (! $stmt->expr instanceof Assign) {
+                continue;
+            }
+
+            $assign = $stmt->expr;
+            if (! $assign->expr instanceof Variable) {
+                continue;
+            }
+
+            if (! $assign->var instanceof PropertyFetch) {
+                continue;
+            }
+
+            if (! $this->nodeNameResolver->isNames($assign->expr, $paramNames)) {
+                continue;
+            }
+
+            unset($classMethod->stmts[$stmtKey]);
+        }
+
+        return $classMethod;
+    }
+}

--- a/src/Rector/Class_/FormTypeWithDependencyToOptionsRector.php
+++ b/src/Rector/Class_/FormTypeWithDependencyToOptionsRector.php
@@ -27,7 +27,6 @@ final class FormTypeWithDependencyToOptionsRector extends AbstractRector
 {
     public function __construct(
         private readonly BuildFormOptionAssignsFactory $buildFormOptionAssignsFactory,
-        // private readonly ComplexNodeRemover $complexNodeRemover,
         private readonly ConstructorDependencyRemover $constructorDependencyRemover,
     ) {
     }
@@ -94,8 +93,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $formTypeObject = new ObjectType('Symfony\Component\Form\AbstractType');
-        if (! $this->isObjectType($node, $formTypeObject)) {
+        $formObjectType = new ObjectType('Symfony\Component\Form\AbstractType');
+        if (! $this->isObjectType($node, $formObjectType)) {
             return null;
         }
 

--- a/src/Rector/Class_/FormTypeWithDependencyToOptionsRector.php
+++ b/src/Rector/Class_/FormTypeWithDependencyToOptionsRector.php
@@ -5,8 +5,16 @@ declare(strict_types=1);
 namespace Rector\Symfony\Rector\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\MethodName;
+use Rector\Symfony\NodeFactory\FormType\BuildFormOptionAssignsFactory;
+use Rector\Symfony\NodeRemover\ConstructorDependencyRemover;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -17,6 +25,13 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class FormTypeWithDependencyToOptionsRector extends AbstractRector
 {
+    public function __construct(
+        private readonly BuildFormOptionAssignsFactory $buildFormOptionAssignsFactory,
+        // private readonly ComplexNodeRemover $complexNodeRemover,
+        private readonly ConstructorDependencyRemover $constructorDependencyRemover,
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Move constructor dependency from form type class to an $options parameter', [
@@ -79,8 +94,85 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        // change the node
+        $formTypeObject = new ObjectType('Symfony\Component\Form\AbstractType');
+        if (! $this->isObjectType($node, $formTypeObject)) {
+            return null;
+        }
+
+        // skip abstract
+        if ($node->isAbstract()) {
+            return null;
+        }
+
+        $constructorClassMethod = $node->getMethod(MethodName::CONSTRUCT);
+        if (! $constructorClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $params = $constructorClassMethod->getParams();
+        if ($params === []) {
+            return null;
+        }
+
+        $buildFormClassMethod = $node->getMethod('buildForm');
+        if (! $buildFormClassMethod instanceof ClassMethod) {
+            // form has to have some items
+            throw new ShouldNotHappenException();
+        }
+
+        $paramNames = $this->nodeNameResolver->getNames($params);
+
+        // 1. add assigns at start of ClassMethod
+        $assignExpressions = $this->buildFormOptionAssignsFactory->createDimFetchAssignsFromParamNames($paramNames);
+        $buildFormClassMethod->stmts = array_merge($assignExpressions, (array) $buildFormClassMethod->stmts);
+
+        // 2. remove properties
+        foreach ($node->getProperties() as $property) {
+            if (! $this->isNames($property, $paramNames)) {
+                continue;
+            }
+
+            $this->removeNode($property);
+        }
+
+        // 3. cleanup ctor
+        $this->constructorDependencyRemover->removeParamsByName($constructorClassMethod, $paramNames);
+
+        $this->replacePropertyFetchesByVariables($buildFormClassMethod, $paramNames);
 
         return $node;
+    }
+
+    /**
+     * 4. replace property fetches in buildForm() by just assigned variable
+     *
+     * @param string[] $paramNames
+     */
+    private function replacePropertyFetchesByVariables(ClassMethod $classMethod, array $paramNames): void
+    {
+        $this->traverseNodesWithCallable(
+            (array) $classMethod->stmts,
+            function (Node $node) use ($paramNames): ?Variable {
+                if (! $node instanceof PropertyFetch) {
+                    return null;
+                }
+
+                if (! $this->nodeNameResolver->isName($node->var, 'this')) {
+                    return null;
+                }
+
+                if (! $this->nodeNameResolver->isNames($node->name, $paramNames)) {
+                    return null;
+                }
+
+                // replace by variable
+                $variableName = $this->getName($node->name);
+                if (! is_string($variableName)) {
+                    return null;
+                }
+
+                return new Variable($variableName);
+            }
+        );
     }
 }

--- a/tests/Rector/Class_/FormTypeWithDependencyToOptionsRector/Fixture/rename_only_local_properties.php.inc
+++ b/tests/Rector/Class_/FormTypeWithDependencyToOptionsRector/Fixture/rename_only_local_properties.php.inc
@@ -1,0 +1,63 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\Class_\FormTypeWithDependencyToOptionsRector\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class RenameOnlyLocalProperties extends AbstractType
+{
+    private Agent $agent;
+
+    public function __construct(Agent $agent)
+    {
+        $this->agent = $agent;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $another = $options['another'];
+
+        if ($this->agent) {
+            $builder->add('agent', TextType::class);
+        }
+
+        if ($another->agent) {
+            $builder->add('another_agent', TextType::class);
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\Class_\FormTypeWithDependencyToOptionsRector\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class RenameOnlyLocalProperties extends AbstractType
+{
+    public function __construct()
+    {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $agent = $options['agent'];
+        $another = $options['another'];
+
+        if ($agent) {
+            $builder->add('agent', TextType::class);
+        }
+
+        if ($another->agent) {
+            $builder->add('another_agent', TextType::class);
+        }
+    }
+}
+
+?>

--- a/tests/Rector/Class_/FormTypeWithDependencyToOptionsRector/Fixture/skip_no_ctor_params.php.inc
+++ b/tests/Rector/Class_/FormTypeWithDependencyToOptionsRector/Fixture/skip_no_ctor_params.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\Class_\FormTypeWithDependencyToOptionsRector\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class SkipNoCtorParams extends AbstractType
+{
+    private int $badgeId;
+
+    public function __construct()
+    {
+        $this->badgeId = 1000;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        if ($this->badgeId) {
+            $builder->add('agent', TextType::class);
+        }
+    }
+}

--- a/tests/Rector/Class_/FormTypeWithDependencyToOptionsRector/Fixture/some_class.php.inc
+++ b/tests/Rector/Class_/FormTypeWithDependencyToOptionsRector/Fixture/some_class.php.inc
@@ -35,10 +35,13 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class FormTypeWithDependency extends AbstractType
 {
+    public function __construct()
+    {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $agent = $options['agent'];
-
         if ($agent) {
             $builder->add('agent', TextType::class);
         }

--- a/tests/Rector/Class_/FormTypeWithDependencyToOptionsRector/FormTypeWithDependencyToOptionsRectorTest.php
+++ b/tests/Rector/Class_/FormTypeWithDependencyToOptionsRector/FormTypeWithDependencyToOptionsRectorTest.php
@@ -15,8 +15,6 @@ final class FormTypeWithDependencyToOptionsRectorTest extends AbstractRectorTest
      */
     public function test(SmartFileInfo $fileInfo): void
     {
-        $this->markTestSkipped('Fix in next PR');
-
         $this->doTestFileInfo($fileInfo);
     }
 


### PR DESCRIPTION
- [Symfony 2.8] Add FormTypeWithDependencyToOptionsRector
- skip no params used
