### PR TITLE
Fix SimplifyFormRenderingRector replacing calls other than createView()

### DIFF
--- a/rules-tests/Symfony62/Rector/MethodCall/SimplifyFormRenderingRector/Fixture/do_not_replace_other_function_calls.php.inc
+++ b/rules-tests/Symfony62/Rector/MethodCall/SimplifyFormRenderingRector/Fixture/do_not_replace_other_function_calls.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ReplaceFormCreateViewFunctionCall extends AbstractController
+{
+    #[Route('/form', name: 'form')]
+    public function form(): Response
+    {
+        $form = $this->createFormBuilder()->getForm();
+        return $this->render('form.html.twig', [
+            'form' => $form->createView(),
+            'data' => $form->getData(),
+        ]);
+    }
+}
+
+?>
+-----
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ReplaceFormCreateViewFunctionCall extends AbstractController
+{
+    #[Route('/form', name: 'form')]
+    public function form(): Response
+    {
+        $form = $this->createFormBuilder()->getForm();
+        return $this->render('form.html.twig', [
+            'form' => $form,
+            'data' => $form,
+        ]);
+    }
+}
+
+?>

--- a/rules-tests/Symfony62/Rector/MethodCall/SimplifyFormRenderingRector/Fixture/do_not_replace_other_function_calls.php.inc
+++ b/rules-tests/Symfony62/Rector/MethodCall/SimplifyFormRenderingRector/Fixture/do_not_replace_other_function_calls.php.inc
@@ -33,7 +33,7 @@ class ReplaceFormCreateViewFunctionCall extends AbstractController
         $form = $this->createFormBuilder()->getForm();
         return $this->render('form.html.twig', [
             'form' => $form,
-            'data' => $form,
+            'data' => $form->getData(),
         ]);
     }
 }

--- a/rules/Symfony62/Rector/MethodCall/SimplifyFormRenderingRector.php
+++ b/rules/Symfony62/Rector/MethodCall/SimplifyFormRenderingRector.php
@@ -124,6 +124,9 @@ CODE_SAMPLE
             if (! $arrayItem->value instanceof MethodCall) {
                 continue;
             }
+            if (! $this->isName($arrayItem->value->name, 'createView')) {
+                continue;
+            }
             if (! $this->isObjectType($arrayItem->value->var, new ObjectType('Symfony\Component\Form\FormInterface'))) {
                 continue;
             }


### PR DESCRIPTION
The SimplifyFormRenderingRector was replacing calls to methods other than ->createView(), which is no longer required in Symfony 6.2, e.g. calls to ->getData().

These are not deprecated and there's no reason to remove them, and in fact the blanket rule of removing any method calls of FormInterface parameters of the container $this->render() function is too wide and could lead to breakage.