### PR TITLE
[Set] SensioLabs annotation to attribute

### DIFF
--- a/config/sets/sensiolabs/annotations-to-attributes.php
+++ b/config/sets/sensiolabs/annotations-to-attributes.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig
+        ->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+            // @see https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/707
+            new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache'),
+            new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity'),
+            new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted'),
+            new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter'),
+            new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\Security'),
+            new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\Template'),
+        ]);
+};

--- a/src/Set/SensiolabsSetList.php
+++ b/src/Set/SensiolabsSetList.php
@@ -22,4 +22,9 @@ final class SensiolabsSetList implements SetListInterface
      * @var string
      */
     final public const FRAMEWORK_EXTRA_61 = __DIR__ . '/../../config/sets/sensiolabs/framework-extra-61.php';
+
+    /**
+     * @var string
+     */
+    final public const ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/sensiolabs/annotations-to-attributes.php';
 }

--- a/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/cache_fixture.php.inc
+++ b/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/cache_fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+/**
+ * @Cache(expires="tomorrow", public=true)
+ */
+class BarController
+{
+    /**
+     * @Cache(smaxage="20")
+     */
+    public function foo()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache;
+
+#[Cache(expires: 'tomorrow', public: true)]
+class BarController
+{
+    #[Cache(smaxage: 20)]
+    public function foo()
+    {
+    }
+}
+
+?>

--- a/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/entity_fixture.php.inc
+++ b/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/entity_fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
+
+class BarController
+{
+    /**
+     * @Entity("user", expr="repository.find(user_id)")
+     */
+    public function foo(User $user)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
+
+class BarController
+{
+    #[Entity('user', expr: 'repository.find(user_id)')]
+    public function foo(User $user)
+    {
+    }
+}
+
+?>

--- a/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/param_converter_fixture.php.inc
+++ b/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/param_converter_fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
+class BarController
+{
+    /**
+     * @ParamConverter("user", class="User")
+     */
+    public function foo(User $user)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+
+class BarController
+{
+    #[ParamConverter('user', class: 'User')]
+    public function foo(User $user)
+    {
+    }
+}
+
+?>

--- a/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/security_and_is_granted_fixture.php.inc
+++ b/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/security_and_is_granted_fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+
+class BarController
+{
+    /**
+     * @IsGranted("ROLE_ADMIN")
+     * @Security("is_granted('ROLE_USER') and is_granted('SHOW_FOO')")
+     */
+    public function foo()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+
+class BarController
+{
+    #[IsGranted('ROLE_ADMIN')]
+    #[Security("is_granted('ROLE_USER') and is_granted('SHOW_FOO')")]
+    public function foo()
+    {
+    }
+}
+
+?>

--- a/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/template_fixture.php.inc
+++ b/tests/Set/SensiolabsAnnotationsToAttributes/Fixture/template_fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class BarController
+{
+    /**
+     * @Template("@Blog/post.html.twig")
+     */
+    public function foo()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class BarController
+{
+    #[Template('@Blog/post.html.twig')]
+    public function foo()
+    {
+    }
+}
+
+?>

--- a/tests/Set/SensiolabsAnnotationsToAttributes/SensiolabsAnnotationsToAttributesTest.php
+++ b/tests/Set/SensiolabsAnnotationsToAttributes/SensiolabsAnnotationsToAttributesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Set\SensiolabsAnnotationsToAttributes;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SensiolabsAnnotationsToAttributesTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/sensiolabsAnnotationsToAttributes.php';
+    }
+}

--- a/tests/Set/SensiolabsAnnotationsToAttributes/config/sensiolabsAnnotationsToAttributes.php
+++ b/tests/Set/SensiolabsAnnotationsToAttributes/config/sensiolabsAnnotationsToAttributes.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SensiolabsSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
+    $rectorConfig->sets([SensiolabsSetList::ANNOTATIONS_TO_ATTRIBUTES]);
+};


### PR DESCRIPTION
SensioFrameworkExtraBundle support [attributes](https://symfony.com/bundles/SensioFrameworkExtraBundle/current/index.html#annotations-for-controllers). 
Added rules,  tests and link when this was [added](https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/707).

