### PR TITLE
[Symfony] Skip sprintf no space on StringToArrayArgumentProcessRector

### DIFF
--- a/src/Rector/New_/StringToArrayArgumentProcessRector.php
+++ b/src/Rector/New_/StringToArrayArgumentProcessRector.php
@@ -171,7 +171,7 @@ CODE_SAMPLE
         }
 
         $arrayNode = $this->nodeTransformer->transformSprintfToArray($funcCall);
-        if ($arrayNode !== null) {
+        if ($arrayNode !== null && count($arrayNode->items) > 1) {
             $assign->expr = $arrayNode;
         }
     }

--- a/tests/Rector/New_/StringToArrayArgumentProcessRector/Fixture/skip_sprintf_no_space.php.inc
+++ b/tests/Rector/New_/StringToArrayArgumentProcessRector/Fixture/skip_sprintf_no_space.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\New_\StringToArrayArgumentProcessRector\Fixture;
+
+use Symfony\Component\Process\Process;
+
+$command = sprintf("FOO=%s", 10);
+
+$process = new Process($command);


### PR DESCRIPTION
Given the following code:

```php
use Symfony\Component\Process\Process;

$command = sprintf("FOO=%s", 10);

$process = new Process($command);
```

it currently produce:

```diff
-$command = sprintf("FOO=%s", 10);
+$command = ['FOO=%s'];
```

which should be skipped.

Fixes https://github.com/rectorphp/rector-symfony/issues/188
