### PR TITLE
Fix issues with ConsoleExecuteReturnIntRector and CommandConstantReturnCodeRector

### DIFF
--- a/src/Rector/ClassMethod/CommandConstantReturnCodeRector.php
+++ b/src/Rector/ClassMethod/CommandConstantReturnCodeRector.php
@@ -50,7 +50,7 @@ class SomeCommand extends Command
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        return Command::SUCCESS;
+        return Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
 }
@@ -118,7 +118,7 @@ CODE_SAMPLE
         }
 
         return $this->nodeFactory->createShortClassConstFetch(
-            'Command',
+            'Symfony\Component\Console\Command\Command',
             SymfonyCommandConstantMap::RETURN_TO_CONST[$lNumber->value]
         );
     }

--- a/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use Rector\Core\NodeAnalyzer\TerminatedNodeAnalyzer;
@@ -229,6 +230,9 @@ CODE_SAMPLE
         }
 
         $staticType = $this->getType($return->expr);
+        if ($staticType instanceof ErrorType) {
+            return;
+        }
         if (! $staticType instanceof IntegerType) {
             $return->expr = new Int_($return->expr);
         }

--- a/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -16,7 +16,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
-use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use Rector\Core\NodeAnalyzer\TerminatedNodeAnalyzer;
@@ -230,9 +229,6 @@ CODE_SAMPLE
         }
 
         $staticType = $this->getType($return->expr);
-        if ($staticType instanceof ErrorType) {
-            return;
-        }
         if (! $staticType instanceof IntegerType) {
             $return->expr = new Int_($return->expr);
         }

--- a/tests/Rector/ClassMethod/CommandConstantReturnCodeRector/Fixture/replace_fail.php.inc
+++ b/tests/Rector/ClassMethod/CommandConstantReturnCodeRector/Fixture/replace_fail.php.inc
@@ -29,7 +29,7 @@ class ReplaceFail extends Command
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        return Command::FAILURE;
+        return Symfony\Component\Console\Command\Command::FAILURE;
     }
 
 }

--- a/tests/Rector/ClassMethod/CommandConstantReturnCodeRector/Fixture/replace_invalid.php.inc
+++ b/tests/Rector/ClassMethod/CommandConstantReturnCodeRector/Fixture/replace_invalid.php.inc
@@ -29,7 +29,7 @@ class ReplaceInvalid extends Command
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        return Command::INVALID;
+        return Symfony\Component\Console\Command\Command::INVALID;
     }
 
 }

--- a/tests/Rector/ClassMethod/CommandConstantReturnCodeRector/Fixture/replace_with_constant.php.inc
+++ b/tests/Rector/ClassMethod/CommandConstantReturnCodeRector/Fixture/replace_with_constant.php.inc
@@ -29,7 +29,7 @@ class ReplaceWithConstant extends Command
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        return Command::SUCCESS;
+        return Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
 }


### PR DESCRIPTION
There is two issues, reported by 
Closes https://github.com/rectorphp/rector-symfony/issues/295
Closes https://github.com/rectorphp/rector-symfony/issues/293

The CommandConstantReturnCodeRector is changing `0` to `Command::Success`, even if `Command` is not imported.
This is breaking the code

Then ConsoleExecuteReturnIntRector is adding `(int)` before `Command::Success` before when resolving with phpstan the constant, an ErrorType is found.

This PR fix both of the issues.