### PR TITLE
Fix AssertSameResponseCodeWithDebugContentsRector to use getContent instead of getContents

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -101,7 +101,7 @@ Make assertSame(200, `$response->getStatusCode())` in tests comparing response c
          $response = $this->processResult();
 
 -        $this->assertSame(200, $response->getStatusCode());
-+        $this->assertSame(200, $response->getStatusCode(), $response->getContents());
++        $this->assertSame(200, $response->getStatusCode(), $response->getContent());
      }
  }
 ```

--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector/Fixture/some_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector/Fixture/some_class.php.inc
@@ -30,7 +30,7 @@ class SomeClass extends TestCase
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = $this->processResult();
 
-        $this->assertSame(200, $response->getStatusCode(), $response->getContents());
+        $this->assertSame(200, $response->getStatusCode(), $response->getContent());
     }
 }
 

--- a/rules/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector.php
@@ -56,7 +56,7 @@ class SomeClass extends TestCase
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = $this->processResult();
 
-        $this->assertSame(200, $response->getStatusCode(), $response->getContents());
+        $this->assertSame(200, $response->getStatusCode(), $response->getContent());
     }
 }
 CODE_SAMPLE
@@ -106,8 +106,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $getContentsMethodCall = new MethodCall($responseExpr, 'getContents');
-        $node->args[2] = new Arg($getContentsMethodCall);
+        $getContentMethodCall = new MethodCall($responseExpr, 'getContent');
+        $node->args[2] = new Arg($getContentMethodCall);
 
         return $node;
     }


### PR DESCRIPTION

Not sure how this was even tested but the `getContents` method does not exist on the [Symfony HttpFoundation Response](https://github.com/symfony/symfony/blob/b2282614e5316e55a096124f8e82b742eccfb79d/src/Symfony/Component/HttpFoundation/Response.php#L459):

PHPStan erros with:

> Call to an undefined method Symfony\Component\HttpFoundation\Response::getContents().


Technically the rule should be also renamed from `AssertSameResponseCodeWithDebugContentsRector` -> `AssertSameResponseCodeWithDebugContentRector` but that would be a bc break.
