### PR TITLE
Register MessageSubscriberInterfaceToAttributeRector to symfony 6.2 config set

### DIFF
--- a/config/sets/symfony/symfony62.php
+++ b/config/sets/symfony/symfony62.php
@@ -9,6 +9,7 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 use Rector\Symfony\Symfony62\Rector\Class_\MessageHandlerInterfaceToAttributeRector;
+use Rector\Symfony\Symfony62\Rector\Class_\MessageSubscriberInterfaceToAttributeRector;
 use Rector\Symfony\Symfony62\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector;
 use Rector\Symfony\Symfony62\Rector\MethodCall\SimplifyFormRenderingRector;
 
@@ -93,4 +94,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(ParamConverterAttributeToMapEntityAttributeRector::class);
     // @see https://github.com/symfony/symfony/pull/47068
     $rectorConfig->rule(MessageHandlerInterfaceToAttributeRector::class);
+
+    $rectorConfig->rule(MessageSubscriberInterfaceToAttributeRector::class);
 };


### PR DESCRIPTION
To avoid error:

```

Run bin/rector missing-in-set --ansi

We could not find there rules in configs
========================================

 * vendor/rector/rector-symfony/config/sets/symfony/symfony62.php

 * Rector\Symfony\Symfony62\Rector\Class_\MessageSubscriberInterfaceToAttributeRector
```

in rector-src.