### PR TITLE
[Symfony] Skip remove comment deep statement on ConsoleExecuteReturnIntRector

### DIFF
--- a/config/sets/symfony/symfony53.php
+++ b/config/sets/symfony/symfony53.php
@@ -28,7 +28,7 @@ return static function (RectorConfig $rectorConfig): void {
             'getMasterRequest',
             'getMainRequest',
         ),
-        new MethodCallRename('Symfony\Component\Console\Helper\Helper', 'strlen', 'width',),
+        new MethodCallRename('Symfony\Component\Console\Helper\Helper', 'strlen', 'width'),
         new MethodCallRename(
             'Symfony\Component\Console\Helper\Helper',
             'strlenWithoutDecoration',

--- a/config/sets/symfony/symfony6/symfony-return-types.php
+++ b/config/sets/symfony/symfony6/symfony-return-types.php
@@ -63,7 +63,7 @@ return static function (RectorConfig $rectorConfig): void {
     $privatesAccessor = new PrivatesAccessor();
     $privatesAccessor->setPrivateProperty($scalarArrayObjectUnionType, 'types', $scalarArrayObjectUnionedTypes);
     $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
-        new AddReturnTypeDeclaration('Symfony\Component\Config\Loader\LoaderInterface', 'load', new MixedType(),),
+        new AddReturnTypeDeclaration('Symfony\Component\Config\Loader\LoaderInterface', 'load', new MixedType()),
         new AddReturnTypeDeclaration('Symfony\Component\Config\Loader\Loader', 'import', new MixedType()),
         new AddReturnTypeDeclaration(
             'Symfony\Component\HttpKernel\KernelInterface',

--- a/config/sets/symfony/symfony60.php
+++ b/config/sets/symfony/symfony60.php
@@ -36,7 +36,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->ruleWithConfiguration(AddParamTypeDeclarationRector::class, [
-        new AddParamTypeDeclaration('Symfony\Component\Config\Loader\LoaderInterface', 'load', 0, new MixedType(),),
+        new AddParamTypeDeclaration('Symfony\Component\Config\Loader\LoaderInterface', 'load', 0, new MixedType()),
         new AddParamTypeDeclaration(
             'Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait',
             'configureRoutes',

--- a/src/NodeFactory/Annotations/StringValueQuoteWrapper.php
+++ b/src/NodeFactory/Annotations/StringValueQuoteWrapper.php
@@ -24,7 +24,7 @@ final class StringValueQuoteWrapper
         }
 
         if (is_array($value)) {
-            return $this->wrapArray($value, $key,);
+            return $this->wrapArray($value, $key);
         }
 
         return $value;

--- a/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -143,7 +143,7 @@ CODE_SAMPLE
             }
 
             // is there return without nesting?
-            if ($this->nodeComparator->areSameNode($parentNode, $classMethod)) {
+            if ($parentNode instanceof Node && $this->nodeComparator->areSameNode($parentNode, $classMethod)) {
                 $hasReturn = true;
             }
 

--- a/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -143,7 +143,7 @@ CODE_SAMPLE
             }
 
             // is there return without nesting?
-            if ($parentNode instanceof Node && $this->nodeComparator->areSameNode($parentNode, $classMethod)) {
+            if ($parentNode === $classMethod) {
                 $hasReturn = true;
             }
 

--- a/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -143,7 +143,7 @@ CODE_SAMPLE
             }
 
             // is there return without nesting?
-            if ($this->nodeComparator->areNodesEqual($parentNode, $classMethod)) {
+            if ($this->nodeComparator->areSameNode($parentNode, $classMethod)) {
                 $hasReturn = true;
             }
 

--- a/src/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
+++ b/src/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
@@ -210,7 +210,7 @@ CODE_SAMPLE
             $classMethod
         );
 
-        $this->refactorNoReturn($classMethod, $thisRenderMethodCall, $templateDoctrineAnnotationTagValueNode,);
+        $this->refactorNoReturn($classMethod, $thisRenderMethodCall, $templateDoctrineAnnotationTagValueNode);
     }
 
     private function hasLastReturnResponse(ClassMethod $classMethod): bool

--- a/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_remove_comment_deep_if.php.inc
+++ b/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_remove_comment_deep_if.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateLeadListsCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+
+        if (rand(0, 1)) {
+            if (rand(1,2)) {
+                if (rand(3,4)) {
+                    try {
+                        if (rand(5,6)) {
+                            // Only full segment rebuilds count
+							echo 'some statement';
+                        }
+                    } catch (QueryException $e) {
+                        return 1;
+                    }
+                }
+            } else {
+                return 2;
+            }
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Based on https://getrector.org/demo/b6b66790-9939-49ba-ba4a-0f6bd3496e49, the comment should not be removed on deep ifs.

Fixes https://github.com/rectorphp/rector/issues/7668