### PR TITLE
Update Readme for usage of AddRouteAnnotationRector

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,14 @@ Some rules like `AddRouteAnnotationRector` require additional access to your Sym
 ```php
 use Rector\Config\RectorConfig;
 
+use Rector\Symfony\Configs\Rector\ClassMethod\AddRouteAnnotationRector;
+use Rector\Symfony\Contract\Bridge\Symfony\Routing\SymfonyRoutesProviderInterface;
+
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->symfonyContainerPhp(__DIR__ . '/tests/symfony-container.php');
+
+    $rectorConfig->singleton(SymfonyRoutesProvider::class);
+    $rectorConfig->alias(SymfonyRoutesProvider::class, SymfonyRoutesProviderInterface::class);
 };
 ```
 


### PR DESCRIPTION
@hildebro @TomasVotruba per https://github.com/rectorphp/rector-symfony/pull/518#pullrequestreview-1615443164 as `AddRouteAnnotationRector` not part of any `SetList`.

I updated the readme for usage of `AddRouteAnnotationRector` for configure service aliased.