### PR TITLE
[Symfony30] Handle contains unicode string on RemoveDefaultGetBlockPrefixRector

### DIFF
--- a/rules-tests/Symfony30/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/contains_unicode_name.php.inc
+++ b/rules-tests/Symfony30/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector/Fixture/contains_unicode_name.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony30\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+
+class ÄxType extends AbstractType
+{
+    public function getBlockPrefix()
+    {
+        return 'äx';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony30\Rector\ClassMethod\RemoveDefaultGetBlockPrefixRector\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+
+class ÄxType extends AbstractType
+{
+}
+
+?>

--- a/rules/Symfony30/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
+++ b/rules/Symfony30/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
@@ -116,7 +116,7 @@ CODE_SAMPLE
 
     private function camelToSnake(string $content): string
     {
-        return strtolower(
+        return mb_strtolower(
             Strings::replace($content, '#([a-z])([A-Z])#', '$1_$2')
         );
     }


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-symfony/pull/511#pullrequestreview-1585885491