### PR TITLE
Performance: Memoize ServiceMap to prevent repeated container parsings

### DIFF
--- a/src/DataProvider/ServiceMapProvider.php
+++ b/src/DataProvider/ServiceMapProvider.php
@@ -16,20 +16,27 @@ final class ServiceMapProvider
 {
     public function __construct(
         private readonly ParameterProvider $parameterProvider,
-        private readonly ServiceMapFactory $serviceMapFactory
+        private readonly ServiceMapFactory $serviceMapFactory,
+        private ?ServiceMap $serviceMap = null
     ) {
     }
 
     public function provide(): ServiceMap
     {
+        if ($this->serviceMap !== null) {
+            return $this->serviceMap;
+        }
+
         $symfonyContainerXmlPath = (string) $this->parameterProvider->provideParameter(
             Option::SYMFONY_CONTAINER_XML_PATH_PARAMETER
         );
 
         if ($symfonyContainerXmlPath === '') {
-            return $this->serviceMapFactory->createEmpty();
+            $this->serviceMap = $this->serviceMapFactory->createEmpty();
+        } else {
+            $this->serviceMap = $this->serviceMapFactory->createFromFileContent($symfonyContainerXmlPath);
         }
 
-        return $this->serviceMapFactory->createFromFileContent($symfonyContainerXmlPath);
+        return $this->serviceMap;
     }
 }


### PR DESCRIPTION
Every time the provider is called and a symfony container path is configured it parsed the container to create the service map. By memoizing the service map and preventing mutiple loads i was able to improve the perfomance in a bigger symfony project by ~50% and the memory footprint by ~30%

Heres the blackfire trace before: https://blackfire.io/profiles/c7c3b1b3-66bc-4a75-821d-c5176c2f2536/graph

And after: https://blackfire.io/profiles/a13b4598-e5fb-4048-921d-79b8862552c3/graph

here you can see the direct comparison: https://blackfire.io/profiles/compare/d43077fb-77e8-4f32-942c-146656ea8c27/graph

![image](https://user-images.githubusercontent.com/15930605/225901827-dfa9770b-a392-44c9-9836-6331ef7abdfe.png)

Relates to https://github.com/rectorphp/rector/issues/7806 and improves the situation described there a lot, but i guess there are more improvements possible.

:rocket: 