### PR TITLE
Add missing "options" in routes (AddRouteAnnotationRector)

### DIFF
--- a/src/Bridge/Symfony/Routing/SymfonyRoutesProvider.php
+++ b/src/Bridge/Symfony/Routing/SymfonyRoutesProvider.php
@@ -49,7 +49,8 @@ final class SymfonyRoutesProvider implements SymfonyRoutesProviderInterface
                 $route->getHost(),
                 $route->getSchemes(),
                 $route->getMethods(),
-                $route->getCondition()
+                $route->getCondition(),
+                $route->getOptions(),
             );
         }
 

--- a/src/Rector/ClassMethod/AddRouteAnnotationRector.php
+++ b/src/Rector/ClassMethod/AddRouteAnnotationRector.php
@@ -126,7 +126,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return array{path: string, name: string, defaults?: CurlyListNode, host?: string, methods?: CurlyListNode, condition?: string}
+     * @return array{path: string, name: string, defaults?: CurlyListNode, host?: string, methods?: CurlyListNode, condition?: string, options?: CurlyListNode}
      */
     private function createRouteItems(SymfonyRouteMetadata $symfonyRouteMetadata): array
     {
@@ -158,6 +158,11 @@ CODE_SAMPLE
 
         if ($symfonyRouteMetadata->getRequirements() !== []) {
             $items['requirements'] = $this->valueQuoteWrapper->wrap($symfonyRouteMetadata->getRequirements());
+        }
+
+        $optionsWithoutDefaultCompilerClass = $symfonyRouteMetadata->getOptionsWithoutDefaultCompilerClass();
+        if ($optionsWithoutDefaultCompilerClass !== []) {
+            $items['options'] = $this->valueQuoteWrapper->wrap($optionsWithoutDefaultCompilerClass);
         }
 
         return $items;

--- a/src/ValueObject/SymfonyRouteMetadata.php
+++ b/src/ValueObject/SymfonyRouteMetadata.php
@@ -16,6 +16,7 @@ class SymfonyRouteMetadata
      * @param array<string, mixed> $requirements
      * @param string[] $schemes
      * @param string[] $methods
+     * @param array<string, mixed> $options
      */
     public function __construct(
         private readonly string $name,
@@ -25,7 +26,8 @@ class SymfonyRouteMetadata
         private readonly string $host,
         private readonly array $schemes,
         private readonly array $methods,
-        private readonly string $condition
+        private readonly string $condition,
+        private readonly array $options,
     ) {
         $this->controllerReference = $defaults['_controller'] ?? null;
     }
@@ -96,6 +98,29 @@ class SymfonyRouteMetadata
     public function getCondition(): string
     {
         return $this->condition;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptionsWithoutDefaultCompilerClass(): array
+    {
+        $options = $this->options;
+
+        $compilerClass = $options['compiler_class'] ?? null;
+        if ($compilerClass === 'Symfony\Component\Routing\RouteCompiler') {
+            unset($options['compiler_class']);
+        }
+
+        return $options;
     }
 
     /**

--- a/stubs/Symfony/Component/Routing/Route.php
+++ b/stubs/Symfony/Component/Routing/Route.php
@@ -14,8 +14,8 @@ class Route
      * @return string[]
      */
     public function getSchemes(): array
-    {}
-
+    {
+    }
 
     public function getCondition(): string
     {
@@ -41,6 +41,10 @@ class Route
     }
 
     public function getPath(): string
+    {
+    }
+
+    public function getOptions(): array
     {
     }
 }

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture.php.inc
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AppController extends Controller
 {
     /**
-     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo"="foo123", "page"=1}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page"="\d+"})
+     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo"="foo123", "page"=1}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page"="\d+"}, options={"compiler_class"="App\Routing\Utf8RouteCompiler", "expose"=true, "foo1"=5, "foo2"="bar"})
      */
     public function allAction()
     {

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_missing_route.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_missing_route.php.inc
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AppController extends Controller
 {
     /**
-     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo"="foo123", "page"=1}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page"="\d+"})
+     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo"="foo123", "page"=1}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page"="\d+"}, options={"compiler_class"="App\Routing\Utf8RouteCompiler", "expose"=true, "foo1"=5, "foo2"="bar"})
      */
     public function allAction()
     {

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Source/DummySymfonyRoutesProvider.php
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Source/DummySymfonyRoutesProvider.php
@@ -37,7 +37,8 @@ final class DummySymfonyRoutesProvider implements SymfonyRoutesProviderInterface
                 host: $route['host'],
                 schemes: $route['schemes'],
                 methods: $route['methods'],
-                condition: $route['condition']
+                condition: $route['condition'],
+                options: $route['options'],
             ),
             $routesJson
         );

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/config/routes.json
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/config/routes.json
@@ -19,7 +19,13 @@
         "requirements": {
             "page": "\\d+"
         },
-        "condition": "context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '\/firefox\/i'"
+        "condition": "context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '\/firefox\/i'",
+        "options": {
+            "compiler_class": "App\\Routing\\Utf8RouteCompiler",
+            "expose": true,
+            "foo1": 5,
+            "foo2": "bar"
+        }
     },
     "minimal": {
         "name": "minimal",
@@ -31,7 +37,10 @@
             "_controller": "Rector\\Symfony\\Tests\\Rector\\ClassMethod\\AddRouteAnnotationRector\\Fixture\\AppController::minimalAction"
         },
         "requirements": [],
-        "condition": ""
+        "condition": "",
+        "options": {
+            "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler"
+        }
     },
     "short": {
         "name": "short",
@@ -43,7 +52,10 @@
             "_controller": "Rector\\Symfony\\Tests\\Rector\\ClassMethod\\AddRouteAnnotationRector\\Fixture\\AppController::shortAction"
         },
         "requirements": [],
-        "condition": ""
+        "condition": "",
+        "options": {
+            "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler"
+        }
     },
     "path_only": {
         "name": "path_only",
@@ -53,6 +65,9 @@
         "methods": [],
         "defaults": {},
         "requirements": [],
-        "condition": ""
+        "condition": "",
+        "options": {
+            "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler"
+        }
     }
 }


### PR DESCRIPTION
When I used the `AddRouteAnnotationRector` rule, I noticed that the options of a route are also important and are missing in the rule.

The Route class sets by default a `compiler_class` value as you see here https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Routing/Route.php#L253. Because of that I ignore this explicit but allow if somebody changed it because the RouteCompiler is based on a interface https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Routing/RouteCompiler.php#L20.