### PR TITLE
[MergeMethodAnnotationToRouteAnnotationRector] Adding single method handling

### DIFF
--- a/src/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
+++ b/src/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Symfony\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
@@ -50,6 +51,14 @@ class DefaultController extends Controller
     public function show($id)
     {
     }
+
+    /**
+     * @Route("/post/{id}")
+     * @Method("POST")
+     */
+    public function post($id)
+    {
+    }
 }
 CODE_SAMPLE
                     ,
@@ -62,6 +71,13 @@ class DefaultController extends Controller
      * @Route("/show/{id}", methods={"GET","HEAD"})
      */
     public function show($id)
+    {
+    }
+
+    /**
+     * @Route("/post/{id}", methods={"POST"})
+     */
+    public function post($id)
     {
     }
 }
@@ -110,9 +126,13 @@ CODE_SAMPLE
             return null;
         }
 
+        if (is_string($sensioMethods)) {
+            $sensioMethods = new CurlyListNode([new ArrayItemNode($sensioMethods, null, String_::KIND_DOUBLE_QUOTED)]);
+        }
+
         $symfonyMethodsArrayItemNode = $symfonyDoctrineAnnotationTagValueNode->getValue('methods');
 
-        // value is already filled, do not enter anythign
+        // value is already filled, do not enter anything
         if ($symfonyMethodsArrayItemNode instanceof ArrayItemNode) {
             return null;
         }
@@ -126,11 +146,11 @@ CODE_SAMPLE
     }
 
     /**
-     * @return string[]|null|CurlyListNode
+     * @return string|string[]|null|CurlyListNode
      */
     private function resolveMethods(
         DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode
-    ): array|null|CurlyListNode {
+    ): string|array|null|CurlyListNode {
         $methodsParameter = $doctrineAnnotationTagValueNode->getValue('methods');
         if ($methodsParameter instanceof ArrayItemNode && $methodsParameter->value instanceof CurlyListNode) {
             return $methodsParameter->value;

--- a/src/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
+++ b/src/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
@@ -51,14 +51,6 @@ class DefaultController extends Controller
     public function show($id)
     {
     }
-
-    /**
-     * @Route("/post/{id}")
-     * @Method("POST")
-     */
-    public function post($id)
-    {
-    }
 }
 CODE_SAMPLE
                     ,
@@ -71,13 +63,6 @@ class DefaultController extends Controller
      * @Route("/show/{id}", methods={"GET","HEAD"})
      */
     public function show($id)
-    {
-    }
-
-    /**
-     * @Route("/post/{id}", methods={"POST"})
-     */
-    public function post($id)
     {
     }
 }

--- a/tests/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector/Fixture/fixture.php.inc
@@ -14,6 +14,14 @@ class DefaultController
     public function show($id)
     {
     }
+
+    /**
+     * @Route("/post/{id}")
+     * @Method("POST")
+     */
+    public function post($id)
+    {
+    }
 }
 
 ?>
@@ -31,6 +39,13 @@ class DefaultController
      * @Route("/show/{id}", methods={"GET", "HEAD"})
      */
     public function show($id)
+    {
+    }
+
+    /**
+     * @Route("/post/{id}", methods={"POST"})
+     */
+    public function post($id)
     {
     }
 }

--- a/tests/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector/Fixture/fixture_with_single_method.php.inc
+++ b/tests/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector/Fixture/fixture_with_single_method.php.inc
@@ -5,13 +5,14 @@ namespace Rector\Symfony\Tests\Rector\ClassMethod\MergeMethodAnnotationToRouteAn
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\Routing\Annotation\Route;
 
-class DefaultController
+class SingleMethodController
 {
+
     /**
-     * @Route("/show/{id}")
-     * @Method({"GET", "HEAD"})
+     * @Route("/post/{id}")
+     * @Method("POST")
      */
-    public function show($id)
+    public function post($id)
     {
     }
 }
@@ -25,12 +26,13 @@ namespace Rector\Symfony\Tests\Rector\ClassMethod\MergeMethodAnnotationToRouteAn
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\Routing\Annotation\Route;
 
-class DefaultController
+class SingleMethodController
 {
+
     /**
-     * @Route("/show/{id}", methods={"GET", "HEAD"})
+     * @Route("/post/{id}", methods={"POST"})
      */
-    public function show($id)
+    public function post($id)
     {
     }
 }


### PR DESCRIPTION
While upgrade a legacy project I noticed some `@Method` annotations were left out because the value was a single string.

This update adds support for single methods :)