### PR TITLE
Bugfix: Allow nullable for ControllerReference (AddRouteAnnotationRector)

### DIFF
--- a/src/NodeAnalyzer/Annotations/MethodCallAnnotationAssertResolver.php
+++ b/src/NodeAnalyzer/Annotations/MethodCallAnnotationAssertResolver.php
@@ -34,9 +34,9 @@ final class MethodCallAnnotationAssertResolver
 
         // based on https://github.com/symfony/symfony/blob/7d4b42cbeef195e0a01272b9c5f464f0afe52542/src/Symfony/Component/Validator/Mapping/GetterMetadata.php#L45-L47
         $possibleMethodNames = [
-            'get' . ucfirst($propertyName),
-            'is' . ucfirst($propertyName),
-            'has' . ucfirst($propertyName),
+            'get' . ucfirst((string) $propertyName),
+            'is' . ucfirst((string) $propertyName),
+            'has' . ucfirst((string) $propertyName),
         ];
 
         $secondArgValue = $args[1]->value;

--- a/src/Rector/Class_/MagicClosureTwigExtensionToNativeMethodsRector.php
+++ b/src/Rector/Class_/MagicClosureTwigExtensionToNativeMethodsRector.php
@@ -16,7 +16,6 @@ use Rector\Core\Reflection\ReflectionResolver;
 use Rector\NodeCollector\NodeAnalyzer\ArrayCallableMethodMatcher;
 use Rector\NodeCollector\ValueObject\ArrayCallable;
 use Rector\Php72\NodeFactory\AnonymousFunctionFactory;
-use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/src/ValueObject/SymfonyRouteMetadata.php
+++ b/src/ValueObject/SymfonyRouteMetadata.php
@@ -9,7 +9,7 @@ class SymfonyRouteMetadata
     /**
      * Format <class>::<method>
      */
-    private readonly string $controllerReference;
+    private readonly ?string $controllerReference;
 
     /**
      * @param array<string, mixed> $defaults
@@ -27,7 +27,7 @@ class SymfonyRouteMetadata
         private readonly array $methods,
         private readonly string $condition
     ) {
-        $this->controllerReference = $defaults['_controller'];
+        $this->controllerReference = $defaults['_controller'] ?? null;
     }
 
     public function getName(): string
@@ -101,7 +101,7 @@ class SymfonyRouteMetadata
     /**
      * Format <class>::<method>
      */
-    public function getControllerReference(): string
+    public function getControllerReference(): ?string
     {
         return $this->controllerReference;
     }

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/config/routes.json
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/config/routes.json
@@ -44,5 +44,15 @@
         },
         "requirements": [],
         "condition": ""
+    },
+    "path_only": {
+        "name": "path_only",
+        "path": "\/path_only.png",
+        "host": "",
+        "schemes": [],
+        "methods": [],
+        "defaults": {},
+        "requirements": [],
+        "condition": ""
     }
 }


### PR DESCRIPTION
Today I've found a new edge case which occurs a error in the `AddRouteAnnotationRector` rule.

If you define a route with a path but without a controller (it's allowed in Symfony) the `Rector\Symfony\ValueObject\SymfonyRouteMetadata::getControllerReference()` method throws the error `Return value must be of type string, null returned`.