### PR TITLE
Fixes the MessageHandlerInterfaceToAttributeRector rule reported as always applied

### DIFF
--- a/rules/Symfony62/Rector/Class_/MessageHandlerInterfaceToAttributeRector.php
+++ b/rules/Symfony62/Rector/Class_/MessageHandlerInterfaceToAttributeRector.php
@@ -107,16 +107,19 @@ CODE_SAMPLE
      */
     private function checkForServices(Class_ $class, array $handlers): ?Class_
     {
+        $hasChanged = false;
         foreach ($handlers as $handler) {
             if ($this->isName($class, $handler->getClass() ?? $handler->getId())) {
                 $options = $this->messengerHelper->extractOptionsFromServiceDefinition($handler);
                 if (! isset($options['method']) || $options['method'] === '__invoke') {
                     $this->messengerHelper->addAttribute($class, $options);
-                    return $class;
+                    $hasChanged = true;
                 }
             }
         }
-
+        if ($hasChanged) {
+            return $class;
+        }
         return null;
     }
 }

--- a/rules/Symfony62/Rector/Class_/MessageHandlerInterfaceToAttributeRector.php
+++ b/rules/Symfony62/Rector/Class_/MessageHandlerInterfaceToAttributeRector.php
@@ -105,17 +105,18 @@ CODE_SAMPLE
     /**
      * @param ServiceDefinition[] $handlers
      */
-    private function checkForServices(Class_ $class, array $handlers): Class_
+    private function checkForServices(Class_ $class, array $handlers): ?Class_
     {
         foreach ($handlers as $handler) {
             if ($this->isName($class, $handler->getClass() ?? $handler->getId())) {
                 $options = $this->messengerHelper->extractOptionsFromServiceDefinition($handler);
                 if (! isset($options['method']) || $options['method'] === '__invoke') {
                     $this->messengerHelper->addAttribute($class, $options);
+                    return $class;
                 }
             }
         }
 
-        return $class;
+        return null;
     }
 }


### PR DESCRIPTION
The `checkForServices()` function should return `null` if it has not actually changed the class

This is part of the SYMFONY_62 rule set