### PR TITLE
[CodeQuality] Skip not from Symfony Response object on AssertSameResponseCodeWithDebugContentsRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector/Fixture/skip_not_response_object.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector/Fixture/skip_not_response_object.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\MethodCall\AssertSameResponseCodeWithDebugContentsRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SkipNotResponseObjectTest extends TestCase
+{
+    public function test(object $obj)
+    {
+        $this->assertSame(200, $obj->getStatusCode());
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -125,7 +126,7 @@ CODE_SAMPLE
         }
 
         $varType = $this->nodeTypeResolver->getType($expr->var);
-        if (! $varType instanceof \PHPStan\Type\ObjectType) {
+        if (! $varType instanceof ObjectType) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/AssertSameResponseCodeWithDebugContentsRector.php
@@ -124,6 +124,15 @@ CODE_SAMPLE
             return null;
         }
 
+        $varType = $this->nodeTypeResolver->getType($expr->var);
+        if (! $varType instanceof \PHPStan\Type\ObjectType) {
+            return null;
+        }
+
+        if (! $varType->isInstanceof('Symfony\Component\HttpFoundation\Response')->yes()) {
+            return null;
+        }
+
         // must be status method call
         if (! $this->isName($expr->name, 'getStatusCode')) {
             return null;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8304