### PR TITLE
Bugfix: Wrap array keys with quotes to prevent a semantical error (AddRouteAnnotationRector)

### DIFF
--- a/src/NodeFactory/Annotations/ValueQuoteWrapper.php
+++ b/src/NodeFactory/Annotations/ValueQuoteWrapper.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\NodeFactory\Annotations;
+
+use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
+
+final class ValueQuoteWrapper
+{
+    /**
+     * @return mixed|CurlyListNode|string
+     */
+    public function wrap(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            return '"' . $value . '"';
+        }
+
+        if (is_array($value)) {
+            return $this->wrapArray($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param mixed[] $value
+     */
+    private function wrapArray(array $value): CurlyListNode
+    {
+        $wrappedValue = [];
+
+        foreach ($value as $nestedKey => $nestedValue) {
+            $key = match (true) {
+                is_numeric($nestedKey) => $nestedKey,
+                default => '"' . $nestedKey . '"',
+            };
+
+            $wrappedValue[$key] = match (true) {
+                is_string($nestedValue) => '"' . $nestedValue . '"',
+                default => $nestedValue,
+            };
+        }
+
+        return new CurlyListNode($wrappedValue);
+    }
+}

--- a/src/Rector/ClassMethod/AddRouteAnnotationRector.php
+++ b/src/Rector/ClassMethod/AddRouteAnnotationRector.php
@@ -11,6 +11,7 @@ use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNod
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\Contract\Bridge\Symfony\Routing\SymfonyRoutesProviderInterface;
 use Rector\Symfony\Enum\SymfonyAnnotation;
+use Rector\Symfony\NodeFactory\Annotations\ValueQuoteWrapper;
 use Rector\Symfony\PhpDocNode\SymfonyRouteTagValueNodeFactory;
 use Rector\Symfony\ValueObject\SymfonyRouteMetadata;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -23,7 +24,8 @@ final class AddRouteAnnotationRector extends AbstractRector
 {
     public function __construct(
         private readonly SymfonyRoutesProviderInterface $symfonyRoutesProvider,
-        private readonly SymfonyRouteTagValueNodeFactory $symfonyRouteTagValueNodeFactory
+        private readonly SymfonyRouteTagValueNodeFactory $symfonyRouteTagValueNodeFactory,
+        private readonly ValueQuoteWrapper $valueQuoteWrapper
     ) {
     }
 
@@ -124,67 +126,38 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, mixed> $items
-     */
-    private function createCurlyListNodeFromIndexedItems(array $items): CurlyListNode
-    {
-        $quotedItems = [];
-
-        foreach ($items as $name => $value) {
-            $quotedItems[sprintf('"%s"', $name)] = match (true) {
-                is_string($value) => sprintf('"%s"', $value),
-                default => $value,
-            };
-        }
-
-        return new CurlyListNode($quotedItems);
-    }
-
-    /**
-     * @param string[] $items
-     */
-    private function createCurlyListNodeFromItems(array $items): CurlyListNode
-    {
-        $quotedItems = array_map(static fn (string $item): string => sprintf('"%s"', $item), $items);
-
-        return new CurlyListNode($quotedItems);
-    }
-
-    /**
      * @return array{path: string, name: string, defaults?: CurlyListNode, host?: string, methods?: CurlyListNode, condition?: string}
      */
     private function createRouteItems(SymfonyRouteMetadata $symfonyRouteMetadata): array
     {
         $items = [
-            'path' => sprintf('"%s"', $symfonyRouteMetadata->getPath()),
-            'name' => sprintf('"%s"', $symfonyRouteMetadata->getName()),
+            'path' => $this->valueQuoteWrapper->wrap($symfonyRouteMetadata->getPath()),
+            'name' => $this->valueQuoteWrapper->wrap($symfonyRouteMetadata->getName()),
         ];
 
         $defaultsWithoutController = $symfonyRouteMetadata->getDefaultsWithoutController();
         if ($defaultsWithoutController !== []) {
-            $items['defaults'] = $this->createCurlyListNodeFromIndexedItems($defaultsWithoutController);
+            $items['defaults'] = $this->valueQuoteWrapper->wrap($defaultsWithoutController);
         }
 
         if ($symfonyRouteMetadata->getHost() !== '') {
-            $items['host'] = sprintf('"%s"', $symfonyRouteMetadata->getHost());
+            $items['host'] = $this->valueQuoteWrapper->wrap($symfonyRouteMetadata->getHost());
         }
 
         if ($symfonyRouteMetadata->getSchemes() !== []) {
-            $items['schemes'] = $this->createCurlyListNodeFromItems($symfonyRouteMetadata->getSchemes());
+            $items['schemes'] = $this->valueQuoteWrapper->wrap($symfonyRouteMetadata->getSchemes());
         }
 
         if ($symfonyRouteMetadata->getMethods() !== []) {
-            $items['methods'] = $this->createCurlyListNodeFromItems($symfonyRouteMetadata->getMethods());
+            $items['methods'] = $this->valueQuoteWrapper->wrap($symfonyRouteMetadata->getMethods());
         }
 
         if ($symfonyRouteMetadata->getCondition() !== '') {
-            $items['condition'] = sprintf('"%s"', $symfonyRouteMetadata->getCondition());
+            $items['condition'] = $this->valueQuoteWrapper->wrap($symfonyRouteMetadata->getCondition());
         }
 
         if ($symfonyRouteMetadata->getRequirements() !== []) {
-            $items['requirements'] = $this->createCurlyListNodeFromIndexedItems(
-                $symfonyRouteMetadata->getRequirements()
-            );
+            $items['requirements'] = $this->valueQuoteWrapper->wrap($symfonyRouteMetadata->getRequirements());
         }
 
         return $items;

--- a/src/Rector/ClassMethod/AddRouteAnnotationRector.php
+++ b/src/Rector/ClassMethod/AddRouteAnnotationRector.php
@@ -124,16 +124,20 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<string, mixed> $defaults
+     * @param array<string, mixed> $items
      */
-    private function createDefaults(array $defaults): CurlyListNode
+    private function createCurlyListNodeFromIndexedItems(array $items): CurlyListNode
     {
-        return new CurlyListNode(
-            array_map(static fn (mixed $default): mixed => match (true) {
-                is_string($default) => sprintf('"%s"', $default),
-                default => $default,
-            }, $defaults)
-        );
+        $quotedItems = [];
+
+        foreach ($items as $name => $value) {
+            $quotedItems[sprintf('"%s"', $name)] = match (true) {
+                is_string($value) => sprintf('"%s"', $value),
+                default => $value,
+            };
+        }
+
+        return new CurlyListNode($quotedItems);
     }
 
     /**
@@ -158,7 +162,7 @@ CODE_SAMPLE
 
         $defaultsWithoutController = $symfonyRouteMetadata->getDefaultsWithoutController();
         if ($defaultsWithoutController !== []) {
-            $items['defaults'] = $this->createDefaults($defaultsWithoutController);
+            $items['defaults'] = $this->createCurlyListNodeFromIndexedItems($defaultsWithoutController);
         }
 
         if ($symfonyRouteMetadata->getHost() !== '') {
@@ -178,7 +182,9 @@ CODE_SAMPLE
         }
 
         if ($symfonyRouteMetadata->getRequirements() !== []) {
-            $items['requirements'] = $this->createCurlyListNodeFromItems($symfonyRouteMetadata->getRequirements());
+            $items['requirements'] = $this->createCurlyListNodeFromIndexedItems(
+                $symfonyRouteMetadata->getRequirements()
+            );
         }
 
         return $items;

--- a/tests/NodeFactory/Annotations/ValueQuoteWrapperTest.php
+++ b/tests/NodeFactory/Annotations/ValueQuoteWrapperTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\NodeFactory\Annotations;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
+use Rector\Symfony\NodeFactory\Annotations\ValueQuoteWrapper;
+use stdClass;
+
+class ValueQuoteWrapperTest extends TestCase
+{
+    /**
+     * @dataProvider provideValues
+     */
+    public function testQuotingValues(mixed $expectedWrappedValue, mixed $value): void
+    {
+        $valueQuoteWrapper = new ValueQuoteWrapper();
+
+        $this->assertEquals($expectedWrappedValue, $valueQuoteWrapper->wrap($value));
+    }
+
+    /**
+     * @return Generator<string, mixed>
+     */
+    public function provideValues(): iterable
+    {
+        yield 'Quote string' => ['"foo"', 'foo'];
+        yield 'Do nothing with integer' => [5, 5];
+        yield 'Do nothing with stdClass' => [new stdClass(), new stdClass()];
+        yield 'Quote strings in array and return CurlyListNode' => [
+            new CurlyListNode(['"foo"', '"bar"']),
+            ['foo', 'bar'],
+        ];
+        yield 'Do nothing with integer in array and return CurlyListNode' => [new CurlyListNode([7, 9]), [7, 9]];
+        yield 'Quote strings and ignore integer in array and return CurlyListNode' => [
+            new CurlyListNode(['"foo"', 790, '"bar"']),
+            ['foo', 790, 'bar'],
+        ];
+        yield 'Quote string keys and return CurlyListNode' => [
+            new CurlyListNode([
+                '"fooKey"' => '"foo"',
+                790,
+                '"barKey"' => '"bar"',
+            ]),
+            [
+                'fooKey' => 'foo',
+                790,
+                'barKey' => 'bar',
+            ],
+        ];
+    }
+}

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture.php.inc
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AppController extends Controller
 {
     /**
-     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={foo="foo123", page=1}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={page="\d+"})
+     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo"="foo123", "page"=1}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page"="\d+"})
      */
     public function allAction()
     {

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_missing_route.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_missing_route.php.inc
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AppController extends Controller
 {
     /**
-     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={foo="foo123", page=1}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={page="\d+"})
+     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo"="foo123", "page"=1}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page"="\d+"})
      */
     public function allAction()
     {


### PR DESCRIPTION
New day, new bug, new fix 🙃

I've got a semantical error because of the unquoted keys of the `defaults` and `requirements` parameters.
```
[Semantical Error] Couldn't find constant company, method Foo\BarBundle\Controller\FooController::deleteFooAction() in /var/www/config/routes/../../src/Foo/BarBundle/Controller/ (which is being imported from "/var/www/config/routes/annotations.yaml"). Make sure annotations are installed and enabled.
```

---

FYI: I finally have time to use the AddRouteAnnotationRector rule on the project for which I needed the rule 🎉  I've also seen that the `options` of a route are missing but I will add them in a separate PR.