### PR TITLE
Move betterNodeFinder,valueResolver,phpDocInfoFactory dependencies from AbstractRector into rules

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -62,4 +62,6 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::NAMING,
         SymfonySetList::SYMFONY_60,
     ]);
+
+    $rectorConfig->rule(\Rector\Utils\Rector\MoveAbstractRectorToChildrenRector::class);
 };

--- a/rector.php
+++ b/rector.php
@@ -62,6 +62,4 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::NAMING,
         SymfonySetList::SYMFONY_60,
     ]);
-
-    $rectorConfig->rule(\Rector\Utils\Rector\MoveAbstractRectorToChildrenRector::class);
 };

--- a/rules/CodeQuality/Rector/ClassMethod/RemoveUnusedRequestParamRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/RemoveUnusedRequestParamRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\FamilyTree\NodeAnalyzer\ClassChildAnalyzer;
@@ -25,6 +26,7 @@ final class RemoveUnusedRequestParamRector extends AbstractRector
         private readonly ControllerAnalyzer $controllerAnalyzer,
         private readonly ReflectionResolver $reflectionResolver,
         private readonly ClassChildAnalyzer $classChildAnalyzer,
+        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 

--- a/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Doctrine\NodeAnalyzer\AttrinationFinder;
 use Rector\Symfony\Enum\SensioAttribute;
@@ -27,7 +28,8 @@ final class ResponseReturnTypeControllerActionRector extends AbstractRector
 {
     public function __construct(
         private readonly ControllerAnalyzer $controllerAnalyzer,
-        private readonly AttrinationFinder $attrinationFinder
+        private readonly AttrinationFinder $attrinationFinder,
+        private readonly BetterNodeFinder $betterNodeFinder
     ) {
     }
 

--- a/rules/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
@@ -20,9 +20,11 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\Annotation\AnnotationAnalyzer;
 use Rector\Symfony\Enum\SymfonyAnnotation;
@@ -50,6 +52,8 @@ final class TemplateAnnotationToThisRenderRector extends AbstractRector
         private readonly EmptyReturnNodeFinder $emptyReturnNodeFinder,
         private readonly AnnotationAnalyzer $annotationAnalyzer,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAnnotationRector.php
+++ b/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAnnotationRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -33,6 +34,7 @@ final class LoadValidatorMetadataToAnnotationRector extends AbstractRector
         private readonly PropertyAnnotationAssertResolver $propertyAnnotationAssertResolver,
         private readonly ClassAnnotationAssertResolver $classAnnotationAssertResolver,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector.php
+++ b/rules/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Core\Exception\NotImplementedYetException;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Naming\Naming\PropertyNaming;
 use Rector\Symfony\NodeAnalyzer\SymfonyClosureExtensionMatcher;
@@ -40,6 +41,7 @@ final class StringExtensionToConfigBuilderRector extends AbstractRector
         private readonly SymfonyPhpClosureDetector $symfonyPhpClosureDetector,
         private readonly SymfonyClosureExtensionMatcher $symfonyClosureExtensionMatcher,
         private readonly PropertyNaming $propertyNaming,
+        private readonly ValueResolver $valueResolver,
     ) {
     }
 

--- a/rules/Configs/Rector/ClassMethod/AddRouteAnnotationRector.php
+++ b/rules/Configs/Rector/ClassMethod/AddRouteAnnotationRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDoc\StringNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocParser\StaticDoctrineAnnotationParser\ArrayParser;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
 use Rector\Core\Rector\AbstractRector;
@@ -28,7 +29,8 @@ final class AddRouteAnnotationRector extends AbstractRector
     public function __construct(
         private readonly SymfonyRoutesProviderInterface $symfonyRoutesProvider,
         private readonly SymfonyRouteTagValueNodeFactory $symfonyRouteTagValueNodeFactory,
-        private readonly ArrayParser $arrayParser
+        private readonly ArrayParser $arrayParser,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory
     ) {
     }
 

--- a/rules/Configs/Rector/Closure/ServiceArgsToServiceNamedArgRector.php
+++ b/rules/Configs/Rector/Closure/ServiceArgsToServiceNamedArgRector.php
@@ -17,6 +17,7 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\Php\PhpParameterReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\NodeAnalyzer\SymfonyPhpClosureDetector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -29,7 +30,8 @@ final class ServiceArgsToServiceNamedArgRector extends AbstractRector
 {
     public function __construct(
         private readonly SymfonyPhpClosureDetector $symfonyPhpClosureDetector,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 
@@ -184,11 +186,11 @@ CODE_SAMPLE
         string $parameterName,
         Expr $expr,
         ?MethodCall $argMethodCall,
-        MethodCall $node
+        MethodCall $methodCall
     ): MethodCall {
         $argArgs = [new Arg(new String_($parameterName)), new Arg($expr)];
 
-        $callerExpr = $argMethodCall instanceof MethodCall ? $argMethodCall : $node->var;
+        $callerExpr = $argMethodCall instanceof MethodCall ? $argMethodCall : $methodCall->var;
 
         return new MethodCall($callerExpr, 'arg', $argArgs);
     }

--- a/rules/Configs/Rector/Closure/ServiceSettersToSettersAutodiscoveryRector.php
+++ b/rules/Configs/Rector/Closure/ServiceSettersToSettersAutodiscoveryRector.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Stmt\Expression;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\MinimalSharedStringSolver;
 use Rector\Symfony\NodeAnalyzer\SymfonyPhpClosureDetector;
@@ -38,6 +39,7 @@ final class ServiceSettersToSettersAutodiscoveryRector extends AbstractRector
         private readonly SymfonyPhpClosureDetector $symfonyPhpClosureDetector,
         private readonly ReflectionProvider $reflectionProvider,
         private readonly Filesystem $filesystem,
+        private readonly ValueResolver $valueResolver,
     ) {
         $this->minimalSharedStringSolver = new MinimalSharedStringSolver();
     }

--- a/rules/Configs/Rector/Closure/ServiceTagsToDefaultsAutoconfigureRector.php
+++ b/rules/Configs/Rector/Closure/ServiceTagsToDefaultsAutoconfigureRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\NodeAnalyzer\SymfonyPhpClosureDetector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -35,6 +36,7 @@ final class ServiceTagsToDefaultsAutoconfigureRector extends AbstractRector
 
     public function __construct(
         private readonly SymfonyPhpClosureDetector $symfonyPhpClosureDetector,
+        private readonly ValueResolver $valueResolver,
     ) {
     }
 

--- a/rules/Configs/Rector/Closure/ServicesSetNameToSetTypeRector.php
+++ b/rules/Configs/Rector/Closure/ServicesSetNameToSetTypeRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\NodeAnalyzer\SymfonyPhpClosureDetector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -36,7 +37,8 @@ final class ServicesSetNameToSetTypeRector extends AbstractRector
     private array $servicesNamesByType = [];
 
     public function __construct(
-        private readonly SymfonyPhpClosureDetector $symfonyPhpClosureDetector
+        private readonly SymfonyPhpClosureDetector $symfonyPhpClosureDetector,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/Symfony25/Rector/MethodCall/MaxLengthSymfonyFormOptionToAttrRector.php
+++ b/rules/Symfony25/Rector/MethodCall/MaxLengthSymfonyFormOptionToAttrRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -25,6 +26,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MaxLengthSymfonyFormOptionToAttrRector extends AbstractRector
 {
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change form option "max_length" to a form "attr" > "max_length"', [

--- a/rules/Symfony26/Rector/MethodCall/RedirectToRouteRector.php
+++ b/rules/Symfony26/Rector/MethodCall/RedirectToRouteRector.php
@@ -7,6 +7,7 @@ namespace Rector\Symfony\Symfony26\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\TypeAnalyzer\ControllerAnalyzer;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -19,7 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RedirectToRouteRector extends AbstractRector
 {
     public function __construct(
-        private readonly ControllerAnalyzer $controllerAnalyzer
+        private readonly ControllerAnalyzer $controllerAnalyzer,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/Symfony27/Rector/MethodCall/ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector.php
+++ b/rules/Symfony27/Rector/MethodCall/ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\NodeAnalyzer\FormAddMethodCallAnalyzer;
 use Rector\Symfony\NodeAnalyzer\FormCollectionAnalyzer;
@@ -35,7 +36,8 @@ final class ChangeCollectionTypeOptionNameFromTypeToEntryTypeRector extends Abst
     public function __construct(
         private readonly FormAddMethodCallAnalyzer $formAddMethodCallAnalyzer,
         private readonly FormOptionsArrayMatcher $formOptionsArrayMatcher,
-        private readonly FormCollectionAnalyzer $formCollectionAnalyzer
+        private readonly FormCollectionAnalyzer $formCollectionAnalyzer,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/Symfony30/Rector/ClassMethod/GetRequestRector.php
+++ b/rules/Symfony30/Rector/ClassMethod/GetRequestRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\Bridge\NodeAnalyzer\ControllerMethodAnalyzer;
 use Rector\Symfony\TypeAnalyzer\ControllerAnalyzer;
@@ -34,6 +35,7 @@ final class GetRequestRector extends AbstractRector
     public function __construct(
         private readonly ControllerMethodAnalyzer $controllerMethodAnalyzer,
         private readonly ControllerAnalyzer $controllerAnalyzer,
+        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 

--- a/rules/Symfony30/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
+++ b/rules/Symfony30/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -22,6 +23,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveDefaultGetBlockPrefixRector extends AbstractRector
 {
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/Symfony30/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
+++ b/rules/Symfony30/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\FormHelper\FormTypeStringToTypeProvider;
 use Rector\Symfony\NodeAnalyzer\FormAddMethodCallAnalyzer;
@@ -31,7 +32,8 @@ final class ChangeStringCollectionOptionToConstantRector extends AbstractRector
         private readonly FormAddMethodCallAnalyzer $formAddMethodCallAnalyzer,
         private readonly FormOptionsArrayMatcher $formOptionsArrayMatcher,
         private readonly FormTypeStringToTypeProvider $formTypeStringToTypeProvider,
-        private readonly FormCollectionAnalyzer $formCollectionAnalyzer
+        private readonly FormCollectionAnalyzer $formCollectionAnalyzer,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/Symfony30/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
+++ b/rules/Symfony30/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\NodeAnalyzer\FormAddMethodCallAnalyzer;
 use Rector\Symfony\NodeAnalyzer\FormCollectionAnalyzer;
@@ -39,6 +40,7 @@ final class FormTypeInstanceToClassConstRector extends AbstractRector
         private readonly FormOptionsArrayMatcher $formOptionsArrayMatcher,
         private readonly FormCollectionAnalyzer $formCollectionAnalyzer,
         private readonly ControllerAnalyzer $controllerAnalyzer,
+        private readonly ValueResolver $valueResolver,
     ) {
     }
 

--- a/rules/Symfony34/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
+++ b/rules/Symfony34/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\ClassLike;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDoc\StringNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
 use Rector\BetterPhpDocParser\ValueObject\PhpDoc\DoctrineAnnotation\CurlyListNode;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
@@ -29,6 +30,7 @@ final class MergeMethodAnnotationToRouteAnnotationRector extends AbstractRector
     public function __construct(
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/Symfony34/Rector/ClassMethod/RemoveServiceFromSensioRouteRector.php
+++ b/rules/Symfony34/Rector/ClassMethod/RemoveServiceFromSensioRouteRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -21,6 +22,7 @@ final class RemoveServiceFromSensioRouteRector extends AbstractRector
 {
     public function __construct(
         private readonly DocBlockUpdater $docBlockUpdater,
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
 

--- a/rules/Symfony34/Rector/ClassMethod/ReplaceSensioRouteAnnotationWithSymfonyRector.php
+++ b/rules/Symfony34/Rector/ClassMethod/ReplaceSensioRouteAnnotationWithSymfonyRector.php
@@ -39,7 +39,7 @@ final class ReplaceSensioRouteAnnotationWithSymfonyRector extends AbstractRector
         private readonly PhpDocTagRemover $phpDocTagRemover,
         private readonly RenamedClassesDataCollector $renamedClassesDataCollector,
         private readonly DocBlockUpdater $docBlockUpdater,
-        private readonly PhpDocNodeByTypeFinder $findDoctrineAnnotationsByClass,
+        private readonly PhpDocNodeByTypeFinder $phpDocNodeByTypeFinder,
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
     ) {
     }
@@ -105,7 +105,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $sensioDoctrineAnnotationTagValueNodes = $this->findDoctrineAnnotationsByClass->findDoctrineAnnotationsByClass(
+        $sensioDoctrineAnnotationTagValueNodes = $this->phpDocNodeByTypeFinder->findDoctrineAnnotationsByClass(
             $phpDocInfo->getPhpDocNode(),
             self::SENSIO_ROUTE_NAME
         );

--- a/rules/Symfony40/Rector/ConstFetch/ConstraintUrlOptionRector.php
+++ b/rules/Symfony40/Rector/ConstFetch/ConstraintUrlOptionRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\New_;
 use PHPStan\Type\ObjectType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -25,6 +26,11 @@ final class ConstraintUrlOptionRector extends AbstractRector
      * @var string
      */
     private const URL_CONSTRAINT_CLASS = 'Symfony\Component\Validator\Constraints\Url';
+
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/rules/Symfony42/Rector/New_/RootNodeTreeBuilderRector.php
+++ b/rules/Symfony42/Rector/New_/RootNodeTreeBuilderRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -24,6 +25,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RootNodeTreeBuilderRector extends AbstractRector
 {
+    public function __construct(
+        private readonly BetterNodeFinder $betterNodeFinder
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/Symfony43/Rector/ClassMethod/EventDispatcherParentConstructRector.php
+++ b/rules/Symfony43/Rector/ClassMethod/EventDispatcherParentConstructRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\Expression;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use Rector\Core\Enum\ObjectReference;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Rector\Core\ValueObject\MethodName;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -21,6 +22,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class EventDispatcherParentConstructRector extends AbstractScopeAwareRector
 {
+    public function __construct(
+        private readonly BetterNodeFinder $betterNodeFinder
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/Symfony43/Rector/MethodCall/ConvertRenderTemplateShortNotationToBundleSyntaxRector.php
+++ b/rules/Symfony43/Rector/MethodCall/ConvertRenderTemplateShortNotationToBundleSyntaxRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ThisType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -24,6 +25,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ConvertRenderTemplateShortNotationToBundleSyntaxRector extends AbstractRector
 {
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/Symfony43/Rector/MethodCall/MakeDispatchFirstArgumentEventRector.php
+++ b/rules/Symfony43/Rector/MethodCall/MakeDispatchFirstArgumentEventRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Type\ObjectType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\TypeAnalyzer\StringTypeAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -24,7 +25,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class MakeDispatchFirstArgumentEventRector extends AbstractRector
 {
     public function __construct(
-        private readonly StringTypeAnalyzer $stringTypeAnalyzer
+        private readonly StringTypeAnalyzer $stringTypeAnalyzer,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/Symfony43/Rector/MethodCall/WebTestCaseAssertIsSuccessfulRector.php
+++ b/rules/Symfony43/Rector/MethodCall/WebTestCaseAssertIsSuccessfulRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\Core\NodeAnalyzer\ExprAnalyzer;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Symfony\NodeAnalyzer\SymfonyTestCaseAnalyzer;
@@ -28,6 +29,7 @@ final class WebTestCaseAssertIsSuccessfulRector extends AbstractRector
         private readonly SymfonyTestCaseAnalyzer $symfonyTestCaseAnalyzer,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly ExprAnalyzer $exprAnalyzer,
+        private readonly ValueResolver $valueResolver,
     ) {
     }
 

--- a/rules/Symfony43/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
+++ b/rules/Symfony43/Rector/MethodCall/WebTestCaseAssertResponseCodeRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Type\ObjectType;
 use Rector\Core\NodeAnalyzer\ExprAnalyzer;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Symfony\NodeAnalyzer\SymfonyTestCaseAnalyzer;
@@ -28,6 +29,7 @@ final class WebTestCaseAssertResponseCodeRector extends AbstractRector
         private readonly SymfonyTestCaseAnalyzer $symfonyTestCaseAnalyzer,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly ExprAnalyzer $exprAnalyzer,
+        private readonly ValueResolver $valueResolver,
     ) {
     }
 

--- a/rules/Symfony43/Rector/MethodCall/WebTestCaseAssertSelectorTextContainsRector.php
+++ b/rules/Symfony43/Rector/MethodCall/WebTestCaseAssertSelectorTextContainsRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\Core\NodeAnalyzer\ExprAnalyzer;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Symfony\NodeAnalyzer\SymfonyTestCaseAnalyzer;
@@ -28,6 +29,7 @@ final class WebTestCaseAssertSelectorTextContainsRector extends AbstractRector
         private readonly SymfonyTestCaseAnalyzer $symfonyTestCaseAnalyzer,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly ExprAnalyzer $exprAnalyzer,
+        private readonly ValueResolver $valueResolver,
     ) {
     }
 

--- a/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -19,6 +19,7 @@ use PhpParser\NodeTraverser;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use Rector\Core\NodeAnalyzer\TerminatedNodeAnalyzer;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -32,7 +33,8 @@ final class ConsoleExecuteReturnIntRector extends AbstractRector
     private bool $hasChanged = false;
 
     public function __construct(
-        private readonly TerminatedNodeAnalyzer $terminatedNodeAnalyzer
+        private readonly TerminatedNodeAnalyzer $terminatedNodeAnalyzer,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 

--- a/rules/Symfony51/Rector/ClassMethod/CommandConstantReturnCodeRector.php
+++ b/rules/Symfony51/Rector/ClassMethod/CommandConstantReturnCodeRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Reflection\ClassReflection;
+use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Rector\Symfony\ValueObject\ConstantMap\SymfonyCommandConstantMap;
@@ -25,6 +26,7 @@ final class CommandConstantReturnCodeRector extends AbstractRector
 {
     public function __construct(
         private readonly ReflectionResolver $reflectionResolver,
+        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 

--- a/rules/Symfony52/Rector/MethodCall/DefinitionAliasSetPrivateToSetPublicRector.php
+++ b/rules/Symfony52/Rector/MethodCall/DefinitionAliasSetPrivateToSetPublicRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Type\ObjectType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -24,8 +25,9 @@ final class DefinitionAliasSetPrivateToSetPublicRector extends AbstractRector
      */
     private array $definitionObjectTypes = [];
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
         $this->definitionObjectTypes = [
             new ObjectType('Symfony\Component\DependencyInjection\Alias'),
             new ObjectType('Symfony\Component\DependencyInjection\Definition'),

--- a/rules/Symfony52/Rector/MethodCall/ReflectionExtractorEnableMagicCallExtractorRector.php
+++ b/rules/Symfony52/Rector/MethodCall/ReflectionExtractorEnableMagicCallExtractorRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -36,6 +37,11 @@ final class ReflectionExtractorEnableMagicCallExtractorRector extends AbstractRe
      * @var string[]
      */
     private const METHODS_WITH_OPTION = ['getWriteInfo', 'getReadInfo'];
+
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/rules/Symfony52/Rector/MethodCall/ValidatorBuilderEnableAnnotationMappingRector.php
+++ b/rules/Symfony52/Rector/MethodCall/ValidatorBuilderEnableAnnotationMappingRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Type\ObjectType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -18,6 +19,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ValidatorBuilderEnableAnnotationMappingRector extends AbstractRector
 {
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/Symfony52/Rector/New_/PropertyAccessorCreationBooleanToFlagsRector.php
+++ b/rules/Symfony52/Rector/New_/PropertyAccessorCreationBooleanToFlagsRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -20,6 +21,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class PropertyAccessorCreationBooleanToFlagsRector extends AbstractRector
 {
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Changes first argument of PropertyAccessor::__construct() to flags from boolean', [

--- a/rules/Symfony53/Rector/MethodCall/SwiftSetBodyToHtmlPlainMethodCallRector.php
+++ b/rules/Symfony53/Rector/MethodCall/SwiftSetBodyToHtmlPlainMethodCallRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PHPStan\Type\ObjectType;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -20,6 +21,11 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SwiftSetBodyToHtmlPlainMethodCallRector extends AbstractRector
 {
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/Symfony60/Rector/FuncCall/ReplaceServiceArgumentRector.php
+++ b/rules/Symfony60/Rector/FuncCall/ReplaceServiceArgumentRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Symfony\ValueObject\ReplaceServiceArgument;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -24,6 +25,11 @@ final class ReplaceServiceArgumentRector extends AbstractRector implements Confi
      * @var ReplaceServiceArgument[]
      */
     private array $replaceServiceArguments = [];
+
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
 
     public function getRuleDefinition(): RuleDefinition
     {

--- a/rules/Symfony62/Rector/Class_/MessageSubscriberInterfaceToAttributeRector.php
+++ b/rules/Symfony62/Rector/Class_/MessageSubscriberInterfaceToAttributeRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -39,6 +40,7 @@ final class MessageSubscriberInterfaceToAttributeRector extends AbstractRector i
         private readonly MessengerHelper $messengerHelper,
         private readonly ClassManipulator $classManipulator,
         private readonly ClassAnalyzer $classAnalyzer,
+        private readonly ValueResolver $valueResolver,
     ) {
     }
 

--- a/rules/Twig134/Rector/Return_/SimpleFunctionAndFilterRector.php
+++ b/rules/Twig134/Rector/Return_/SimpleFunctionAndFilterRector.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Stmt\Return_;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ReflectionResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -38,7 +39,8 @@ final class SimpleFunctionAndFilterRector extends AbstractRector
     ];
 
     public function __construct(
-        private readonly ReflectionResolver $reflectionResolver
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly ValueResolver $valueResolver
     ) {
     }
 


### PR DESCRIPTION
Ref
 
- https://github.com/rectorphp/rector-src/pull/5051
- https://github.com/rectorphp/rector-src/pull/5052
- https://github.com/rectorphp/rector-src/pull/5053