### PR TITLE
Fix location config in tests

### DIFF
--- a/rules-tests/Symfony30/Rector/Class_/FormTypeWithDependencyToOptionsRector/config/configured_rule.php
+++ b/rules-tests/Symfony30/Rector/Class_/FormTypeWithDependencyToOptionsRector/config/configured_rule.php
@@ -6,7 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\Symfony\Symfony30\Rector\Class_\FormTypeWithDependencyToOptionsRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/config.php');
 
     $rectorConfig->rule(FormTypeWithDependencyToOptionsRector::class);
 };

--- a/rules-tests/Symfony53/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/config/configured_rule.php
+++ b/rules-tests/Symfony53/Rector/MethodCall/SwiftCreateMessageToNewEmailRector/config/configured_rule.php
@@ -6,7 +6,7 @@ use Rector\Config\RectorConfig;
 use Rector\Symfony\Symfony53\Rector\MethodCall\SwiftCreateMessageToNewEmailRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/config.php');
 
     $rectorConfig->rule(SwiftCreateMessageToNewEmailRector::class);
 };

--- a/rules-tests/Twig134/Rector/Return_/SimpleFunctionAndFilterRector/config/configured_rule.php
+++ b/rules-tests/Twig134/Rector/Return_/SimpleFunctionAndFilterRector/config/configured_rule.php
@@ -6,6 +6,6 @@ use Rector\Config\RectorConfig;
 use Rector\Symfony\Twig134\Rector\Return_\SimpleFunctionAndFilterRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/../../../../../config/config.php');
+    $rectorConfig->import(__DIR__ . '/../../../../../../config/config.php');
     $rectorConfig->rule(SimpleFunctionAndFilterRector::class);
 };


### PR DESCRIPTION
To avoid error in rector-src tests

```
There were 9 errors:

1) Rector\Symfony\Tests\Symfony30\Rector\Class_\FormTypeWithDependencyToOptionsRector\FormTypeWithDependencyToOptionsRectorTest::test with data set #0
Symfony\Component\Config\Exception\LoaderLoadException: The file "/home/runner/work/rector-src/rector-src/rules-tests/Symfony30/Rector/Class_/FormTypeWithDependencyToOptionsRector/config/../../../../../config/config.php" does not exist in /home/runner/work/rector-src/rector-src/rules-tests/Symfony30/Rector/Class_/FormTypeWithDependencyToOptionsRector/config/../../../../../config/config.php (which is being imported from "/home/runner/work/rector-src/rector-src/rules-tests/Symfony30/Rector/Class_/FormTypeWithDependencyToOptionsRector/config/configured_rule.php").
```