### PR TITLE
[SYMFONY62] Replace ParamConverter with MapEntity

### DIFF
--- a/config/sets/symfony/symfony62.php
+++ b/config/sets/symfony/symfony62.php
@@ -8,6 +8,7 @@ use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
+use Rector\Symfony\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector;
 use Rector\Symfony\Rector\MethodCall\SimplifyFormRenderingRector;
 
 return static function (RectorConfig $rectorConfig): void {

--- a/config/sets/symfony/symfony62.php
+++ b/config/sets/symfony/symfony62.php
@@ -87,4 +87,6 @@ return static function (RectorConfig $rectorConfig): void {
             'MAX_USERNAME_LENGTH'
         ),
     ]);
+
+    $rectorConfig->rule(ParamConverterAttributeToMapEntityAttributeRector::class);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 77 Rules Overview
+# 78 Rules Overview
 
 ## ActionSuffixRemoverRector
 
@@ -1072,6 +1072,30 @@ Turns old option names to new ones in FormTypes in Form in Symfony
  $builder = new FormBuilder;
 -$builder->add("...", ["precision" => "...", "virtual" => "..."];
 +$builder->add("...", ["scale" => "...", "inherit_data" => "..."];
+```
+
+<br>
+
+## ParamConverterAttributeToMapEntityAttributeRector
+
+Replace ParamConverter attribute with mappings with the MapEntity attribute
+
+- class: [`Rector\Symfony\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector`](../src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php)
+
+```diff
+ class SomeController
+ {
+     #[Route('/blog/{date}/{slug}/comments/{comment_slug}')]
+-    #[ParamConverter('post', options: ['mapping' => ['date' => 'date', 'slug' => 'slug']])]
+-    #[ParamConverter('comment', options: ['mapping' => ['comment_slug' => 'slug']])]
+     public function showComment(
+-        Post $post,
+-        Comment $comment
++        #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['date' => 'date', 'slug' => 'slug'])] Post $post,
++        #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['comment_slug' => 'slug'])] Comment $comment
+     ) {
+     }
+ }
 ```
 
 <br>

--- a/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
+++ b/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
@@ -35,8 +35,6 @@ final class ParamConverterAttributeToMapEntityAttributeRector extends AbstractRe
 
     private const MAP_ENTITY_CLASS = 'Symfony\Bridge\Doctrine\Attribute\MapEntity';
 
-    private ?Use_ $use = null;
-
     public function __construct(
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
     ) {
@@ -88,15 +86,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [Use_::class, ClassMethod::class];
+        return [ClassMethod::class];
     }
 
     public function refactor(Node $node): ?Node
     {
-        if (($node instanceof Use_) && $this->isName($node, self::PARAM_CONVERTER_CLASS)) {
-            $this->use = $node;
-        }
-
         if (
             ! $node instanceof ClassMethod ||
             ! $node->isPublic() ||
@@ -107,9 +101,6 @@ CODE_SAMPLE
 
         $this->refactorParamConverter($node);
 
-        if ($this->use !== null) {
-            $this->removeNode($this->use);
-        }
         return $node;
     }
 
@@ -160,7 +151,6 @@ CODE_SAMPLE
         }
 
         if (! $probablyEntity) {
-            $this->use = null;
             return;
         }
 

--- a/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
+++ b/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
@@ -35,7 +35,7 @@ final class ParamConverterAttributeToMapEntityAttributeRector extends AbstractRe
 
     private const MAP_ENTITY_CLASS = 'Symfony\Bridge\Doctrine\Attribute\MapEntity';
 
-    private ?Use_ $useNode;
+    private ?Use_ $use = null;
 
     public function __construct(
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
@@ -94,7 +94,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         if (($node instanceof Use_) && $this->isName($node, self::PARAM_CONVERTER_CLASS)) {
-            $this->useNode = $node;
+            $this->use = $node;
         }
 
         if (
@@ -107,8 +107,8 @@ CODE_SAMPLE
 
         $this->refactorParamConverter($node);
 
-        if ($this->useNode) {
-            $this->removeNode($this->useNode);
+        if ($this->use !== null) {
+            $this->removeNode($this->use);
         }
         return $node;
     }
@@ -160,7 +160,7 @@ CODE_SAMPLE
         }
 
         if (! $probablyEntity) {
-            $this->useNode = null;
+            $this->use = null;
             return;
         }
 

--- a/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
+++ b/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Use_;
 use Rector\Core\Configuration\RenamedClassesDataCollector;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -36,7 +37,7 @@ final class ParamConverterAttributeToMapEntityAttributeRector extends AbstractRe
 
     public function __construct(
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
-        private readonly RenamedClassesDataCollector $renamedClassesDataCollector
+        private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
     ) {
     }
 
@@ -86,14 +87,15 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [ClassMethod::class];
+        return [Use_::class, ClassMethod::class];
     }
 
-    /**
-     * @param ClassMethod $node
-     */
     public function refactor(Node $node): ?Node
     {
+        if (($node instanceof Use_) && $this->isName($node, self::PARAM_CONVERTER_CLASS)) {
+            $this->removeNode($node);
+        }
+
         if (
             ! $node instanceof ClassMethod ||
             ! $node->isPublic() ||

--- a/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
+++ b/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Use_;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\Node\AttributeKey;

--- a/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
+++ b/src/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\Configuration\RenamedClassesDataCollector;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Doctrine\NodeAnalyzer\AttributeFinder;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://symfony.com/blog/new-in-symfony-6-2-built-in-cache-security-template-and-doctrine-attributes
+ *
+ * @see \Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\ParamConverterAttributeToMapEntityAttributeRectorTest
+ */
+final class ParamConverterAttributeToMapEntityAttributeRector extends AbstractRector implements MinPhpVersionInterface
+{
+    private const PARAM_CONVERTER_CLASS = 'Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter';
+    private const MAP_ENTITY_CLASS = 'Symfony\Bridge\Doctrine\Attribute\MapEntity';
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
+    }
+
+    public function __construct(
+        private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
+        private readonly AttributeFinder $attributeFinder,
+        private readonly RenamedClassesDataCollector $renamedClassesDataCollector
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace ParamConverter attribute with mappings with the MapEntity attribute',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeController
+{
+    #[Route('/blog/{date}/{slug}/comments/{comment_slug}')]
+    #[ParamConverter('post', options: ['mapping' => ['date' => 'date', 'slug' => 'slug']])]
+    #[ParamConverter('comment', options: ['mapping' => ['comment_slug' => 'slug']])]
+    public function showComment(
+        Post $post,
+        Comment $comment
+    ) {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+class SomeController
+{
+    #[Route('/blog/{date}/{slug}/comments/{comment_slug}')]
+    public function showComment(
+        #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['date' => 'date', 'slug' => 'slug'])] Post $post,
+        #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['comment_slug' => 'slug'])] Comment $comment
+    ) {
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ( ! $this->phpAttributeAnalyzer->hasPhpAttribute($node, self::PARAM_CONVERTER_CLASS)) {
+            return null;
+        }
+
+        if ( ! $node->isPublic()) {
+            return null;
+        }
+
+        return $this->refactorParamConverter($node);
+    }
+
+    private function refactorParamConverter(ClassMethod $classMethod): ?Node
+    {
+        $attribute = $this->attributeFinder->findAttributeByClass($classMethod, self::PARAM_CONVERTER_CLASS);
+        if ( ! $attribute instanceof Node\Attribute) {
+            return null;
+        }
+
+        $this->renamedClassesDataCollector->addOldToNewClasses([
+            self::PARAM_CONVERTER_CLASS => self::MAP_ENTITY_CLASS,
+        ]);
+
+        if ('options' !== $attribute->args[1]->name->name) {
+            return null;
+        }
+
+        $mapping = $attribute->args[1]->value;
+
+        if ( ! $mapping instanceof Node\Expr\Array_) {
+            return null;
+        }
+
+        $name = $attribute->args[0]->value->value;
+        $this->removeNode($attribute->args[0]);
+
+        $attribute->args = [new Arg($mapping->items[0]->value, name: new Identifier($mapping->items[0]->key->value))];
+
+
+        $attributeGroup = $attribute->getAttribute(AttributeKey::PARENT_NODE);
+
+        $this->addMapEntityAttribute($classMethod, $name, $attributeGroup);
+        $this->removeNode($attributeGroup);
+
+        return $classMethod;
+    }
+
+    private function addMapEntityAttribute(ClassMethod $classMethod, string $variableName, AttributeGroup $attributeGroup)
+    {
+        foreach ($classMethod->params as $param) {
+            if ( ! $param->var instanceof Variable) {
+                continue;
+            }
+            if ($variableName === $param->var->name) {
+                $param->attrGroups = [$attributeGroup];
+            }
+        }
+    }
+}

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/multiple_paramconverters.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/multiple_paramconverters.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\Routing\Annotation\Route;
+
+class MultiParamConverter {
+
+    #[Route('/blog/{date}/{slug}/comments/{comment_slug}')]
+    #[ParamConverter('post', options: ['mapping' => ['date' => 'date', 'slug' => 'slug']])]
+    #[ParamConverter('comment', options: ['mapping' => ['comment_slug' => 'slug']])]
+    public function showComment(Post $post, Comment $comment)
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class MultiParamConverter {
+
+    #[Route('/blog/{date}/{slug}/comments/{comment_slug}')]
+    public function showComment(#[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['date' => 'date', 'slug' => 'slug'])] Post $post, #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['comment_slug' => 'slug'])] Comment $comment)
+    {
+    }
+}
+?>

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/multiple_paramconverters.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/multiple_paramconverters.php.inc
@@ -25,7 +25,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class MultiParamConverter {
 
     #[Route('/blog/{date}/{slug}/comments/{comment_slug}')]
-    public function showComment(#[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['date' => 'date', 'slug' => 'slug'])] Post $post, #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['comment_slug' => 'slug'])] Comment $comment)
+    public function showComment(#[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['date' => 'date', 'slug' => 'slug'])]
+    Post $post, #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['comment_slug' => 'slug'])]
+    Comment $comment)
     {
     }
 }

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/multiple_paramconverters.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/multiple_paramconverters.php.inc
@@ -20,6 +20,7 @@ class MultiParamConverter {
 
 namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\Routing\Annotation\Route;
 
 class MultiParamConverter {

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter.php.inc
@@ -26,6 +26,7 @@ class ReplaceParamConverterWithMapping
 
 namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter.php.inc
@@ -35,7 +35,8 @@ class ReplaceParamConverterWithMapping
     #[Route('/blog/{blogSlug}', name: 'blog_detail')]
     public function convert(
         Request $request,
-        #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['blogSlug' => 'slug'])] stdClass $blog
+        #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['blogSlug' => 'slug'])]
+        stdClass $blog,
     ): Response
     {
         return new Response();

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ReplaceParamConverterWithMapping
+{
+    #[Route('/blog/{blogSlug}', name: 'blog_detail')]
+    #[ParamConverter('blog', options: ['mapping' => ['blogSlug' => 'slug']])]
+    public function convert(
+        Request $request,
+        stdClass $blog,
+    ): Response
+    {
+        return new Response();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ReplaceParamConverterWithMapping
+{
+    #[Route('/blog/{blogSlug}', name: 'blog_detail')]
+    public function convert(
+        Request $request,
+        #[\Symfony\Bridge\Doctrine\Attribute\MapEntity(mapping: ['blogSlug' => 'slug'])] stdClass $blog
+    ): Response
+    {
+        return new Response();
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter_more_options.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter_more_options.php.inc
@@ -3,7 +3,6 @@
 namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -23,7 +22,6 @@ class ReplaceParamConverterWithMoreOptions
 
 namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter_more_options.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter_more_options.php.inc
@@ -22,6 +22,7 @@ class ReplaceParamConverterWithMoreOptions
 
 namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter_more_options.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter_more_options.php.inc
@@ -30,7 +30,8 @@ use Symfony\Component\Routing\Annotation\Route;
 class ReplaceParamConverterWithMoreOptions
 {
     #[Route('/blog/{date}/{slug}')]
-    public function show(#[\Symfony\Bridge\Doctrine\Attribute\MapEntity(exclude: ['date'], entity_manager: 'foo')] Post $post, \DateTime $date): Response
+    public function show(#[\Symfony\Bridge\Doctrine\Attribute\MapEntity(exclude: ['date'], entity_manager: 'foo')]
+    Post $post, \DateTime $date): Response
     {
         return new Response();
     }

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter_more_options.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/replace_paramconverter_more_options.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ReplaceParamConverterWithMoreOptions
+{
+    #[Route('/blog/{date}/{slug}')]
+    #[ParamConverter('post', options: ['exclude' => ['date'], 'entity_manager' => 'foo'])]
+    public function show(Post $post, \DateTime $date): Response
+    {
+        return new Response();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ReplaceParamConverterWithMoreOptions
+{
+    #[Route('/blog/{date}/{slug}')]
+    public function show(#[\Symfony\Bridge\Doctrine\Attribute\MapEntity(exclude: ['date'], entity_manager: 'foo')] Post $post, \DateTime $date): Response
+    {
+        return new Response();
+    }
+}
+
+?>

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/skip_datetimeconverter.php.inc
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/Fixture/skip_datetimeconverter.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\Routing\Annotation\Route;
+
+class BlogControllerWithParamConverter
+{
+    #[Route('/blog/archive/{start}/{end}')]
+    #[ParamConverter('start', options: ['format' => '!Y-m-d'])]
+    #[ParamConverter('end', options: ['format' => '!Y-m-d'])]
+    public function archive(\DateTime $start, \DateTime $end)
+    {
+    }
+}

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/ParamConverterAttributeToMapEntityAttributeRectorTest.php
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/ParamConverterAttributeToMapEntityAttributeRectorTest.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector;
 
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 final class ParamConverterAttributeToMapEntityAttributeRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/ParamConverterAttributeToMapEntityAttributeRectorTest.php
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/ParamConverterAttributeToMapEntityAttributeRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ParamConverterAttributeToMapEntityAttributeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/config/configured_rule.php
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/config/configured_rule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Rector\ClassMethod\ActionSuffixRemoverRector;
+use Rector\Symfony\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->rule(ParamConverterAttributeToMapEntityAttributeRector::class);
+};

--- a/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/config/configured_rule.php
+++ b/tests/Rector/ClassMethod/ParamConverterAttributeToMapEntityAttributeRector/config/configured_rule.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Symfony\Rector\ClassMethod\ActionSuffixRemoverRector;
 use Rector\Symfony\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector;
 
 return static function (RectorConfig $rectorConfig): void {


### PR DESCRIPTION
See https://github.com/rectorphp/rector-symfony/issues/264

This is my first time working with Rector and the AST so please add feedback 🙂 

Right now I'm confused why the `use` is not being removed (I thought `RenamedClassesDataCollector` would take care of that) and why the `MapEntity` is placed on a new line instead of prepended to the parameter.

### To do:
- [x] ~Set `MapEntity` on the same line as the class method parameter~ [Rector convention](https://github.com/rectorphp/rector-symfony/pull/291#discussion_r1032600236)
- [x] Remove `use` of `ParamConverter`
- [x] Add fixture with multiple ParamConverters
- [x] Add fixture(s) that should be skipped
- [x] Add fixture with other options (`id`, `exclude`, `strip_null`, `entity_manager` and `evict_cache`)
- [x] Fix CI

### Discussion:
1. Should this also replace `Entity` attributes since that is a shortcut for using `expr`?