### PR TITLE
add test cases for symfony forms in symfony 5.0 and 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "rector/rector-src": "dev-main",
         "symfony/config": "^6.3",
         "symfony/dependency-injection": "^6.3",
+        "symfony/form": "^6.3",
         "symfony/routing": "^6.2",
         "symfony/security-core": "^6.2",
         "symfony/security-http": "^6.1",

--- a/tests/Set/Symfony50/Fixture/form_map_data_to_forms.php.inc
+++ b/tests/Set/Symfony50/Fixture/form_map_data_to_forms.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
+
+class FormTest extends AbstractType implements DataMapperInterface
+{
+
+    public function mapDataToForms(mixed $viewData, $forms)
+    {
+
+    }
+
+    public function mapFormsToData($forms, mixed &$viewData)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
+
+class FormTest extends AbstractType implements DataMapperInterface
+{
+
+    public function mapDataToForms(mixed $viewData, iterable $forms)
+    {
+
+    }
+
+    public function mapFormsToData(iterable $forms, mixed &$viewData)
+    {
+
+    }
+}
+
+?>

--- a/tests/Set/Symfony53/Fixture/form_map_data_to_forms.php.inc
+++ b/tests/Set/Symfony53/Fixture/form_map_data_to_forms.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
+
+class FormTest extends AbstractType implements DataMapperInterface
+{
+
+    public function mapDataToForms(mixed $viewData, iterable $forms)
+    {
+
+    }
+
+    public function mapFormsToData(iterable $forms, mixed &$viewData)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
+
+class FormTest extends AbstractType implements DataMapperInterface
+{
+
+    public function mapDataToForms(mixed $viewData, \Traversable $forms)
+    {
+
+    }
+
+    public function mapFormsToData(\Traversable $forms, mixed &$viewData)
+    {
+
+    }
+}
+
+?>

--- a/tests/Set/Symfony53/Symfony53Test.php
+++ b/tests/Set/Symfony53/Symfony53Test.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Set\Symfony53;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Symfony53Test extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/symfony53_attributes.php';
+    }
+}

--- a/tests/Set/Symfony53/config/symfony53_attributes.php
+++ b/tests/Set/Symfony53/config/symfony53_attributes.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([SymfonySetList::SYMFONY_53]);
+};

--- a/tests/Set/UpToSymfony53/Fixture/form_map_data_to_forms.php.inc
+++ b/tests/Set/UpToSymfony53/Fixture/form_map_data_to_forms.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
+
+class FormTest extends AbstractType implements DataMapperInterface
+{
+
+    public function mapDataToForms(mixed $viewData, iterable $forms)
+    {
+
+    }
+
+    public function mapFormsToData(iterable $forms, mixed &$viewData)
+    {
+
+    }
+}
+
+?>
+-----
+<?php
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
+
+class FormTest extends AbstractType implements DataMapperInterface
+{
+
+    public function mapDataToForms(mixed $viewData, \Traversable $forms)
+    {
+
+    }
+
+    public function mapFormsToData(\Traversable $forms, mixed &$viewData)
+    {
+
+    }
+}
+
+?>

--- a/tests/Set/UpToSymfony53/UpToSymfony53Test.php
+++ b/tests/Set/UpToSymfony53/UpToSymfony53Test.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Set\UpToSymfony53;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class UpToSymfony53Test extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/up_to_symfony53_attributes.php';
+    }
+}

--- a/tests/Set/UpToSymfony53/config/up_to_symfony53_attributes.php
+++ b/tests/Set/UpToSymfony53/config/up_to_symfony53_attributes.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonyLevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([SymfonyLevelSetList::UP_TO_SYMFONY_53]);
+};


### PR DESCRIPTION
See issue mentioned in https://github.com/rectorphp/rector-symfony/pull/545#issuecomment-1787500851

The test in ``tests/Set/UpToSymfony53/UpToSymfony53Test.php`` is failing, but it should pass.