### PR TITLE
[WebTestCaseAssertResponseCodeRector] resolve message param fixes #7844

### DIFF
--- a/src/NodeFactory/OnSuccessLogoutClassMethodFactory.php
+++ b/src/NodeFactory/OnSuccessLogoutClassMethodFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Symfony\NodeFactory;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
@@ -61,7 +62,7 @@ final class OnSuccessLogoutClassMethodFactory
                 return null;
             }
 
-            if ($node->expr === null) {
+            if (! $node->expr instanceof Expr) {
                 return null;
             }
 

--- a/src/NodeFactory/ThisRenderFactory.php
+++ b/src/NodeFactory/ThisRenderFactory.php
@@ -61,7 +61,7 @@ final class ThisRenderFactory
         $arguments = [$templateNameString];
 
         $parametersExpr = $this->resolveParametersExpr($return, $templateDoctrineAnnotationTagValueNode);
-        if ($parametersExpr !== null) {
+        if ($parametersExpr instanceof Expr) {
             $arguments[] = new Arg($parametersExpr);
         }
 
@@ -95,7 +95,7 @@ final class ThisRenderFactory
             return $this->createArrayFromArrayItemNodes($vars);
         }
 
-        if ($return === null) {
+        if (! $return instanceof Return_) {
             return null;
         }
 

--- a/src/Rector/ClassMethod/AddRouteAnnotationRector.php
+++ b/src/Rector/ClassMethod/AddRouteAnnotationRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
+use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayParser;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
 use Rector\Core\Rector\AbstractRector;
@@ -73,7 +74,7 @@ final class AddRouteAnnotationRector extends AbstractRector
         // skip if already has an annotation
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $doctrineAnnotationTagValueNode = $phpDocInfo->getByAnnotationClass(SymfonyAnnotation::ROUTE);
-        if ($doctrineAnnotationTagValueNode !== null) {
+        if ($doctrineAnnotationTagValueNode instanceof DoctrineAnnotationTagValueNode) {
             return null;
         }
 

--- a/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -219,7 +219,7 @@ CODE_SAMPLE
 
     private function setReturnTo0InsteadOfNull(Return_ $return): void
     {
-        if ($return->expr === null) {
+        if (! $return->expr instanceof Expr) {
             $return->expr = new LNumber(0);
             return;
         }

--- a/src/Rector/ClassMethod/FormTypeGetParentRector.php
+++ b/src/Rector/ClassMethod/FormTypeGetParentRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Symfony\Rector\ClassMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -106,7 +107,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            if ($node->expr === null) {
+            if (! $node->expr instanceof Expr) {
                 return null;
             }
 

--- a/src/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
+++ b/src/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
@@ -114,7 +115,7 @@ CODE_SAMPLE
 
     private function addAbstractControllerParentClassIfMissing(Class_ $class): ?Class_
     {
-        if ($class->extends !== null) {
+        if ($class->extends instanceof Name) {
             return null;
         }
 
@@ -220,7 +221,7 @@ CODE_SAMPLE
             return false;
         }
 
-        if ($node->expr === null) {
+        if (! $node->expr instanceof Expr) {
             return false;
         }
 
@@ -238,7 +239,7 @@ CODE_SAMPLE
         ClassMethod $classMethod
     ): void {
         // nothing we can do
-        if ($return->expr === null) {
+        if (! $return->expr instanceof Expr) {
             return;
         }
 

--- a/src/Rector/Class_/CommandPropertyToAttributeRector.php
+++ b/src/Rector/Class_/CommandPropertyToAttributeRector.php
@@ -120,17 +120,17 @@ CODE_SAMPLE),
 
         if ($defaultDescription !== null) {
             $attributeGroup->attrs[0]->args[] = new Arg(new String_($defaultDescription));
-        } elseif ($array !== null || $constFetch !== null) {
+        } elseif ($array instanceof Array_ || $constFetch instanceof ConstFetch) {
             $attributeGroup->attrs[0]->args[] = new Arg($this->nodeFactory->createNull());
         }
 
-        if ($array !== null) {
+        if ($array instanceof Array_) {
             $attributeGroup->attrs[0]->args[] = new Arg($array);
-        } elseif ($constFetch !== null) {
+        } elseif ($constFetch instanceof ConstFetch) {
             $attributeGroup->attrs[0]->args[] = new Arg(new Array_());
         }
 
-        if ($constFetch !== null) {
+        if ($constFetch instanceof ConstFetch) {
             $attributeGroup->attrs[0]->args[] = new Arg($constFetch);
         }
 

--- a/src/Rector/Class_/EventListenerToEventSubscriberRector.php
+++ b/src/Rector/Class_/EventListenerToEventSubscriberRector.php
@@ -133,7 +133,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         // anonymous class
-        if ($node->name === null) {
+        if (! $node->name instanceof Identifier) {
             return null;
         }
 

--- a/src/Rector/MethodCall/ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector.php
+++ b/src/Rector/MethodCall/ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\Core\Rector\AbstractRector;
@@ -117,11 +119,11 @@ CODE_SAMPLE
     private function refactorOptionsArray(Array_ $optionsArray): void
     {
         foreach ($optionsArray->items as $arrayItem) {
-            if ($arrayItem === null) {
+            if (! $arrayItem instanceof ArrayItem) {
                 continue;
             }
 
-            if ($arrayItem->key === null) {
+            if (! $arrayItem->key instanceof Expr) {
                 continue;
             }
 

--- a/src/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
+++ b/src/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\Core\Rector\AbstractRector;
@@ -115,10 +117,10 @@ CODE_SAMPLE
     private function processChangeToConstant(Array_ $optionsArray, MethodCall $methodCall): ?Node
     {
         foreach ($optionsArray->items as $optionsArrayItem) {
-            if ($optionsArrayItem === null) {
+            if (! $optionsArrayItem instanceof ArrayItem) {
                 continue;
             }
-            if ($optionsArrayItem->key === null) {
+            if (! $optionsArrayItem->key instanceof Expr) {
                 continue;
             }
             if (! $this->valueResolver->isValues($optionsArrayItem->key, ['type', 'entry_type'])) {

--- a/src/Rector/MethodCall/FormIsValidRector.php
+++ b/src/Rector/MethodCall/FormIsValidRector.php
@@ -95,7 +95,7 @@ CODE_SAMPLE
 
         $previousNode = $methodCall->getAttribute(AttributeKey::PREVIOUS_NODE);
 
-        if ($previousNode !== null) {
+        if ($previousNode instanceof Node) {
             return true;
         }
 

--- a/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
+++ b/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name;
@@ -112,11 +114,11 @@ CODE_SAMPLE
         }
 
         foreach ($optionsArray->items as $arrayItem) {
-            if ($arrayItem === null) {
+            if (! $arrayItem instanceof ArrayItem) {
                 continue;
             }
 
-            if ($arrayItem->key === null) {
+            if (! $arrayItem->key instanceof Expr) {
                 continue;
             }
 

--- a/src/Rector/MethodCall/OptionNameRector.php
+++ b/src/Rector/MethodCall/OptionNameRector.php
@@ -6,6 +6,7 @@ namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\Core\Rector\AbstractRector;
@@ -76,7 +77,7 @@ CODE_SAMPLE
         }
 
         foreach ($optionsArray->items as $arrayItemNode) {
-            if ($arrayItemNode === null) {
+            if (! $arrayItemNode instanceof ArrayItem) {
                 continue;
             }
 

--- a/src/Rector/MethodCall/WebTestCaseAssertIsSuccessfulRector.php
+++ b/src/Rector/MethodCall/WebTestCaseAssertIsSuccessfulRector.php
@@ -6,10 +6,10 @@ namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
+use Rector\Core\NodeAnalyzer\ExprAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Symfony\NodeAnalyzer\SymfonyTestCaseAnalyzer;
@@ -27,6 +27,7 @@ final class WebTestCaseAssertIsSuccessfulRector extends AbstractRector
     public function __construct(
         private readonly SymfonyTestCaseAnalyzer $symfonyTestCaseAnalyzer,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly ExprAnalyzer $exprAnalyzer,
     ) {
     }
 
@@ -99,7 +100,7 @@ CODE_SAMPLE
         $newArgs = [];
         // When we had a custom message argument we want to add it to the new assert.
         if (isset($args[2])) {
-            if ($args[2]->value instanceof FuncCall) {
+            if ($this->exprAnalyzer->isDynamicExpr($args[2]->value)) {
                 $newArgs[] = $args[2]->value;
             } else {
                 $newArgs[] = new Arg(new String_($this->valueResolver->getValue($args[2]->value, true)));

--- a/src/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
+++ b/src/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
@@ -6,10 +6,10 @@ namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Type\ObjectType;
+use Rector\Core\NodeAnalyzer\ExprAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Symfony\NodeAnalyzer\SymfonyTestCaseAnalyzer;
@@ -27,6 +27,7 @@ final class WebTestCaseAssertResponseCodeRector extends AbstractRector
     public function __construct(
         private readonly SymfonyTestCaseAnalyzer $symfonyTestCaseAnalyzer,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly ExprAnalyzer $exprAnalyzer,
     ) {
     }
 
@@ -149,7 +150,7 @@ CODE_SAMPLE
         $newArgs = [$methodCall->args[0]];
         // When we had a custom message argument we want to add it to the new assert.
         if (isset($args[2])) {
-            if ($args[2]->value instanceof FuncCall) {
+            if ($this->exprAnalyzer->isDynamicExpr($args[2]->value)) {
                 $newArgs[] = $args[2]->value;
             } else {
                 $newArgs[] = $this->valueResolver->getValue($args[2]->value, true);
@@ -180,7 +181,7 @@ CODE_SAMPLE
         if (isset($args[2])) {
             // When we had a $message argument we want to add it to the new assert together with $expectedCode null.
             $newArgs[] = null;
-            if ($args[2]->value instanceof FuncCall) {
+            if ($this->exprAnalyzer->isDynamicExpr($args[2]->value)) {
                 $newArgs[] = $args[2]->value;
             } else {
                 $newArgs[] = $this->valueResolver->getValue($args[2]->value, true);

--- a/src/Rector/MethodCall/WebTestCaseAssertSelectorTextContainsRector.php
+++ b/src/Rector/MethodCall/WebTestCaseAssertSelectorTextContainsRector.php
@@ -6,10 +6,10 @@ namespace Rector\Symfony\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
+use Rector\Core\NodeAnalyzer\ExprAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Symfony\NodeAnalyzer\SymfonyTestCaseAnalyzer;
@@ -27,6 +27,7 @@ final class WebTestCaseAssertSelectorTextContainsRector extends AbstractRector
     public function __construct(
         private readonly SymfonyTestCaseAnalyzer $symfonyTestCaseAnalyzer,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly ExprAnalyzer $exprAnalyzer,
     ) {
     }
 
@@ -110,7 +111,7 @@ CODE_SAMPLE
         $newArgs = [$nestedMethodCall->args[0], $args[0]];
         // When we had a custom message argument we want to add it to the new assert.
         if (isset($args[2])) {
-            if ($args[2]->value instanceof FuncCall) {
+            if ($this->exprAnalyzer->isDynamicExpr($args[2]->value)) {
                 $newArgs[] = $args[2]->value;
             } else {
                 $newArgs[] = new Arg(new String_($this->valueResolver->getValue($args[2]->value, true)));

--- a/src/Rector/New_/StringToArrayArgumentProcessRector.php
+++ b/src/Rector/New_/StringToArrayArgumentProcessRector.php
@@ -133,7 +133,7 @@ CODE_SAMPLE
 
         if ($firstArgumentExpr instanceof FuncCall && $this->isName($firstArgumentExpr, 'sprintf')) {
             $arrayNode = $this->nodeTransformer->transformSprintfToArray($firstArgumentExpr);
-            if ($arrayNode !== null) {
+            if ($arrayNode instanceof Array_) {
                 $args[$argumentPosition]->value = $arrayNode;
             }
         } elseif ($firstArgumentExpr instanceof String_) {
@@ -171,7 +171,7 @@ CODE_SAMPLE
         }
 
         $arrayNode = $this->nodeTransformer->transformSprintfToArray($funcCall);
-        if ($arrayNode !== null && count($arrayNode->items) > 1) {
+        if ($arrayNode instanceof Array_ && count($arrayNode->items) > 1) {
             $assign->expr = $arrayNode;
         }
     }

--- a/src/Rector/Return_/SimpleFunctionAndFilterRector.php
+++ b/src/Rector/Return_/SimpleFunctionAndFilterRector.php
@@ -6,6 +6,7 @@ namespace Rector\Symfony\Rector\Return_;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\New_;
@@ -102,7 +103,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if ($node->expr === null) {
+        if (! $node->expr instanceof Expr) {
             return null;
         }
 

--- a/src/TypeAnalyzer/JMSDITypeResolver.php
+++ b/src/TypeAnalyzer/JMSDITypeResolver.php
@@ -82,7 +82,7 @@ final class JMSDITypeResolver
         // 2. service name
         if ($serviceMap->hasService($serviceName)) {
             $serviceType = $serviceMap->getServiceType($serviceName);
-            if ($serviceType !== null) {
+            if ($serviceType instanceof Type) {
                 return $serviceType;
             }
         }

--- a/src/ValueObjectFactory/ServiceMapFactory.php
+++ b/src/ValueObjectFactory/ServiceMapFactory.php
@@ -40,7 +40,7 @@ final class ServiceMapFactory
         foreach ($xml->services->service as $def) {
             /** @var SimpleXMLElement $attrs */
             $attrs = $def->attributes();
-            if (! (property_exists($attrs, 'id') && $attrs->id !== null)) {
+            if (! (property_exists($attrs, 'id') && $attrs->id instanceof SimpleXMLElement)) {
                 continue;
             }
 
@@ -97,10 +97,22 @@ final class ServiceMapFactory
                 (string) $attrs->id,
                 1
             ) : (string) $attrs->id,
-            property_exists($attrs, 'class') && $attrs->class !== null ? (string) $attrs->class : null,
-            ! (property_exists($attrs, 'public') && $attrs->public !== null) || (string) $attrs->public !== 'false',
-            property_exists($attrs, 'synthetic') && $attrs->synthetic !== null && (string) $attrs->synthetic === 'true',
-            property_exists($attrs, 'alias') && $attrs->alias !== null ? (string) $attrs->alias : null,
+            property_exists(
+                $attrs,
+                'class'
+            ) && $attrs->class instanceof SimpleXMLElement ? (string) $attrs->class : null,
+            ! (property_exists(
+                $attrs,
+                'public'
+            ) && $attrs->public instanceof SimpleXMLElement) || (string) $attrs->public !== 'false',
+            property_exists(
+                $attrs,
+                'synthetic'
+            ) && $attrs->synthetic instanceof SimpleXMLElement && (string) $attrs->synthetic === 'true',
+            property_exists(
+                $attrs,
+                'alias'
+            ) && $attrs->alias instanceof SimpleXMLElement ? (string) $attrs->alias : null,
             $tags
         );
     }

--- a/tests/Rector/MethodCall/WebTestCaseAssertResponseCodeRector/Fixture/http_code.php.inc
+++ b/tests/Rector/MethodCall/WebTestCaseAssertResponseCodeRector/Fixture/http_code.php.inc
@@ -16,11 +16,15 @@ final class SomeClass extends WebTestCase
     public function testFound()
     {
         $response = self::getClient()->getResponse();
+        $customMessage = 'Custom message';
+        $customMessageInt = 1;
 
-        $this->assertSame(302, $response->getStatusCode(), 'Custom message');
-        $this->assertSame(HttpCode::FOUND, $response->getStatusCode(), 'Custom message');
+        $this->assertSame(302, $response->getStatusCode(), $customMessage);
+        $this->assertSame(302, $response->getStatusCode(), (string) $customMessageInt);
+        $this->assertSame(HttpCode::FOUND, $response->getStatusCode(), $customMessage);
         $this->assertSame('https://example.com', $response->headers->get('Location'));
-        $this->assertSame('https://example.com', $response->headers->get('Location'), 'Custom message');
+        $this->assertSame('https://example.com', $response->headers->get('Location'), $customMessage);
+        $this->assertSame('https://example.com', $response->headers->get('Location'), (string) $customMessageInt);
     }
 
     /**
@@ -64,11 +68,15 @@ final class SomeClass extends WebTestCase
     public function testFound()
     {
         $response = self::getClient()->getResponse();
+        $customMessage = 'Custom message';
+        $customMessageInt = 1;
 
-        $this->assertResponseStatusCodeSame(302, 'Custom message');
-        $this->assertResponseStatusCodeSame(HttpCode::FOUND, 'Custom message');
+        $this->assertResponseStatusCodeSame(302, $customMessage);
+        $this->assertResponseStatusCodeSame(302, (string) $customMessageInt);
+        $this->assertResponseStatusCodeSame(HttpCode::FOUND, $customMessage);
         $this->assertResponseRedirects('https://example.com');
-        $this->assertResponseRedirects('https://example.com', null, 'Custom message');
+        $this->assertResponseRedirects('https://example.com', null, $customMessage);
+        $this->assertResponseRedirects('https://example.com', null, (string) $customMessageInt);
     }
 
     /**


### PR DESCRIPTION
Resolve argument variable $message correctly for WebTestCaseAssertResponseCodeRector, WebTestCaseAssertIsSuccessfulRector and WebTestCaseAssertSelectorTextContainsRector

Fixes: https://github.com/rectorphp/rector/issues/7844