### PR TITLE
Exclude Error and Exception class name on StringClassNameToClassConstantRector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -20,7 +20,7 @@ return static function (RectorConfig $rectorConfig): void {
         '*/Source/*',
         '*/Source*/*',
         '*/tests/*/Fixture*/Expected/*',
-        StringClassNameToClassConstantRector::class,
+        StringClassNameToClassConstantRector::class => [__DIR__ . '/config'],
 
         \Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchMethodCallReturnTypeRector::class => [
             // "data" => "datum" false positive
@@ -34,6 +34,8 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->ruleWithConfiguration(StringClassNameToClassConstantRector::class, [
+        'Error',
+        'Exception',
         'Symfony\*',
         'Twig_*',
         'Twig*',


### PR DESCRIPTION
ref https://github.com/rectorphp/rector-symfony/pull/235#pullrequestreview-1094097162

I think the skip config should actually merge instead of replace existing `classesToSkip` config.