### PR TITLE
Separating Swiftmailer to Symfony Mailer from Symfony 5.3 set

### DIFF
--- a/config/sets/swiftmailer/swiftmailer-to-symfony-mailer.php
+++ b/config/sets/swiftmailer/swiftmailer-to-symfony-mailer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Symfony\Symfony53\Rector\MethodCall\SwiftCreateMessageToNewEmailRector;
+use Rector\Symfony\Symfony53\Rector\MethodCall\SwiftSetBodyToHtmlPlainMethodCallRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    // @see https://symfony.com/blog/the-end-of-swiftmailer
+    $rectorConfig->rules([
+        SwiftCreateMessageToNewEmailRector::class,
+        SwiftSetBodyToHtmlPlainMethodCallRector::class,
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Swift_Mailer' => 'Symfony\Component\Mailer\MailerInterface',
+        'Swift_Message' => 'Symfony\Component\Mime\Email',
+        // message
+        'Swift_Mime_SimpleMessage' => 'Symfony\Component\Mime\RawMessage',
+        // transport
+        'Swift_SmtpTransport' => 'Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport',
+        'Swift_FailoverTransport' => 'Symfony\Component\Mailer\Transport\FailoverTransport',
+        'Swift_SendmailTransport' => 'Symfony\Component\Mailer\Transport\SendmailTransport',
+    ]);
+};

--- a/config/sets/symfony/symfony53.php
+++ b/config/sets/symfony/symfony53.php
@@ -12,8 +12,6 @@ use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\RenameClassConstFetch;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\Symfony\Symfony53\Rector\Class_\CommandDescriptionToPropertyRector;
-use Rector\Symfony\Symfony53\Rector\MethodCall\SwiftCreateMessageToNewEmailRector;
-use Rector\Symfony\Symfony53\Rector\MethodCall\SwiftSetBodyToHtmlPlainMethodCallRector;
 use Rector\Symfony\Symfony53\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
@@ -115,19 +113,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         KernelTestCaseContainerPropertyDeprecationRector::class,
         CommandDescriptionToPropertyRector::class,
-        // @see https://symfony.com/blog/the-end-of-swiftmailer
-        SwiftCreateMessageToNewEmailRector::class,
-        SwiftSetBodyToHtmlPlainMethodCallRector::class,
-    ]);
-
-    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
-        'Swift_Mailer' => 'Symfony\Component\Mailer\MailerInterface',
-        'Swift_Message' => 'Symfony\Component\Mime\Email',
-        // message
-        'Swift_Mime_SimpleMessage' => 'Symfony\Component\Mime\RawMessage',
-        // transport
-        'Swift_SmtpTransport' => 'Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport',
-        'Swift_FailoverTransport' => 'Symfony\Component\Mailer\Transport\FailoverTransport',
-        'Swift_SendmailTransport' => 'Symfony\Component\Mailer\Transport\SendmailTransport',
     ]);
 };

--- a/src/Set/SwiftmailerSetList.php
+++ b/src/Set/SwiftmailerSetList.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Set;
+
+use Rector\Set\Contract\SetListInterface;
+
+/**
+ * @api
+ */
+final class SwiftmailerSetList implements SetListInterface
+{
+    /**
+     * @var string
+     */
+    final public const ANNOTATIONS_TO_ATTRIBUTES = __DIR__ . '/../../config/sets/swiftmailer/swiftmailer-to-symfony-mailer.php';
+}


### PR DESCRIPTION
I came across these rules while working on a project.

Since these rules are incomplete for their purpose (as mentioned in #401) , I feel like they should not come with a Symfony set.