### PR TITLE
WIP: AddRouteAnnotationRector: respect ordering of named arguments on migration

### DIFF
--- a/src/Rector/ClassMethod/AddRouteAnnotationRector.php
+++ b/src/Rector/ClassMethod/AddRouteAnnotationRector.php
@@ -145,6 +145,17 @@ CODE_SAMPLE
             String_::KIND_DOUBLE_QUOTED
         );
 
+        if ($symfonyRouteMetadata->getRequirements() !== []) {
+            $requriementsCurlyList = $this->createCurlyQuoted($symfonyRouteMetadata->getRequirements());
+            $arrayItemNodes[] = new ArrayItemNode($requriementsCurlyList, 'requirements');
+        }
+
+        $optionsWithoutDefaultCompilerClass = $symfonyRouteMetadata->getOptionsWithoutDefaultCompilerClass();
+        if ($optionsWithoutDefaultCompilerClass !== []) {
+            $optionsCurlyQuoted = $this->createCurlyQuoted($optionsWithoutDefaultCompilerClass);
+            $arrayItemNodes[] = new ArrayItemNode($optionsCurlyQuoted, 'options');
+        }
+
         $defaultsWithoutController = $symfonyRouteMetadata->getDefaultsWithoutController();
         if ($defaultsWithoutController !== []) {
             $defaultsWithoutControllerCurlyList = $this->createCurlyQuoted($defaultsWithoutController);
@@ -159,14 +170,14 @@ CODE_SAMPLE
             );
         }
 
-        if ($symfonyRouteMetadata->getSchemes() !== []) {
-            $schemesArrayItemNodes = $this->createCurlyQuoted($symfonyRouteMetadata->getSchemes());
-            $arrayItemNodes[] = new ArrayItemNode($schemesArrayItemNodes, 'schemes');
-        }
-
         if ($symfonyRouteMetadata->getMethods() !== []) {
             $methodsCurlyList = $this->createCurlyQuoted($symfonyRouteMetadata->getMethods());
             $arrayItemNodes[] = new ArrayItemNode($methodsCurlyList, 'methods');
+        }
+
+        if ($symfonyRouteMetadata->getSchemes() !== []) {
+            $schemesArrayItemNodes = $this->createCurlyQuoted($symfonyRouteMetadata->getSchemes());
+            $arrayItemNodes[] = new ArrayItemNode($schemesArrayItemNodes, 'schemes');
         }
 
         if ($symfonyRouteMetadata->getCondition() !== '') {
@@ -175,17 +186,6 @@ CODE_SAMPLE
                 'condition',
                 String_::KIND_DOUBLE_QUOTED
             );
-        }
-
-        if ($symfonyRouteMetadata->getRequirements() !== []) {
-            $requriementsCurlyList = $this->createCurlyQuoted($symfonyRouteMetadata->getRequirements());
-            $arrayItemNodes[] = new ArrayItemNode($requriementsCurlyList, 'requirements');
-        }
-
-        $optionsWithoutDefaultCompilerClass = $symfonyRouteMetadata->getOptionsWithoutDefaultCompilerClass();
-        if ($optionsWithoutDefaultCompilerClass !== []) {
-            $optionsCurlyQuoted = $this->createCurlyQuoted($optionsWithoutDefaultCompilerClass);
-            $arrayItemNodes[] = new ArrayItemNode($optionsCurlyQuoted, 'options');
         }
 
         return $arrayItemNodes;

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture.php.inc
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AppController extends Controller
 {
     /**
-     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo" = "foo123", "page" = 1, "nullableDefault" = null, "booleanDefaultTrue" = true, "booleanDefaultFalse" = false}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page" = "\d+"}, options={"compiler_class" = "App\Routing\Utf8RouteCompiler", "expose" = true, "foo1" = 5, "foo2" = "bar"})
+     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", requirements={"page" = "\d+"}, options={"compiler_class" = "App\Routing\Utf8RouteCompiler", "expose" = true, "foo1" = 5, "foo2" = "bar"}, defaults={"foo" = "foo123", "page" = 1, "nullableDefault" = null, "booleanDefaultTrue" = true, "booleanDefaultFalse" = false}, host="m.example.com", methods={"GET", "POST"}, schemes={"http", "https"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'")
      */
     public function allAction()
     {

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_missing_route.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_missing_route.php.inc
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AppController extends Controller
 {
     /**
-     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", defaults={"foo" = "foo123", "page" = 1, "nullableDefault" = null, "booleanDefaultTrue" = true, "booleanDefaultFalse" = false}, host="m.example.com", schemes={"http", "https"}, methods={"GET", "POST"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'", requirements={"page" = "\d+"}, options={"compiler_class" = "App\Routing\Utf8RouteCompiler", "expose" = true, "foo1" = 5, "foo2" = "bar"})
+     * @\Symfony\Component\Routing\Annotation\Route(path="/all/{foo}/{page}", name="all", requirements={"page" = "\d+"}, options={"compiler_class" = "App\Routing\Utf8RouteCompiler", "expose" = true, "foo1" = 5, "foo2" = "bar"}, defaults={"foo" = "foo123", "page" = 1, "nullableDefault" = null, "booleanDefaultTrue" = true, "booleanDefaultFalse" = false}, host="m.example.com", methods={"GET", "POST"}, schemes={"http", "https"}, condition="context.getMethod() in ['GET', 'HEAD'] and request.headers.get('User-Agent') matches '/firefox/i'")
      */
     public function allAction()
     {

--- a/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_with_null_as_default.php.inc
+++ b/tests/Rector/ClassMethod/AddRouteAnnotationRector/Fixture/fixture_with_null_as_default.php.inc
@@ -22,7 +22,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class AppController extends Controller
 {
     /**
-     * @\Symfony\Component\Routing\Annotation\Route(path="/null/as/default/{nullableDefault}", name="null_as_default", defaults={"nullableDefault" = null}, options={"nullableOption" = null})
+     * @\Symfony\Component\Routing\Annotation\Route(path="/null/as/default/{nullableDefault}", name="null_as_default", options={"nullableOption" = null}, defaults={"nullableDefault" = null})
      */
     public function nullAction()
     {


### PR DESCRIPTION
Route Migration Pfad: `xml/yaml > Annotation -> Attributes`

Currently PhpStorm reports wrong ordering of named arguments, maybe it would be nice to directly generate them ordered.

- [x] Wait for PR: https://github.com/rectorphp/rector-symfony/pull/270