### PR TITLE
[WebTestCaseAssertResponseCodeRector] Removing check for null value

### DIFF
--- a/src/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
+++ b/src/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
@@ -140,9 +140,6 @@ CODE_SAMPLE
         }
 
         $statusCode = $this->valueResolver->getValue($args[0]->value, true);
-        if ($statusCode === null) {
-            return null;
-        }
 
         // handled by another method
         if ($statusCode === 200) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/7540 after the fixture in https://github.com/rectorphp/rector-symfony/pull/267 has been corrected