### PR TITLE
[Symfony] Handle single action with __construct on InvokableControllerRector

### DIFF
--- a/src/Rector/Class_/InvokableControllerRector.php
+++ b/src/Rector/Class_/InvokableControllerRector.php
@@ -112,7 +112,10 @@ CODE_SAMPLE
 
         // 1. single action method → only rename
         if (count($actionClassMethods) === 1) {
-            return $this->refactorSingleAction($actionClassMethods[0], $node);
+            return $this->refactorSingleAction(
+                current($actionClassMethods),
+                $node
+            );
         }
 
         // 2. multiple action methods → split + rename current based on action name

--- a/src/Rector/Class_/InvokableControllerRector.php
+++ b/src/Rector/Class_/InvokableControllerRector.php
@@ -112,10 +112,7 @@ CODE_SAMPLE
 
         // 1. single action method → only rename
         if (count($actionClassMethods) === 1) {
-            return $this->refactorSingleAction(
-                current($actionClassMethods),
-                $node
-            );
+            return $this->refactorSingleAction(current($actionClassMethods), $node);
         }
 
         // 2. multiple action methods → split + rename current based on action name

--- a/src/Rector/New_/RootNodeTreeBuilderRector.php
+++ b/src/Rector/New_/RootNodeTreeBuilderRector.php
@@ -102,7 +102,7 @@ CODE_SAMPLE
         }
 
         $nextExpression = $currentStmt->getAttribute(AttributeKey::NEXT_NODE);
-        if ($nextExpression === null) {
+        if (! $nextExpression instanceof Node) {
             return null;
         }
 

--- a/tests/Rector/Class_/InvokableControllerRector/Fixture/single_action_with_construct.php.inc
+++ b/tests/Rector/Class_/InvokableControllerRector/Fixture/single_action_with_construct.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Rector\Class_\InvokableControllerRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\SerializerInterface;
+
+final class SingleActionWithConstruct extends AbstractController
+{
+    public function __construct(
+        private SerializerInterface $serializer,
+    ) {
+    }
+
+    public function create(): Response
+    {
+        return $this->json([], Response::HTTP_CREATED);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Rector\Class_\InvokableControllerRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\SerializerInterface;
+
+final class SingleActionWithConstruct extends AbstractController
+{
+    public function __construct(
+        private SerializerInterface $serializer,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        return $this->json([], Response::HTTP_CREATED);
+    }
+}
+
+?>


### PR DESCRIPTION
Given the following code:

```php
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\HttpFoundation\Response;
use Symfony\Component\Serializer\SerializerInterface;

final class SingleActionWithConstruct extends AbstractController
{
    public function __construct(
        private SerializerInterface $serializer,
    ) {
    }

    public function create(): Response
    {
        return $this->json([], Response::HTTP_CREATED);
    }
}
```

It currently produce error:

```bash

There was 1 error:

1) Rector\Symfony\Tests\Rector\Class_\InvokableControllerRector\InvokableControllerRectorTest::test with data set #1 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
Undefined array key 0
```

Fixes https://github.com/rectorphp/rector/issues/7365