### PR TITLE
[RemoveUnusedRequestParamRector] Add rector rule to docs

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 71 Rules Overview
+# 72 Rules Overview
 
 ## ActionSuffixRemoverRector
 
@@ -1230,6 +1230,28 @@ Remove service from Sensio `@Route`
      public function run()
      {
      }
+ }
+```
+
+<br>
+
+## RemoveUnusedRequestParamRector
+
+Remove unused $request parameter from controller action
+
+- class: [`Rector\Symfony\Rector\ClassMethod\RemoveUnusedRequestParamRector`](../src/Rector/ClassMethod/RemoveUnusedRequestParamRector.php)
+
+```diff
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+final class SomeController extends Controller
+{
+-    public function run(Request $request, int $id)
++    public function run(int $id)
+    {
+        echo $id;
+    }
  }
 ```
 

--- a/src/Rector/ClassMethod/RemoveUnusedRequestParamRector.php
+++ b/src/Rector/ClassMethod/RemoveUnusedRequestParamRector.php
@@ -42,6 +42,7 @@ CODE_SAMPLE
 
                 ,
                 <<<'CODE_SAMPLE'
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 final class SomeController extends Controller


### PR DESCRIPTION
@TomasVotruba yesterday I saw we where missing one more rule in the docs. After this it should be complete as the number of rules are same in rector folder and in docs.

I also changed code sample to show the correct output off the rule