### PR TITLE
[FormBuilderSetDataMapperRector] Invalid data mapper replacement

### DIFF
--- a/tests/Rector/MethodCall/FormBuilderSetDataMapperRector/Fixture/form_trait_data_mapper.php.inc
+++ b/tests/Rector/MethodCall/FormBuilderSetDataMapperRector/Fixture/form_trait_data_mapper.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+use Symfony\Component\Form\FormBuilderInterface;
+
+trait FormTraitDataMappter
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        parent::buildForm($builder, $options);
+        $builder
+            ->setDataMapper($this);
+    }
+}
+


### PR DESCRIPTION
# Failing Test for FormBuilderSetDataMapperRector
Same as https://github.com/rectorphp/rector-symfony/pull/185

Based on https://getrector.org/demo/ef71e26f-5722-4f99-a450-4d19a119eb61

