### PR TITLE
Fixes namespace of `ChainRequestMatcher`

### DIFF
--- a/config/sets/symfony/symfony62.php
+++ b/config/sets/symfony/symfony62.php
@@ -53,7 +53,7 @@ return static function (RectorConfig $rectorConfig): void {
             'Symfony\Component\Translation\Extractor\PhpAstExtractor' => 'Symfony\Component\Translation\Extractor\PhpAstExtractor',
             // @see https://github.com/symfony/symfony/pull/47595
             'Symfony\Component\HttpFoundation\ExpressionRequestMatcher' => 'Symfony\Component\HttpFoundation\RequestMatcher\ExpressionRequestMatcher',
-            'Symfony\Component\HttpFoundation\RequestMatcher' => 'Symfony\Component\HttpFoundation\RequestMatcher\ChainRequestMatcher',
+            'Symfony\Component\HttpFoundation\RequestMatcher' => 'Symfony\Component\HttpFoundation\ChainRequestMatcher',
         ],
     );
 


### PR DESCRIPTION
That file does not exist :sweat_smile: 

https://github.com/symfony/symfony/tree/6.2/src/Symfony/Component/HttpFoundation/RequestMatcher

It was introduced in https://github.com/symfony/symfony/pull/47595