### PR TITLE
Skip non-direct inheritors for AbstractType in RemoveDefaultGetBlockPrefixRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,7 +18,6 @@ parameters:
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:
-        # @todo update in rules package
         -
              message: '#Instead of "instanceof/is_a\(\)" use ReflectionProvider service or "\(new ObjectType\(<desired_type\>\)\)\-\>isSuperTypeOf\(<element_type\>\)" for static reflection to work#'
              path: src/ValueObjectFactory/ServiceMapFactory.php
@@ -43,6 +42,9 @@ parameters:
              path: tests
 
         - '#Dynamic call to static method PHPUnit\\Framework\\Assert\:\:(.*?)(.*?)\(\)#'
+
+        # refactor with scope covariant edge-case
+        - '#Parameter \#1 \$node \(PhpParser\\Node\\Stmt\\ClassMethod\) of method Rector\\Symfony\\Rector\\ClassMethod\\RemoveDefaultGetBlockPrefixRector\:\:refactorWithScope\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Core\\Contract\\Rector\\ScopeAwarePhpRectorInterface\:\:refactorWithScope\(\)#'
 
         -
             path: "src/ValueObjectFactory/ServiceMapFactory.php"

--- a/src/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
+++ b/src/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
@@ -114,12 +114,12 @@ CODE_SAMPLE
             return false;
         }
 
-        if (! $classReflection->isSubclassOf('Symfony\Component\Form\AbstractType')) {
+        // refactoring only direct inheritors, so allow override of custom children
+        $parentClassReflection = $classReflection->getParentClass();
+        if (! $parentClassReflection instanceof ClassReflection) {
             return false;
         }
 
-        // refactoring only direct inheritors, so allow override of custom children
-        $parentClassReflection = $classReflection->getParentClass();
         if ($parentClassReflection->getName() !== 'Symfony\Component\Form\AbstractType') {
             return false;
         }

--- a/src/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
+++ b/src/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
@@ -7,13 +7,13 @@ namespace Rector\Symfony\Rector\ClassMethod;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
-use PHPStan\Type\ObjectType;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Rector\AbstractScopeAwareRector;
 use Symfony\Component\String\UnicodeString;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -23,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\Symfony\Tests\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector\RemoveDefaultGetBlockPrefixRectorTest
  */
-final class RemoveDefaultGetBlockPrefixRector extends AbstractRector
+final class RemoveDefaultGetBlockPrefixRector extends AbstractScopeAwareRector
 {
     public function getRuleDefinition(): RuleDefinition
     {
@@ -66,9 +66,9 @@ CODE_SAMPLE
     /**
      * @param ClassMethod $node
      */
-    public function refactor(Node $node): ?Node
+    public function refactorWithScope(Node $node, Scope $scope): ?Node
     {
-        if (! $this->isObjectMethodNameMatch($node)) {
+        if (! $this->isObjectMethodNameMatch($node, $scope)) {
             return null;
         }
 
@@ -107,18 +107,24 @@ CODE_SAMPLE
         return null;
     }
 
-    private function isObjectMethodNameMatch(ClassMethod $classMethod): bool
+    private function isObjectMethodNameMatch(ClassMethod $classMethod, Scope $scope): bool
     {
-        $class = $this->betterNodeFinder->findParentType($classMethod, Class_::class);
-        if (! $class instanceof Class_) {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
             return false;
         }
 
-        if (! $this->isObjectType($classMethod, new ObjectType('Symfony\Component\Form\AbstractType'))) {
+        if (! $classReflection->isSubclassOf('Symfony\Component\Form\AbstractType')) {
             return false;
         }
 
-        return $this->isName($classMethod->name, 'getBlockPrefix');
+        // refactoring only direct inheritors, so allow override of custom children
+        $parentClassReflection = $classReflection->getParentClass();
+        if ($parentClassReflection->getName() !== 'Symfony\Component\Form\AbstractType') {
+            return false;
+        }
+
+        return $classMethod->name->toString() === 'getBlockPrefix';
     }
 
     /**

--- a/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/skip_extending_custom_type.php.inc
+++ b/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/skip_extending_custom_type.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector\Fixture;
+
+use Rector\Symfony\Tests\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector\Source\CustomType;
+
+final class SkipExtendingCustomType extends CustomType
+{
+    public function getBlockPrefix()
+    {
+        return 'anything';
+    }
+}

--- a/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/skip_no_parent.php.inc
+++ b/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/skip_no_parent.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector\Fixture;
+
+final class SkipNoParent
+{
+    public function getBlockPrefix()
+    {
+        return 'unique';
+    }
+}

--- a/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/skip_with_get_block_prefix.php.inc
+++ b/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/skip_with_get_block_prefix.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+
+class IconType extends ChoiceType
+{
+    public function getBlockPrefix()
+    {
+        return 'icon';
+    }
+}
+
+class ChoiceType extends AbstractType
+{
+    public function getBlockPrefix()
+    {
+        return 'something';
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/skip_with_get_block_prefix.php.inc
+++ b/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/skip_with_get_block_prefix.php.inc
@@ -19,5 +19,3 @@ class ChoiceType extends AbstractType
         return 'something';
     }
 }
-
-?>

--- a/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Source/CustomType.php
+++ b/tests/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Source/CustomType.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector\Source;
+
+use Symfony\Component\Form\AbstractType;
+
+class CustomType extends AbstractType
+{
+    public function getBlockPrefix()
+    {
+        return 'custom';
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7347

Closes https://github.com/rectorphp/rector-symfony/pull/212