### PR TITLE
[Symfony 4.3] Skip dynamic variable on ConvertRenderTemplateShortNotationToBundleSyntaxRector

### DIFF
--- a/rules-tests/Symfony43/Rector/MethodCall/ConvertRenderTemplateShortNotationToBundleSyntaxRector/Fixture/skip_dynamic_variable.php.inc
+++ b/rules-tests/Symfony43/Rector/MethodCall/ConvertRenderTemplateShortNotationToBundleSyntaxRector/Fixture/skip_dynamic_variable.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony43\Rector\MethodCall\ConvertRenderTemplateShortNotationToBundleSyntaxRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class SkipDynamicVariable extends Controller
+{
+    function indexAction()
+    {
+        $this->deferRender('appBundle:Landing\Main:index.html.twig');
+    }
+
+    function deferRender($template)
+    {
+        $this->render($template);
+    }
+}

--- a/rules/Symfony43/Rector/MethodCall/ConvertRenderTemplateShortNotationToBundleSyntaxRector.php
+++ b/rules/Symfony43/Rector/MethodCall/ConvertRenderTemplateShortNotationToBundleSyntaxRector.php
@@ -94,6 +94,10 @@ CODE_SAMPLE
 
         $tplName = $this->valueResolver->getValue($args[0]->value);
 
+        if ($tplName === null) {
+            return null;
+        }
+
         $matches = Strings::match($tplName, '/:/', PREG_OFFSET_CAPTURE);
         if ($matches === null) {
             return null;


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8449