### PR TITLE
[Symfony 4.3] Add GetCurrencyBundleMethodCallsToIntlRector

### DIFF
--- a/config/sets/symfony/symfony43.php
+++ b/config/sets/symfony/symfony43.php
@@ -10,6 +10,7 @@ use Rector\DependencyInjection\Rector\ClassMethod\AddMethodParentCallRector;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Symfony\Rector\MethodCall\GetCurrencyBundleMethodCallsToIntlRector;
 use Rector\Symfony\Rector\MethodCall\MakeDispatchFirstArgumentEventRector;
 use Rector\Symfony\Rector\MethodCall\WebTestCaseAssertIsSuccessfulRector;
 use Rector\Symfony\Rector\MethodCall\WebTestCaseAssertResponseCodeRector;
@@ -23,6 +24,7 @@ return static function (RectorConfig $rectorConfig): void {
         WebTestCaseAssertResponseCodeRector::class,
         TwigBundleFilesystemLoaderToTwigRector::class,
         MakeDispatchFirstArgumentEventRector::class,
+        GetCurrencyBundleMethodCallsToIntlRector::class,
     ]);
 
     $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 82 Rules Overview
+# 83 Rules Overview
 
 ## ActionSuffixRemoverRector
 
@@ -672,6 +672,21 @@ Move constructor dependency from form type class to an `$options` parameter
          }
      }
  }
+```
+
+<br>
+
+## GetCurrencyBundleMethodCallsToIntlRector
+
+Intl static bundle method were changed to direct static calls
+
+- class: [`Rector\Symfony\Rector\MethodCall\GetCurrencyBundleMethodCallsToIntlRector`](../src/Rector/MethodCall/GetCurrencyBundleMethodCallsToIntlRector.php)
+
+```diff
+-$currencyBundle = \Symfony\Component\Intl\Intl::getCurrencyBundle();
+-
+-$currencyNames = $currencyBundle->getCurrencyNames();
++$currencyNames = \Symfony\Component\Intl\Currencies::getNames();
 ```
 
 <br>

--- a/src/Rector/MethodCall/GetCurrencyBundleMethodCallsToIntlRector.php
+++ b/src/Rector/MethodCall/GetCurrencyBundleMethodCallsToIntlRector.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Symfony\ValueObject\IntlBundleClassToNewClass;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://symfony.com/blog/new-in-symfony-4-3-simpler-access-to-intl-data
+ * @changelog https://github.com/symfony/symfony/pull/28846
+ *
+ * @see \Rector\Symfony\Tests\Rector\MethodCall\GetCurrencyBundleMethodCallsToIntlRector\GetCurrencyBundleMethodCallsToIntlRectorTest
+ */
+final class GetCurrencyBundleMethodCallsToIntlRector extends AbstractRector
+{
+    /**
+     * @var IntlBundleClassToNewClass[]
+     */
+    private array $intlBundleClassesToNewClasses = [];
+
+    public function __construct()
+    {
+        $this->intlBundleClassesToNewClasses[] = new IntlBundleClassToNewClass(
+            'Symfony\Component\Intl\ResourceBundle\LanguageBundleInterface',
+            'Symfony\Component\Intl\Languages',
+            [
+                'getLanguageNames' => 'getNames',
+                'getLanguageName' => 'getName',
+            ]
+        );
+
+        $this->intlBundleClassesToNewClasses[] = new IntlBundleClassToNewClass(
+            'Symfony\Component\Intl\ResourceBundle\RegionBundleInterface',
+            'Symfony\Component\Intl\Currencies',
+            [
+                'getCountryNames' => 'getNames',
+                'getCountryName' => 'getName',
+            ]
+        );
+
+        $this->intlBundleClassesToNewClasses[] = new IntlBundleClassToNewClass(
+            'Symfony\Component\Intl\ResourceBundle\CurrencyBundleInterface',
+            'Symfony\Component\Intl\Currencies',
+            [
+                'getCurrencyNames' => 'getNames',
+                'getCurrencyName' => 'getName',
+                'getCurrencySymbol' => 'getSymbol',
+                'getFractionDigits' => 'getFractionDigits',
+            ]
+        );
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Intl static bundle method were changed to direct static calls', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$currencyBundle = \Symfony\Component\Intl\Intl::getCurrencyBundle();
+
+$currencyNames = $currencyBundle->getCurrencyNames();
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$currencyNames = \Symfony\Component\Intl\Currencies::getNames();
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?StaticCall
+    {
+        foreach ($this->intlBundleClassesToNewClasses as $intlBundleClassToNewClass) {
+            if (! $this->isObjectType($node->var, new ObjectType($intlBundleClassToNewClass->getOldClass()))) {
+                continue;
+            }
+
+            foreach ($intlBundleClassToNewClass->getOldToNewMethods() as $oldMethodName => $newMethodName) {
+                if (! $this->isName($node->name, $oldMethodName)) {
+                    continue;
+                }
+
+                $currenciesFullyQualified = new FullyQualified($intlBundleClassToNewClass->getNewClass());
+                return new StaticCall($currenciesFullyQualified, $newMethodName);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ValueObject/IntlBundleClassToNewClass.php
+++ b/src/ValueObject/IntlBundleClassToNewClass.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\ValueObject;
+
+use Rector\Core\Validation\RectorAssert;
+use Webmozart\Assert\Assert;
+
+final class IntlBundleClassToNewClass
+{
+    /**
+     * @param array<string, string> $oldToNewMethods
+     */
+    public function __construct(
+        private readonly string $oldClass,
+        private readonly string $newClass,
+        private readonly array $oldToNewMethods
+    ) {
+        RectorAssert::className($oldClass);
+        RectorAssert::className($newClass);
+
+        Assert::allString($oldToNewMethods);
+        Assert::allString(array_keys($oldToNewMethods));
+    }
+
+    public function getOldClass(): string
+    {
+        return $this->oldClass;
+    }
+
+    public function getNewClass(): string
+    {
+        return $this->newClass;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getOldToNewMethods(): array
+    {
+        return $this->oldToNewMethods;
+    }
+}

--- a/stubs/Symfony/Component/Intl/Intl.php
+++ b/stubs/Symfony/Component/Intl/Intl.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Intl;
+
+use Symfony\Component\Intl\ResourceBundle\CurrencyBundleInterface;
+
+final class Intl
+{
+    public static function getCurrencyBundle(): CurrencyBundleInterface
+    {
+    }
+}

--- a/stubs/Symfony/Component/Intl/ResourceBundle/CurrencyBundleInterface.php
+++ b/stubs/Symfony/Component/Intl/ResourceBundle/CurrencyBundleInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Intl\ResourceBundle;
+
+interface CurrencyBundleInterface
+{
+}

--- a/tests/Rector/MethodCall/GetCurrencyBundleMethodCallsToIntlRector/Fixture/some_class.php.inc
+++ b/tests/Rector/MethodCall/GetCurrencyBundleMethodCallsToIntlRector/Fixture/some_class.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\MethodCall\GetCurrencyBundleMethodCallsToIntlRector\Fixture;
+
+$currencyBundle = \Symfony\Component\Intl\Intl::getCurrencyBundle();
+
+$currencyNames = $currencyBundle->getCurrencyNames();
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Naming\Rector\MethodCall\GetCurrencyBundleMethodCallsToIntlRector\Fixture;
+
+$currencyBundle = \Symfony\Component\Intl\Intl::getCurrencyBundle();
+
+$currencyNames = \Symfony\Component\Intl\Currencies::getNames();
+
+?>

--- a/tests/Rector/MethodCall/GetCurrencyBundleMethodCallsToIntlRector/GetCurrencyBundleMethodCallsToIntlRectorTest.php
+++ b/tests/Rector/MethodCall/GetCurrencyBundleMethodCallsToIntlRector/GetCurrencyBundleMethodCallsToIntlRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Rector\MethodCall\GetCurrencyBundleMethodCallsToIntlRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class GetCurrencyBundleMethodCallsToIntlRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/Rector/MethodCall/GetCurrencyBundleMethodCallsToIntlRector/config/configured_rule.php
+++ b/tests/Rector/MethodCall/GetCurrencyBundleMethodCallsToIntlRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Rector\MethodCall\GetCurrencyBundleMethodCallsToIntlRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(GetCurrencyBundleMethodCallsToIntlRector::class);
+};


### PR DESCRIPTION
See

* https://symfony.com/blog/new-in-symfony-4-3-simpler-access-to-intl-data
* https://github.com/symfony/symfony/pull/28846