### PR TITLE
[Symfony] Skip Try Catch Return on ConsoleExecuteReturnIntRector

### DIFF
--- a/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -171,11 +171,11 @@ CODE_SAMPLE
         $lastKey = array_key_last((array) $classMethod->stmts);
 
         $return = new Return_(new LNumber(0));
-        if (is_int($lastKey) && $this->terminatedNodeAnalyzer->isAlwaysTerminated(
+        if ($lastKey !== null && (isset($classMethod->stmts[$lastKey]) && $this->terminatedNodeAnalyzer->isAlwaysTerminated(
             $classMethod,
             $classMethod->stmts[$lastKey],
             $return
-        )) {
+        ))) {
             return;
         }
 

--- a/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -18,6 +18,7 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
+use Rector\Core\NodeAnalyzer\TerminatedNodeAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -29,6 +30,10 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ConsoleExecuteReturnIntRector extends AbstractRector
 {
+    public function __construct(private readonly TerminatedNodeAnalyzer $terminatedNodeAnalyzer)
+    {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Returns int from Command::execute command', [
@@ -163,7 +168,18 @@ CODE_SAMPLE
             return;
         }
 
-        $classMethod->stmts[] = new Return_(new LNumber(0));
+        $lastKey = array_key_last((array) $classMethod->stmts);
+
+        $return = new Return_(new LNumber(0));
+        if (is_int($lastKey) && $this->terminatedNodeAnalyzer->isAlwaysTerminated(
+            $classMethod,
+            $classMethod->stmts[$lastKey],
+            $return
+        )) {
+            return;
+        }
+
+        $classMethod->stmts[] = $return;
     }
 
     private function isReturnWithExprIntEquals(Node $parentNode, Node $node): bool

--- a/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_try_catch_return.php.inc
+++ b/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_try_catch_return.php.inc
@@ -6,7 +6,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class SkipNestedReturn extends Command
+final class SkipTryCatchReturn extends Command
 {
     public function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_try_catch_return.php.inc
+++ b/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_try_catch_return.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipNestedReturn extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            return 0;
+        } catch (\Exception $e) {
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector-symfony/pull/238