### PR TITLE
[PHPStan] Fix PHPStan notice

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,8 +22,6 @@ parameters:
              message: '#Instead of "instanceof/is_a\(\)" use ReflectionProvider service or "\(new ObjectType\(<desired_type\>\)\)\-\>isSuperTypeOf\(<element_type\>\)" for static reflection to work#'
              path: src/ValueObjectFactory/ServiceMapFactory.php
 
-        - '#Parameter \#1 \$class of method Rector\\BetterPhpDocParser\\PhpDocInfo\\PhpDocInfo<PHPStan\\PhpDocParser\\Ast\\Node\>\:\:(.*?)\(\) expects class\-string, string given#'
-
         # rector co-variant
         - '#Parameter \#1 \$node \(PhpParser\\Node\\(.*?) of method Rector\\(.*?)\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Core\\Contract\\Rector\\PhpRectorInterface\:\:refactor\(\)#'
 

--- a/src/Rector/New_/StringToArrayArgumentProcessRector.php
+++ b/src/Rector/New_/StringToArrayArgumentProcessRector.php
@@ -18,8 +18,8 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use Rector\Core\PhpParser\NodeTransformer;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\Util\Reflection\PrivatesAccessor;
 use Symfony\Component\Console\Input\StringInput;
-use Symplify\PackageBuilder\Reflection\PrivatesCaller;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -149,8 +149,8 @@ CODE_SAMPLE
      */
     private function splitProcessCommandToItems(string $process): array
     {
-        $privatesCaller = new \Rector\Core\Util\Reflection\PrivatesAccessor();
-        return $privatesCaller->callPrivateMethod(new StringInput(''), 'tokenize', [$process]);
+        $privatesAccessor = new PrivatesAccessor();
+        return $privatesAccessor->callPrivateMethod(new StringInput(''), 'tokenize', [$process]);
     }
 
     private function processPreviousAssign(Node $node, Expr $firstArgumentExpr): void


### PR DESCRIPTION
Fix PHPStan notice:

```
composer phpstan
> vendor/bin/phpstan analyse --ansi --error-format symplify

 ! [NOTE] The Xdebug PHP extension is active, but "--xdebug" is not used. This may  
 !        slow down performance and the process will not halt at breakpoints.       

Note: Using configuration file /Users/samsonasik/www/rector-symfony/phpstan.neon.
 394/394 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


                                                                                    
 [WARNING] Ignored error pattern #Parameter \#1 \$class of method                   
           Rector\\BetterPhpDocParser\\PhpDocInfo\\PhpDocInfo<PHPStan\\PhpDocParser\</>
           Ast\\Node>\:\:(.*?)\(\) expects class\-string, string given# was not     
           matched in reported errors.                  
```