### PR TITLE
Add removal of AsEventListener attribute when converting to EventSubscriber

### DIFF
--- a/rules/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector.php
+++ b/rules/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector.php
@@ -176,5 +176,18 @@ CODE_SAMPLE
             $this->eventNamesToClassConstants
         );
         $class->stmts[] = $classMethod;
+
+        $this->removeAttribute($class);
+    }
+
+    private function removeAttribute(Class_ $class){
+        foreach ($class->attrGroups as $attrGroupKey => $attrGroup) {
+            foreach ($attrGroup->attrs as $attribute) {
+                if (!$this->nodeNameResolver->isName($attribute->name, 'Symfony\Component\EventDispatcher\Attribute\AsEventListener')) {
+                    continue;
+                }
+                unset($class->attrGroups[$attrGroupKey]);
+            }
+        }
     }
 }


### PR DESCRIPTION
Current behaviour results in a mixed result when the `#AsEventListener` attribute has been used:

```diff
 namespace App\EventListener;

+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use App\Exception\Http\RestHttpExceptionInterface;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
@@ @@
 use Symfony\Component\HttpKernel\KernelEvents;

 #[AsEventListener(KernelEvents::EXCEPTION, method: 'onKernelException', priority: 10)]
-class RestExceptionListener
+class RestExceptionEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         protected ViewHandlerInterface $viewHandler,
@@ @@
             $response = $this->viewHandler->handle($view);
             $event->setResponse($response);
         }
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::EXCEPTION => ['onKernelException', 10]];
     }
 }
```
Since the rule is there to convert a Listener to a Subscriber it makes sense to remove the attribute right?

Todo:

- [ ] Add fixture(s)
- [ ] Code formatting