### PR TITLE
Add failing test for GetParameterToConstructorInjectionRector

### DIFF
--- a/tests/Rector/MethodCall/GetParameterToConstructorInjectionRector/Fixture/two_params_with_parent_constructor.php.inc
+++ b/tests/Rector/MethodCall/GetParameterToConstructorInjectionRector/Fixture/two_params_with_parent_constructor.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Tests\Symfony\Rector\MethodCall\GetParameterToConstructorInjectionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller as SymfonyController;
+
+class Service {
+}
+
+abstract class Controller extends SymfonyController {
+    public function __construct(protected Service $service)
+    {
+        // do something else
+    }
+}
+
+class TestController extends Controller
+{
+    public function test()
+    {
+        $foo = $this->getParameter('foo') . $this->getParameter('bar');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Symfony\Rector\MethodCall\GetParameterToConstructorInjectionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller as SymfonyController;
+
+class Service {
+}
+
+abstract class Controller extends SymfonyController {
+    public function __construct(protected Service $service)
+    {
+        // do something else
+    }
+}
+
+class TestController extends Controller
+{
+    public function __construct(\Rector\Tests\Symfony\Rector\MethodCall\GetParameterToConstructorInjectionRector\Fixture\Service $service, private string $foo, private string $bar)
+    {
+        parent::__construct($service);
+    }
+    public function test()
+    {
+        $foo = $this->foo . $this->bar;
+    }
+}
+
+?>


### PR DESCRIPTION
The expected behavior would be that the parent constructor is only called once.