### PR TITLE
Fix test on symfony-44 test on merge of symfony 4.3 + symfony 4.4 ruleWithConfiguration()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "phpunit/phpunit": "^10.3",
         "rector/phpstan-rules": "^0.6",
         "rector/rector-generator": "^0.7",
-        "rector/rector-src": "dev-main",
+        "rector/rector-src": "dev-failing-fixture",
         "symfony/routing": "^6.2",
         "symfony/security-core": "^6.2",
         "symfony/security-http": "^6.1",

--- a/tests/Set/Symfony44/Fixture/event_fixture.php.inc
+++ b/tests/Set/Symfony44/Fixture/event_fixture.php.inc
@@ -19,7 +19,7 @@ namespace Rector\Symfony\Tests\Set\Symfony44\Fixture;
 
 class SomeEventListener
 {
-    public function someMethod(\Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $exceptionEvent)
+    public function someMethod(\Symfony\Component\HttpKernel\Event\ExceptionEvent $exceptionEvent)
     {
         $exception = $exceptionEvent->getThrowable();
         $exceptionEvent->setThrowable($exception);


### PR DESCRIPTION
@TomasVotruba @lucasmirloup this is based on fix of PR:

- https://github.com/rectorphp/rector-src/pull/4831

temporary use `rector-src:dev-failing-fixture` for it.