### PR TITLE
Add rector to replace KernelTestCase::$container with KernelTestCase::getContainer() in tests

### DIFF
--- a/config/sets/symfony/symfony53.php
+++ b/config/sets/symfony/symfony53.php
@@ -10,6 +10,7 @@ use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameClassConstFetch;
+use Rector\Symfony\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
@@ -96,4 +97,6 @@ return static function (RectorConfig $rectorConfig): void {
                 'MAIN_REQUEST'
             ),
         ]);
+
+    $rectorConfig->rule(KernelTestCaseContainerPropertyDeprecationRector::class);
 };

--- a/config/sets/symfony/symfony60.php
+++ b/config/sets/symfony/symfony60.php
@@ -12,6 +12,7 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Symfony\Rector\FuncCall\ReplaceServiceArgumentRector;
 use Rector\Symfony\Rector\MethodCall\GetHelperControllerToServiceRector;
+use Rector\Symfony\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\Symfony\ValueObject\ReplaceServiceArgument;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
@@ -75,4 +76,5 @@ return static function (RectorConfig $rectorConfig): void {
             ),
         ]);
     $rectorConfig->rule(GetHelperControllerToServiceRector::class);
+    $rectorConfig->rule(KernelTestCaseContainerPropertyDeprecationRector::class);
 };

--- a/config/sets/symfony/symfony60.php
+++ b/config/sets/symfony/symfony60.php
@@ -12,7 +12,6 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Symfony\Rector\FuncCall\ReplaceServiceArgumentRector;
 use Rector\Symfony\Rector\MethodCall\GetHelperControllerToServiceRector;
-use Rector\Symfony\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\Symfony\ValueObject\ReplaceServiceArgument;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
@@ -76,5 +75,4 @@ return static function (RectorConfig $rectorConfig): void {
             ),
         ]);
     $rectorConfig->rule(GetHelperControllerToServiceRector::class);
-    $rectorConfig->rule(KernelTestCaseContainerPropertyDeprecationRector::class);
 };

--- a/src/NodeAnalyzer/SymfonyTestCaseAnalyzer.php
+++ b/src/NodeAnalyzer/SymfonyTestCaseAnalyzer.php
@@ -23,4 +23,14 @@ final class SymfonyTestCaseAnalyzer
 
         return $classReflection->isSubclassOf('Symfony\Bundle\FrameworkBundle\Test\WebTestCase');
     }
+
+    public function isInKernelTestCase(Node $node): bool
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        return $classReflection->isSubclassOf('Symfony\Bundle\FrameworkBundle\Test\KernelTestCase');
+    }
 }

--- a/src/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector.php
+++ b/src/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Rector\StaticPropertyFetch;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use PhpParser\Node\Name;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Symfony\NodeAnalyzer\SymfonyTestCaseAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Symfony\Tests\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector\KernelTestCaseContainerPropertyDeprecationRectorTest
+ */
+class KernelTestCaseContainerPropertyDeprecationRector extends AbstractRector
+{
+    public function __construct(
+        private readonly SymfonyTestCaseAnalyzer $symfonyTestCaseAnalyzer,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Simplify use of assertions in WebTestCase', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SomeTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        $container = self::$container;
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SomeTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        $container = self::getContainer();
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [StaticPropertyFetch::class];
+    }
+
+    /**
+     * @param StaticPropertyFetch $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->symfonyTestCaseAnalyzer->isInKernelTestCase($node)) {
+            return null;
+        }
+
+        if ($this->nodeNameResolver->getName($node->name) !== 'container') {
+            return null;
+        }
+
+        if (! $node->class instanceof Name || (string) $node->class !== 'self') {
+            return null;
+        }
+
+        return $this->nodeFactory->createStaticCall('self', 'getContainer');
+    }
+}

--- a/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/Fixture/change_to_method_call.php.inc
+++ b/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/Fixture/change_to_method_call.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SomeTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        $container = self::$container;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SomeTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        $container = self::getContainer();
+    }
+}
+
+?>

--- a/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/Fixture/skip_access_in_another_class.php.inc
+++ b/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/Fixture/skip_access_in_another_class.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SomeTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        $container = \Foo::$container;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class SomeTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        $container = \Foo::$container;
+    }
+}
+
+?>

--- a/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/Fixture/skip_other_classes.php.inc
+++ b/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/Fixture/skip_other_classes.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $container = self::$container;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $container = self::$container;
+    }
+}
+
+?>

--- a/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/KernelTestCaseContainerPropertyDeprecationRectorTest.php
+++ b/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/KernelTestCaseContainerPropertyDeprecationRectorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class KernelTestCaseContainerPropertyDeprecationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/config/configured_rule.php
+++ b/tests/Rector/StaticPropertyFetch/KernelTestCaseContainerPropertyDeprecationRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+
+    $rectorConfig->rule(KernelTestCaseContainerPropertyDeprecationRector::class);
+};


### PR DESCRIPTION
Symfony deprecated `KernelTestCase::$container` back in `5.3` (https://github.com/symfony/symfony/blob/5.3/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php#L39) and removed it in `6.0`.

The recommended alternative ist to call `KernelTestCase::getContainer()` instead.