### PR TITLE
AddRouteAnnotationRector: add support for multiple controller matching

### DIFF
--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_duplicate.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_duplicate.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\AddRouteAnnotationRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class AppController extends Controller
+{
+    public function duplicateAction()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\AddRouteAnnotationRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class AppController extends Controller
+{
+    /**
+     * @\Symfony\Component\Routing\Annotation\Route(path="/duplicate/{foo}/{page}", name="duplicate_all")
+     * @\Symfony\Component\Routing\Annotation\Route(path="/duplicate/{foo}", name="duplicate_all_short")
+     */
+    public function duplicateAction()
+    {
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/config/routes.json
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/config/routes.json
@@ -89,5 +89,35 @@
             "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler",
             "nullableOption": null
         }
+    },
+    "all_duplicate": {
+        "name": "duplicate_all",
+        "path": "/duplicate/{foo}/{page}",
+        "host": "",
+        "schemes": [],
+        "methods": [],
+        "requirements": [],
+        "condition": "",
+        "options": {
+            "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler"
+        },
+        "defaults": {
+            "_controller": "Rector\\Symfony\\Tests\\Rector\\ClassMethod\\AddRouteAnnotationRector\\Fixture\\AppController::duplicateAction"
+        }
+    },
+    "duplicate_all_short": {
+        "name": "duplicate_all_short",
+        "path": "\/duplicate\/{foo}",
+        "host": "",
+        "schemes": [],
+        "methods": [],
+        "requirements": [],
+        "condition": "",
+        "options": {
+            "compiler_class": "Symfony\\Component\\Routing\\RouteCompiler"
+        },
+        "defaults": {
+            "_controller": "Rector\\Symfony\\Tests\\Rector\\ClassMethod\\AddRouteAnnotationRector\\Fixture\\AppController::duplicateAction"
+        }
     }
 }


### PR DESCRIPTION
I noticed that only the first "controller" match is migrated for "@Route" annotation. 

So given the pattern (eg "optional placeholder"), will be now also migrated with 2 annotations:

```
YYY:
  path: /unit/{foo}.json
  defaults:
    _controller: XXX::yyyAction

XXX:
  path: /unit/{foo}/{date}.json
  defaults:
    _controller: XXX::yyyAction

```