### PR TITLE
[Symfony 62] Ensure change Annotation to Attribute first before rename Annotation on IsGranted, Cache, Template

### DIFF
--- a/config/sets/symfony/symfony62.php
+++ b/config/sets/symfony/symfony62.php
@@ -13,9 +13,23 @@ use Rector\Symfony\Symfony62\Rector\Class_\MessageSubscriberInterfaceToAttribute
 use Rector\Symfony\Symfony62\Rector\ClassMethod\ClassMethod\ArgumentValueResolverToValueResolverRector;
 use Rector\Symfony\Symfony62\Rector\ClassMethod\ParamConverterAttributeToMapEntityAttributeRector;
 use Rector\Symfony\Symfony62\Rector\MethodCall\SimplifyFormRenderingRector;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(SimplifyFormRenderingRector::class);
+
+    // change to attribute before rename
+    // https://symfony.com/blog/new-in-symfony-6-2-built-in-cache-security-template-and-doctrine-attributes
+    // @see https://github.com/rectorphp/rector-symfony/issues/535#issuecomment-1783983383
+    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+        // @see https://github.com/symfony/symfony/pull/46907
+        new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted'),
+        // @see https://github.com/symfony/symfony/pull/46880
+        new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\Cache'),
+        // @see https://github.com/symfony/symfony/pull/46906
+        new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\Template'),
+    ]);
 
     // https://symfony.com/blog/new-in-symfony-6-2-built-in-cache-security-template-and-doctrine-attributes
     $rectorConfig->ruleWithConfiguration(

--- a/rules/Twig134/Rector/Return_/SimpleFunctionAndFilterRector.php
+++ b/rules/Twig134/Rector/Return_/SimpleFunctionAndFilterRector.php
@@ -199,7 +199,7 @@ CODE_SAMPLE
 
         if ($oldArguments[0]->value instanceof Array_) {
             // already array, just shift it
-            $new->args = array_merge([new Arg(new String_($filterName))], $oldArguments);
+            $new->args = [new Arg(new String_($filterName)), ...$oldArguments];
             return;
         }
 

--- a/src/NodeFactory/OnLogoutClassMethodFactory.php
+++ b/src/NodeFactory/OnLogoutClassMethodFactory.php
@@ -37,7 +37,7 @@ final class OnLogoutClassMethodFactory
         $classMethod = $this->bareLogoutClassMethodFactory->create();
 
         $assignStmts = $this->createAssignStmtFromOldClassMethod($logoutClassMethod);
-        $classMethod->stmts = array_merge($assignStmts, (array) $logoutClassMethod->stmts);
+        $classMethod->stmts = [...$assignStmts, ...(array) $logoutClassMethod->stmts];
 
         return $classMethod;
     }

--- a/src/NodeFactory/OnSuccessLogoutClassMethodFactory.php
+++ b/src/NodeFactory/OnSuccessLogoutClassMethodFactory.php
@@ -49,7 +49,7 @@ final class OnSuccessLogoutClassMethodFactory
         $this->replaceRequestWithGetRequest($onLogoutSuccessClassMethod);
 
         $oldClassStmts = (array) $onLogoutSuccessClassMethod->stmts;
-        $classMethod->stmts = array_merge([$if], $oldClassStmts);
+        $classMethod->stmts = [$if, ...$oldClassStmts];
 
         return $classMethod;
     }


### PR DESCRIPTION
@jambonfarci @stefantalen @TomasVotruba here ensure change annotation to attribute before rename,

see https://getrector.com/demo/894cda53-f2a9-4216-b64a-7ba2247b0a73
Ref https://github.com/rectorphp/rector-symfony/issues/535#issuecomment-1783983383

For auto import, it require PR on rector-src on auto import enabled usage:

- https://github.com/rectorphp/rector-src/pull/5213