### PR TITLE
[Symfony26] Fix RedirectToRouteRector with non-default reference type

### DIFF
--- a/src/Rector/MethodCall/RedirectToRouteRector.php
+++ b/src/Rector/MethodCall/RedirectToRouteRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\TypeAnalyzer\ControllerAnalyzer;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -74,7 +75,25 @@ final class RedirectToRouteRector extends AbstractRector
             return null;
         }
 
+        if (! $this->isDefaultReferenceType($argumentValue)) {
+            return null;
+        }
+
         return $this->nodeFactory->createMethodCall('this', 'redirectToRoute', $this->resolveArguments($node));
+    }
+
+    private function isDefaultReferenceType(MethodCall $methodCall): bool
+    {
+        if (! isset($methodCall->args[2])) {
+            return true;
+        }
+
+        $refTypeArg = $methodCall->args[2];
+        if (! $refTypeArg instanceof Arg) {
+            return false;
+        }
+
+        return $this->valueResolver->isValue($refTypeArg->value, UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
     /**

--- a/tests/Rector/MethodCall/RedirectToRouteRector/Fixture/generate_url_with_default.php.inc
+++ b/tests/Rector/MethodCall/RedirectToRouteRector/Fixture/generate_url_with_default.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class GenerateUrlWithDefault extends AbstractController
+{
+    public function someAction()
+    {
+        return $this->redirect(
+            $this->generateUrl('something', [], UrlGeneratorInterface::ABSOLUTE_PATH)
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class GenerateUrlWithDefault extends AbstractController
+{
+    public function someAction()
+    {
+        return $this->redirectToRoute('something', []);
+    }
+}
+
+?>

--- a/tests/Rector/MethodCall/RedirectToRouteRector/Fixture/generate_url_with_relative.php.inc
+++ b/tests/Rector/MethodCall/RedirectToRouteRector/Fixture/generate_url_with_relative.php.inc
@@ -16,20 +16,3 @@ final class GenerateUrlWithRelative extends AbstractController
 }
 
 ?>
------
-<?php
-
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
-
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-
-final class GenerateUrlWithRelative extends AbstractController
-{
-    public function someAction()
-    {
-        return $this->redirectToRoute('something', []);
-    }
-}
-
-?>


### PR DESCRIPTION
When the code passes a non-default `$referenceType` to the `generateUrl()` call the RedirectToRouteRector should not change the type of the resulting URL. That would be a breaking change.

The PR takes into account the default value defined in the user's UrlGeneratorInterface. But that's also the part I'm not so sure about - couldn't find a similar example in the existing code in reasonable time.

First time digging into the code of the tool, so any suggestions to improve are welcome.