### PR TITLE
[CodeQuality] Skip getAction() on ActionSuffixRemoverRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ActionSuffixRemoverRector/Fixture/skip_get_action.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ActionSuffixRemoverRector/Fixture/skip_get_action.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ActionSuffixRemoverRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class SkipGetAction extends Controller
+{
+    public function getAction()
+    {
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/ActionSuffixRemoverRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ActionSuffixRemoverRector.php
@@ -68,6 +68,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->name->toString() === 'getAction') {
+            return null;
+        }
+
         $this->removeSuffix($node, 'Action');
 
         return $node;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector-symfony/issues/510