### PR TITLE
[DX] Move RedirectToRouteRector into Symfony26 category

### DIFF
--- a/config/sets/symfony/symfony26.php
+++ b/config/sets/symfony/symfony26.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Symfony\Rector\MethodCall\RedirectToRouteRector;
+use Rector\Symfony\Symfony26\Rector\MethodCall\RedirectToRouteRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(RedirectToRouteRector::class);

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/fixture.php.inc
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -16,7 +16,7 @@ class AppController extends Controller
 -----
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/fixture2.php.inc
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/fixture2.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -16,7 +16,7 @@ class AppController2 extends Controller
 -----
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/fixture3.php.inc
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/fixture3.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
@@ -16,7 +16,7 @@ class AppController3 extends Controller
 -----
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/fixture4.php.inc
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/fixture4.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
@@ -16,7 +16,7 @@ class AppController extends AbstractController
 -----
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/generate_url_with_default.php.inc
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/generate_url_with_default.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -19,7 +19,7 @@ final class GenerateUrlWithDefault extends AbstractController
 -----
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/generate_url_with_relative.php.inc
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/generate_url_with_relative.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/skip_other_generator.php.inc
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/Fixture/skip_other_generator.php.inc
@@ -1,7 +1,8 @@
 <?php
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\Fixture;
 
+use Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\Fixture\SomeGenerator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 class SkipController extends AbstractController

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/RedirectToRouteRectorTest.php
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/RedirectToRouteRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector;
+namespace Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/config/configured_rule.php
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/config/configured_rule.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Symfony\Rector\MethodCall\RedirectToRouteRector;
+use Rector\Symfony\Symfony26\Rector\MethodCall\RedirectToRouteRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/config.php');
     $rectorConfig->rule(RedirectToRouteRector::class);
 };

--- a/rules/Symfony26/Rector/MethodCall/RedirectToRouteRector.php
+++ b/rules/Symfony26/Rector/MethodCall/RedirectToRouteRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Symfony\Rector\MethodCall;
+namespace Rector\Symfony\Symfony26\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
@@ -14,7 +14,7 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\Symfony\Tests\Rector\MethodCall\RedirectToRouteRector\RedirectToRouteRectorTest
+ * @see \Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\RedirectToRouteRectorTest
  */
 final class RedirectToRouteRector extends AbstractRector
 {

--- a/rules/Symfony27/Rector/MethodCall/ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector.php
+++ b/rules/Symfony27/Rector/MethodCall/ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector.php
@@ -20,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @changelog https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form
  *
- * @see \Rector\Symfony\Tests\Rector\MethodCall\ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector\ChangeCollectionTypeOptionNameFromTypeToEntryTypeRectorTest
+ * @see \Rector\Symfony\Tests\Symfony27\Rector\MethodCall\ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector\ChangeCollectionTypeOptionNameFromTypeToEntryTypeRectorTest
  */
 final class ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector extends AbstractRector
 {


### PR DESCRIPTION
- fix test path
- Move RedirectToRouteRector into Symfony26 category
