### PR TITLE
Fix ContainerServiceProvider::provideByName 

### DIFF
--- a/src/Bridge/Symfony/ContainerServiceProvider.php
+++ b/src/Bridge/Symfony/ContainerServiceProvider.php
@@ -10,21 +10,32 @@ use Webmozart\Assert\Assert;
 
 final class ContainerServiceProvider
 {
+    protected ?object $container = null;
+
     public function __construct(
         private readonly RectorConfigProvider $rectorConfigProvider
     ) {
     }
 
+    protected function getSymfonyContainer(): object
+    {
+        if ($this->container === null) {
+            $symfonyContainerPhp = $this->rectorConfigProvider->getSymfonyContainerPhp();
+            Assert::fileExists($symfonyContainerPhp);
+
+            $container = require_once $symfonyContainerPhp;
+
+            // this allows older Symfony versions, e.g. 2.8 did not have the PSR yet
+            Assert::isInstanceOf($container, 'Symfony\Component\DependencyInjection\Container');
+            $this->container = $container;
+        }
+
+        return $this->container;
+    }
+
     public function provideByName(string $serviceName): object
     {
-        $symfonyContainerPhp = $this->rectorConfigProvider->getSymfonyContainerPhp();
-        Assert::fileExists($symfonyContainerPhp);
-
-        $container = require_once $symfonyContainerPhp;
-
-        // this allows older Symfony versions, e.g. 2.8 did not have the PSR yet
-        Assert::isInstanceOf($container, 'Symfony\Component\DependencyInjection\Container');
-
+        $container = $this->getSymfonyContainer();
         if (! $container->has($serviceName)) {
             $errorMessage = sprintf('Symfony container has no service "%s", maybe it is private', $serviceName);
             throw new ShouldNotHappenException($errorMessage);


### PR DESCRIPTION
Only first ContainerServiceProvider::provideByName call working as epected. On next calls $container = require_once $symfonyContainerPhp; give us `true` as described in official documentation and we get error trying to call has method on bool variable