### PR TITLE
Handle static calls in WebTestCaseAssertResponseCodeRector

### DIFF
--- a/src/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
+++ b/src/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
@@ -7,6 +7,7 @@ namespace Rector\Symfony\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
@@ -68,11 +69,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [MethodCall::class];
+        return [MethodCall::class, StaticCall::class];
     }
 
     /**
-     * @param MethodCall $node
+     * @param MethodCall|StaticCall $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -111,7 +112,10 @@ CODE_SAMPLE
         return $this->valueResolver->isValue($firstArg->value, 'Location');
     }
 
-    private function processAssertResponseStatusCodeSame(MethodCall $methodCall): ?MethodCall
+    /**
+     * @param StaticCall|MethodCall $methodCall
+     */
+    private function processAssertResponseStatusCodeSame(Expr\CallLike $methodCall): ?Expr\CallLike
     {
         if (! $this->isName($methodCall->name, 'assertSame')) {
             return null;
@@ -148,10 +152,14 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($methodCall instanceof StaticCall) {
+            return $this->nodeFactory->createStaticCall('self', 'assertResponseStatusCodeSame', [$methodCall->args[0]]);
+        }
+
         return $this->nodeFactory->createLocalMethodCall('assertResponseStatusCodeSame', [$methodCall->args[0]]);
     }
 
-    private function processAssertResponseRedirects(MethodCall $methodCall): ?MethodCall
+    private function processAssertResponseRedirects(Expr\CallLike $methodCall): ?Expr\CallLike
     {
         if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($methodCall, ['assertSame'])) {
             return null;
@@ -165,6 +173,11 @@ CODE_SAMPLE
         }
 
         $expectedUrl = $args[0]->value;
+
+        if ($methodCall instanceof StaticCall) {
+            return $this->nodeFactory->createStaticCall('self', 'assertResponseRedirects', [$expectedUrl]);
+        }
+
         return $this->nodeFactory->createLocalMethodCall('assertResponseRedirects', [$expectedUrl]);
     }
 }

--- a/src/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
+++ b/src/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
@@ -112,10 +112,7 @@ CODE_SAMPLE
         return $this->valueResolver->isValue($firstArg->value, 'Location');
     }
 
-    /**
-     * @param StaticCall|MethodCall $methodCall
-     */
-    private function processAssertResponseStatusCodeSame(Expr\CallLike $methodCall): ?Expr\CallLike
+    private function processAssertResponseStatusCodeSame(StaticCall|MethodCall $methodCall): MethodCall|StaticCall|null
     {
         if (! $this->isName($methodCall->name, 'assertSame')) {
             return null;
@@ -159,7 +156,7 @@ CODE_SAMPLE
         return $this->nodeFactory->createLocalMethodCall('assertResponseStatusCodeSame', [$methodCall->args[0]]);
     }
 
-    private function processAssertResponseRedirects(Expr\CallLike $methodCall): ?Expr\CallLike
+    private function processAssertResponseRedirects(MethodCall|StaticCall $methodCall): MethodCall|StaticCall|null
     {
         if (! $this->testsNodeAnalyzer->isPHPUnitMethodCallNames($methodCall, ['assertSame'])) {
             return null;

--- a/tests/Rector/MethodCall/WebTestCaseAssertResponseCodeRector/Fixture/handle_static_calls.php.inc
+++ b/tests/Rector/MethodCall/WebTestCaseAssertResponseCodeRector/Fixture/handle_static_calls.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\WebTestCaseAssertResponseCodeRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ResponseCodeSame extends WebTestCase
+{
+    public function test()
+    {
+        $response = self::$client->getResponse();
+        self::assertSame(362, $response->getStatusCode());
+        self::assertSame('https://unknown.com', $response->headers->get('Location'));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\WebTestCaseAssertResponseCodeRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ResponseCodeSame extends WebTestCase
+{
+    public function test()
+    {
+        $response = self::$client->getResponse();
+        self::assertResponseStatusCodeSame(362);
+        self::assertResponseRedirects('https://unknown.com');
+    }
+}
+
+?>


### PR DESCRIPTION
Both PHPUnit's and Symfony's `assert*` methods are `static`, so this adds the handling of static calls.