### PR TITLE
Add failing test fixture for `CommandPropertyToAttributeRector`

### DIFF
--- a/tests/Rector/Class_/CommandPropertyToAttributeRector/Fixture/skip_command_with_description_set.php.inc
+++ b/tests/Rector/Class_/CommandPropertyToAttributeRector/Fixture/skip_command_with_description_set.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\Class_\CommandPropertyToAttributeRector\Fixture;
+
+#[\Symfony\Component\Console\Attribute\AsCommand('frozen', 'let it go')]
+namespace Rector\Tests\Symfony\Rector\Class_\CommandPropertyToAttributeRector\Fixture;
+
+class Command extends \Symfony\Component\Console\Command\Command
+{
+}
+
+?>


### PR DESCRIPTION
# Failing Test for CommandPropertyToAttributeRector

Based on https://getrector.org/demo/19d05cac-0ca7-423f-9e5e-08483d221bd2

I'm adding descriptions to my commands, but rector keeps removing them - even if there is a [test stating skip if attributes set](https://github.com/JohJohan/rector-symfony/blob/main/tests/Rector/Class_/CommandPropertyToAttributeRector/Fixture/skip_command_with_attributes_set.php.inc). I guess this is just a missing behavior.