### PR TITLE
[Symfony 4.4] Updating AuthorizationCheckerIsGrantedExtractorRector

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -110,7 +110,7 @@ Make assertSame(200, `$response->getStatusCode())` in tests comparing response c
 
 ## AuthorizationCheckerIsGrantedExtractorRector
 
-Change `$this->authorizationChecker->isGranted([$a, $b])` to `$this->authorizationChecker->isGranted($a) || $this->authorizationChecker->isGranted($b)`
+Change `$this->authorizationChecker->isGranted([$a, $b])` to `$this->authorizationChecker->isGranted($a) || `$this->authorizationChecker->isGranted($b)`,` also updates AbstractController usages
 
 - class: [`Rector\Symfony\Symfony44\Rector\MethodCall\AuthorizationCheckerIsGrantedExtractorRector`](../rules/Symfony44/Rector/MethodCall/AuthorizationCheckerIsGrantedExtractorRector.php)
 

--- a/rules-tests/Symfony44/Rector/MethodCall/AuthorizationCheckerIsGrantedExtractorRector/Fixture/controller_deny_array_value.php.inc
+++ b/rules-tests/Symfony44/Rector/MethodCall/AuthorizationCheckerIsGrantedExtractorRector/Fixture/controller_deny_array_value.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\MethodCall\AuthorizationCheckerIsGrantedExtractorRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+class AccessController extends AbstractController
+{
+    public function someMethod()
+    {
+        if ($this->isGranted(['ROLE_USER', 'ROLE_ADMIN'])) {
+
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\MethodCall\AuthorizationCheckerIsGrantedExtractorRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+class AccessController extends AbstractController
+{
+    public function someMethod()
+    {
+        if ($this->isGranted('ROLE_USER') || $this->isGranted('ROLE_ADMIN')) {
+
+        }
+    }
+}
+
+?>

--- a/stubs/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/stubs/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -70,4 +70,8 @@ abstract class AbstractController implements \Symfony\Component\DependencyInject
     public function stream(string $view, array $parameters = [], StreamedResponse $response = null): StreamedResponse
     {
     }
+
+    protected function isGranted($attributes, $subject = null): bool
+    {
+    }
 }


### PR DESCRIPTION
Felt like this rule was missing the AbstractController implementation.

This PR will add `AbstractController::isGranted()` ~and `AbstractController::denyAccessUnlessGranted()`~ support