### PR TITLE
AddRouteAnnotationRector: Some bugfixes

### DIFF
--- a/src/Rector/ClassMethod/AddRouteAnnotationRector.php
+++ b/src/Rector/ClassMethod/AddRouteAnnotationRector.php
@@ -152,7 +152,11 @@ CODE_SAMPLE
         }
 
         if ($symfonyRouteMetadata->getHost() !== '') {
-            $arrayItemNodes[] = new ArrayItemNode($symfonyRouteMetadata->getHost(), 'host');
+            $arrayItemNodes[] = new ArrayItemNode(
+                $symfonyRouteMetadata->getHost(),
+                'host',
+                String_::KIND_DOUBLE_QUOTED
+            );
         }
 
         if ($symfonyRouteMetadata->getSchemes() !== []) {
@@ -208,12 +212,18 @@ CODE_SAMPLE
         $curlyListNode = new CurlyListNode($methodsArrayItems);
 
         foreach ($curlyListNode->values as $nestedMethodsArrayItem) {
-            if (! is_numeric($nestedMethodsArrayItem->value)) {
+            if (is_string($nestedMethodsArrayItem->value)) {
                 $nestedMethodsArrayItem->kindValueQuoted = String_::KIND_DOUBLE_QUOTED;
             }
 
             if (is_string($nestedMethodsArrayItem->key)) {
                 $nestedMethodsArrayItem->kindKeyQuoted = String_::KIND_DOUBLE_QUOTED;
+            }
+
+            if ($nestedMethodsArrayItem->value === null) {
+                $nestedMethodsArrayItem->value = 'null';
+            } elseif (is_bool($nestedMethodsArrayItem->value)) {
+                $nestedMethodsArrayItem->value = $nestedMethodsArrayItem->value ? 'true' : 'false';
             }
         }
 

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture.php.inc
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AppController extends Controller
 {
     /**
-     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo" = "foo123", "page" = 1}, host=m.example.com, schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page" = "\d+"}, options={"compiler_class" = "App\Routing\Utf8RouteCompiler", "expose" = "1", "foo1" = 5, "foo2" = "bar"})
+     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo" = "foo123", "page" = 1, "nullableDefault" = null, "booleanDefaultTrue" = true, "booleanDefaultFalse" = false}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page" = "\d+"}, options={"compiler_class" = "App\Routing\Utf8RouteCompiler", "expose" = true, "foo1" = 5, "foo2" = "bar"})
      */
     public function allAction()
     {

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_missing_route.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_missing_route.php.inc
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AppController extends Controller
 {
     /**
-     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo" = "foo123", "page" = 1}, host=m.example.com, schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page" = "\d+"}, options={"compiler_class" = "App\Routing\Utf8RouteCompiler", "expose" = "1", "foo1" = 5, "foo2" = "bar"})
+     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo" = "foo123", "page" = 1, "nullableDefault" = null, "booleanDefaultTrue" = true, "booleanDefaultFalse" = false}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page" = "\d+"}, options={"compiler_class" = "App\Routing\Utf8RouteCompiler", "expose" = true, "foo1" = 5, "foo2" = "bar"})
      */
     public function allAction()
     {

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_with_null_as_default.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_with_null_as_default.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\AddRouteAnnotationRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class AppController extends Controller
+{
+    public function nullAction()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\AddRouteAnnotationRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class AppController extends Controller
+{
+    /**
+     * @\Symfony\Component\Routing\Annotation\Route(path="/null/as/default/{nullableDefault}", name="null_as_default", defaults={"nullableDefault" = null}, options={"nullableOption" = null})
+     */
+    public function nullAction()
+    {
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/config/routes.json
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/config/routes.json
@@ -14,7 +14,10 @@
         "defaults": {
             "_controller": "Rector\\Symfony\\Tests\\Rector\\ClassMethod\\AddRouteAnnotationRector\\Fixture\\AppController::allAction",
             "foo": "foo123",
-            "page": 1
+            "page": 1,
+            "nullableDefault": null,
+            "booleanDefaultTrue": true,
+            "booleanDefaultFalse": false
         },
         "requirements": {
             "page": "\\d+"
@@ -68,6 +71,23 @@
         "condition": "",
         "options": {
             "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler"
+        }
+    },
+    "null_as_default": {
+        "name": "null_as_default",
+        "path": "\/null\/as\/default\/{nullableDefault}",
+        "host": "",
+        "schemes": [],
+        "methods": [],
+        "defaults": {
+            "_controller": "Rector\\Symfony\\Tests\\Rector\\ClassMethod\\AddRouteAnnotationRector\\Fixture\\AppController::nullAction",
+            "nullableDefault": null
+        },
+        "requirements": [],
+        "condition": "",
+        "options": {
+            "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler",
+            "nullableOption": null
         }
     }
 }


### PR DESCRIPTION
* Fix issue that a `null` default parameter was a empty string as annotation
* Fix issue that boolean default parameter was a numeric string as annotation
* Fix issue that host was not quoted

https://github.com/rectorphp/rector-symfony/issues/242