### PR TITLE
Remove translator class renaming from Symfony 3.0

### DIFF
--- a/config/sets/symfony/symfony30.php
+++ b/config/sets/symfony/symfony30.php
@@ -193,9 +193,6 @@ return static function (RectorConfig $rectorConfig): void {
         'Symfony\Bridge\Monolog\Logger' => 'Psr\Log\LoggerInterface',
         # security
         'Symfony\Component\Security\Core\Authorization\Voter\AbstractVoter' => 'Symfony\Component\Security\Core\Authorization\Voter\Voter',
-        # translator
-        # partial with class rename
-        'Symfony\Component\Translation\Translator' => 'Symfony\Component\Translation\TranslatorBagInterface',
         # twig
         'Symfony\Bundle\TwigBundle\TwigDefaultEscapingStrategy' => 'Twig_FileExtensionEscapingStrategy',
         # validator


### PR DESCRIPTION
HI @TomasVotruba

According to
https://github.com/symfony/symfony/blob/3.4/UPGRADE-3.0.md#translator
```
The getMessages() method of the Symfony\Component\Translation\Translator class was removed. You should use the getCatalogue() method of the Symfony\Component\Translation\TranslatorBagInterface.
```

But the `Symfony\Component\Translation\Translator` class was not deprecated.
- We should still be able to use it as a param
- We should still be able to use it as a return type
- We should still be able to use it in the phpdoc

Currently some code like
```
    /**
     * @var Translator
     */
    private Translator $translator;

    /**
     * @return Translator
     */
    final protected function getTranslator(): Translator
    {
        return $this->translator;
    }
```
is changed to
```
    /**
     * @var TranslatorBagInterface
     */
    private TranslatorBagInterface $translator;

    /**
     * @return TranslatorBagInterface
     */
    final protected function getTranslator(): TranslatorBagInterface
    {
        return $this->translator;
    }
```
which is definitely wrong because
- Translator is a TranslatorInterface, TranslatorBagInterface is not
- There is a lot more method in Translator than in TranslatorBagInterface

So this rule break the code.