### PR TITLE
Add failing test for Command::execute return int rector with try catch

### DIFF
--- a/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_try_catch_return.php.inc
+++ b/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_try_catch_return.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipNestedReturn extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            return 0;
+        } catch (\Exception $e) {
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
Add failing test for ConsoleExecuteReturnIntRector when execute method has a try catch setup and contains return's in the try and catch part so no extra return should be necessary.

See example: https://getrector.org/demo/7d04f7ed-a69a-4fd1-8389-c1444e3ba15d