### PR TITLE
[Configs] Alias SymfonyRoutesProviderInterface into SymfonyRoutesProvider

### DIFF
--- a/rules-tests/Configs/Rector/ClassMethod/AddRouteAnnotationRector/config/configured_rule.php
+++ b/rules-tests/Configs/Rector/ClassMethod/AddRouteAnnotationRector/config/configured_rule.php
@@ -3,11 +3,16 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Symfony\Contract\Bridge\Symfony\Routing\SymfonyRoutesProviderInterface;
+
+use Rector\Symfony\Bridge\Symfony\Routing\SymfonyRoutesProvider;
 use Rector\Symfony\Configs\Rector\ClassMethod\AddRouteAnnotationRector;
+use Rector\Symfony\Contract\Bridge\Symfony\Routing\SymfonyRoutesProviderInterface;
 use Rector\Symfony\Tests\Configs\Rector\ClassMethod\AddRouteAnnotationRector\Source\DummySymfonyRoutesProvider;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->singleton(SymfonyRoutesProvider::class);
+    $rectorConfig->alias(SymfonyRoutesProvider::class, SymfonyRoutesProviderInterface::class);
+
     $rectorConfig->rule(AddRouteAnnotationRector::class);
 
     // only for tests


### PR DESCRIPTION
@hildebro here should fix https://github.com/rectorphp/rector-symfony/issues/516