### PR TITLE
[Symfony43] Skip not instanceof FilesystemLoader via dynamic new $class on TwigBundleFilesystemLoaderToTwigRector

### DIFF
--- a/rules-tests/Symfony43/Rector/StmtsAwareInterface/TwigBundleFilesystemLoaderToTwigRector/Fixture/skip_not_instanceof_filesystem_loader.php.inc
+++ b/rules-tests/Symfony43/Rector/StmtsAwareInterface/TwigBundleFilesystemLoaderToTwigRector/Fixture/skip_not_instanceof_filesystem_loader.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony43\Rector\StmtsAwareInterface\TwigBundleFilesystemLoaderToTwigRector\Fixture;
+
+final class SkipNotInstanceofFilesystemLoader
+{
+    public function run($class)
+    {
+         $classInstance = new $class();
+    }
+}

--- a/rules/Symfony43/Rector/StmtsAwareInterface/TwigBundleFilesystemLoaderToTwigRector.php
+++ b/rules/Symfony43/Rector/StmtsAwareInterface/TwigBundleFilesystemLoaderToTwigRector.php
@@ -6,6 +6,7 @@ namespace Rector\Symfony\Symfony43\Rector\StmtsAwareInterface;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
@@ -104,6 +105,10 @@ CODE_SAMPLE
 
             $assign = $stmt->expr;
             if (! $assign->expr instanceof New_) {
+                continue;
+            }
+
+            if ($assign->expr->class instanceof Expr) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8189