### PR TITLE
Add failing test fixture for RemoveUnusedRequestParamRector with abstract parent method

### DIFF
--- a/tests/Rector/ClassMethod/RemoveUnusedRequestParamRector/Fixture/controller.php.inc
+++ b/tests/Rector/ClassMethod/RemoveUnusedRequestParamRector/Fixture/controller.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\RemoveUnusedRequestParamRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+abstract class AbstractController extends Controller
+{
+    abstract public function fooAction(Request $request): Response;
+}
+
+class DemoController extends AbstractController
+{
+    public function fooAction(Request $request): Response
+    {
+        return new Response();
+    }
+
+    public function barAction(Request $request): Response
+    {
+        return new Response();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\RemoveUnusedRequestParamRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+abstract class AbstractController extends Controller
+{
+    abstract public function fooAction(Request $request): Response;
+}
+
+class DemoController extends AbstractController
+{
+    public function fooAction(Request $request): Response
+    {
+        return new Response();
+    }
+
+    public function barAction(): Response
+    {
+        return new Response();
+    }
+}
+
+?>


### PR DESCRIPTION
# Failing Test for RemoveUnusedRequestParamRector

Based on https://getrector.com/demo/381c0067-b8fa-4c7b-8bb1-80f0737a4799

See #366 