### PR TITLE
Register RemoveServiceFromSensioRouteRector and MagicClosureTwigExtensionToNativeMethodsRector to config set

### DIFF
--- a/config/sets/symfony/symfony34.php
+++ b/config/sets/symfony/symfony34.php
@@ -6,6 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\Removing\Rector\ClassMethod\ArgumentRemoverRector;
 use Rector\Removing\ValueObject\ArgumentRemover;
 use Rector\Symfony\Symfony34\Rector\ClassMethod\MergeMethodAnnotationToRouteAnnotationRector;
+use Rector\Symfony\Symfony34\Rector\ClassMethod\RemoveServiceFromSensioRouteRector;
 use Rector\Symfony\Symfony34\Rector\ClassMethod\ReplaceSensioRouteAnnotationWithSymfonyRector;
 use Rector\Symfony\Symfony34\Rector\Closure\ContainerGetNameToTypeInTestsRector;
 
@@ -21,6 +22,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->rules([
         MergeMethodAnnotationToRouteAnnotationRector::class,
+        RemoveServiceFromSensioRouteRector::class,
         ReplaceSensioRouteAnnotationWithSymfonyRector::class,
         ContainerGetNameToTypeInTestsRector::class,
     ]);

--- a/config/sets/symfony/symfony61.php
+++ b/config/sets/symfony/symfony61.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Symfony\Symfony61\Rector\Class_\CommandPropertyToAttributeRector;
+use Rector\Symfony\Symfony61\Rector\Class_\MagicClosureTwigExtensionToNativeMethodsRector;
 use Rector\Symfony\Symfony61\Rector\StaticPropertyFetch\ErrorNamesPropertyToConstantRector;
 
 # https://github.com/symfony/symfony/blob/6.1/UPGRADE-6.1.md
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rules([CommandPropertyToAttributeRector::class, ErrorNamesPropertyToConstantRector::class]);
+    $rectorConfig->rules([
+        CommandPropertyToAttributeRector::class,
+        ErrorNamesPropertyToConstantRector::class,
+        MagicClosureTwigExtensionToNativeMethodsRector::class,
+    ]);
 
     $rectorConfig->ruleWithConfiguration(
         RenameClassRector::class,


### PR DESCRIPTION
to avoid error:

```

1s
Run bin/rector missing-in-set --ansi

We could not find there rules in configs
========================================

 * vendor/rector/rector-symfony/config/sets/symfony/symfony34.php

 * Rector\Symfony\Symfony34\Rector\ClassMethod\RemoveServiceFromSensioRouteRector


We could not find there rules in configs
========================================

 * vendor/rector/rector-symfony/config/sets/symfony/symfony61.php

 * Rector\Symfony\Symfony61\Rector\Class_\MagicClosureTwigExtensionToNativeMethodsRector
 ```

ref https://github.com/rectorphp/rector-src/actions/runs/5365010566/jobs/9733554418?pr=4337#step:5:11