### PR TITLE
Add failing test fixture for `CommandPropertyToAttributeRector`

### DIFF
--- a/tests/Rector/Class_/CommandPropertyToAttributeRector/Fixture/do_stuff_command.php.inc
+++ b/tests/Rector/Class_/CommandPropertyToAttributeRector/Fixture/do_stuff_command.php.inc
@@ -12,11 +12,3 @@ use Symfony\Component\Console\Command\Command;
  }
 ?>
 -----
-<?php
-
-namespace Rector\Tests\Symfony\Rector\Class_\CommandPropertyToAttributeRector\Fixture;
-
-// what is expected code?
-// should remain the same? delete part below ----- (included)
-
-?>

--- a/tests/Rector/Class_/CommandPropertyToAttributeRector/Fixture/do_stuff_command.php.inc
+++ b/tests/Rector/Class_/CommandPropertyToAttributeRector/Fixture/do_stuff_command.php.inc
@@ -1,0 +1,22 @@
+<?php
+namespace App\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+
+ #[AsCommand(
+     name: 'do:stuff',
+     description: 'Do cool stuff',
+ )]
+ final class DoStuffCommand extends Command
+ {
+ }
+?>
+-----
+<?php
+
+namespace Rector\Tests\Symfony\Rector\Class_\CommandPropertyToAttributeRector\Fixture;
+
+// what is expected code?
+// should remain the same? delete part below ----- (included)
+
+?>


### PR DESCRIPTION
# Failing Test for CommandPropertyToAttributeRector

Based on https://getrector.org/demo/144bbc1f-e170-45a9-b72f-d8daa0686db0