### PR TITLE
chore(symfony-routing): replace Symfony route annotation by attribute one

### DIFF
--- a/config/sets/symfony/symfony64.php
+++ b/config/sets/symfony/symfony64.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Symfony\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector;
 
 // @see https://github.com/symfony/symfony/blob/6.4/UPGRADE-6.4.md
 return static function (RectorConfig $rectorConfig): void {
@@ -14,4 +15,5 @@ return static function (RectorConfig $rectorConfig): void {
             'Symfony\Component\HttpKernel\Debug\FileLinkFormatter' => 'Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter',
         ],
     );
+    $rectorConfig->rule(ChangeRouteAttributeFromAnnotationSubnamespaceRector::class);
 };

--- a/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/ChangeRouteAttributeFromAnnotationSubnamespaceRectorTest.php
+++ b/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/ChangeRouteAttributeFromAnnotationSubnamespaceRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeRouteAttributeFromAnnotationSubnamespaceRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/Fixture/use-annotation-should-skip.php.inc
+++ b/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/Fixture/use-annotation-should-skip.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector\Fixture;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+USE Symfony\Component\Routing\Annotation\Route;
+
+class RectorController
+{
+    /**
+     * @Route("/")
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector\Fixture;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+USE Symfony\Component\Routing\Annotation\Route;
+
+class RectorController
+{
+    /**
+     * @Route("/")
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse();
+    }
+}
+
+?>

--- a/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/Fixture/use-annotation-should-skip.php.inc
+++ b/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/Fixture/use-annotation-should-skip.php.inc
@@ -16,26 +16,3 @@ class RectorController
         return new JsonResponse();
     }
 }
-
-?>
------
-<?php
-
-namespace Rector\Symfony\Tests\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector\Fixture;
-
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
-USE Symfony\Component\Routing\Annotation\Route;
-
-class RectorController
-{
-    /**
-     * @Route("/")
-     */
-    public function __invoke(Request $request): JsonResponse
-    {
-        return new JsonResponse();
-    }
-}
-
-?>

--- a/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/Fixture/use-attribute-with-annotation-import-on-class.php.inc
+++ b/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/Fixture/use-attribute-with-annotation-import-on-class.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector\Fixture;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+#[\Symfony\Component\Routing\Annotation\Route('/blog', name: 'blog_list')]
+class RectorController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector\Fixture;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+#[\Symfony\Component\Routing\Attribute\Route('/blog', name: 'blog_list')]
+class RectorController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse();
+    }
+}
+
+?>

--- a/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/Fixture/use-attribute-with-annotation-import.php.inc
+++ b/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/Fixture/use-attribute-with-annotation-import.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector\Fixture;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class RectorController
+{
+    #[\Symfony\Component\Routing\Annotation\Route('/blog', name: 'blog_list')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector\Fixture;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class RectorController
+{
+    #[\Symfony\Component\Routing\Attribute\Route('/blog', name: 'blog_list')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse();
+    }
+}
+
+?>

--- a/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/config/configured_rule.php
+++ b/rules-tests/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ChangeRouteAttributeFromAnnotationSubnamespaceRector::class);
+};

--- a/rules/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector.php
+++ b/rules/Symfony64/Rector/Class_/ChangeRouteAttributeFromAnnotationSubnamespaceRector.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Symfony64\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Symfony\Tests\Symfony64\Rector\Class_\ChangeRouteAttributeFromAnnotationSubnamespaceRector
+ */
+final class ChangeRouteAttributeFromAnnotationSubnamespaceRector extends AbstractRector
+{
+    private const ANNOTATION_ROUTE = 'Symfony\Component\Routing\Annotation\Route';
+    private const ATTRIBUTE_ROUTE = 'Symfony\Component\Routing\Attribute\Route';
+
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace Symfony\Component\Routing\Annotation\Route by Symfony\Component\Routing\Attribute\Route when the class use #Route[] attribute',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+    /**
+     * #[\Symfony\Component\Routing\Annotation\Route("/foo")]
+    */
+    public function create(Request $request): Response
+    {
+        return new Response();
+    }
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+    #[\Symfony\Component\Routing\Attribute\Route('/foo')]
+    public function create(Request $request): Response
+    {
+        return new Response();
+    }
+CODE_SAMPLE
+                ),
+
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Class_::class];
+    }
+
+    /**
+     * @param ClassMethod|Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        foreach ($node->attrGroups as $attributeGroup) {
+            foreach ($attributeGroup->attrs as $attribute) {
+                if ($this->isSymfonyRouteAttribute($attribute)) {
+                    $attribute->name = new Node\Name\FullyQualified(self::ATTRIBUTE_ROUTE);
+                    return $node;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function isSymfonyRouteAttribute(Node $node): bool
+    {
+        return $node instanceof Attribute && $node->name !== null && (string) $node->name === self::ANNOTATION_ROUTE;
+    }
+}


### PR DESCRIPTION
Integrate in Symfony upgrade the replacement of Symfony\Component\Routing\Annotation\Route by Symfony\Component\Routing\Attribute\Route

see [this issue](https://github.com/rectorphp/rector/issues/8384)

Closes https://github.com/rectorphp/rector/issues/8384