### PR TITLE
[Symfony] Skip before is TryCatch that always terminated on ConsoleExecuteReturnIntRector

### DIFF
--- a/src/Rector/Class_/MagicClosureTwigExtensionToNativeMethodsRector.php
+++ b/src/Rector/Class_/MagicClosureTwigExtensionToNativeMethodsRector.php
@@ -16,7 +16,6 @@ use Rector\Core\Reflection\ReflectionResolver;
 use Rector\NodeCollector\NodeAnalyzer\ArrayCallableMethodMatcher;
 use Rector\NodeCollector\ValueObject\ArrayCallable;
 use Rector\Php72\NodeFactory\AnonymousFunctionFactory;
-use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_already_returned_in_try_stmts.php.inc
+++ b/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_already_returned_in_try_stmts.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipAlreadyReturnedInTryStmts  extends Command
+{
+    private const SUCCESS = 0;
+    private const FAILURE = 1;
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $this->service->foo();
+            return self::SUCCESS;
+        } catch (\Throwable $exception) {
+            return self::FAILURE;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7242