### PR TITLE
[Symfony 2.7] Move ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector to symfony 2.7 config set

### DIFF
--- a/config/sets/symfony/level/up-to-symfony-27.php
+++ b/config/sets/symfony/level/up-to-symfony-27.php
@@ -7,5 +7,5 @@ use Rector\Symfony\Set\SymfonyLevelSetList;
 use Rector\Symfony\Set\SymfonySetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([SymfonySetList::SYMFONY_28, SymfonyLevelSetList::UP_TO_SYMFONY_27]);
+    $rectorConfig->sets([SymfonySetList::SYMFONY_27, SymfonyLevelSetList::UP_TO_SYMFONY_26]);
 };

--- a/config/sets/symfony/symfony27.php
+++ b/config/sets/symfony/symfony27.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Rector\MethodCall\ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector::class);
+};

--- a/config/sets/symfony/symfony30.php
+++ b/config/sets/symfony/symfony30.php
@@ -12,7 +12,6 @@ use Rector\Symfony\Rector\ClassMethod\FormTypeGetParentRector;
 use Rector\Symfony\Rector\ClassMethod\GetRequestRector;
 use Rector\Symfony\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector;
 use Rector\Symfony\Rector\MethodCall\CascadeValidationFormBuilderRector;
-use Rector\Symfony\Rector\MethodCall\ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector;
 use Rector\Symfony\Rector\MethodCall\ChangeStringCollectionOptionToConstantRector;
 use Rector\Symfony\Rector\MethodCall\FormTypeInstanceToClassConstRector;
 use Rector\Symfony\Rector\MethodCall\OptionNameRector;
@@ -38,7 +37,6 @@ return static function (RectorConfig $rectorConfig): void {
 
         // forms - collection
         ChangeStringCollectionOptionToConstantRector::class,
-        ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector::class,
     ]);
 
     $rectorConfig

--- a/src/Set/SymfonyLevelSetList.php
+++ b/src/Set/SymfonyLevelSetList.php
@@ -21,6 +21,11 @@ final class SymfonyLevelSetList implements SetListInterface
     /**
      * @var string
      */
+    final public const UP_TO_SYMFONY_27 = __DIR__ . '/../../config/sets/symfony/level/up-to-symfony-27.php';
+
+    /**
+     * @var string
+     */
     final public const UP_TO_SYMFONY_28 = __DIR__ . '/../../config/sets/symfony/level/up-to-symfony-28.php';
 
     /**

--- a/src/Set/SymfonySetList.php
+++ b/src/Set/SymfonySetList.php
@@ -26,6 +26,11 @@ final class SymfonySetList implements SetListInterface
     /**
      * @var string
      */
+    final public const SYMFONY_27 = __DIR__ . '/../../config/sets/symfony/symfony27.php';
+
+    /**
+     * @var string
+     */
     final public const SYMFONY_28 = __DIR__ . '/../../config/sets/symfony/symfony28.php';
 
     /**


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector-symfony/issues/214