### PR TITLE
EventListenerToEventSubscriberRector runs also if AsEventSubscriber-Attribute is present

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_class.php.inc
@@ -9,19 +9,3 @@ class SingleMethodListener
     {
     }
 }
-
-?>
------
-<?php
-
-namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
-
-#[AsEventListener]
-class SingleMethodListener
-{
-    public function __invoke()
-    {
-    }
-}
-
-?>

--- a/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_class.php.inc
@@ -2,6 +2,8 @@
 
 namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
 
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
 #[AsEventListener]
 class SingleMethodListener
 {

--- a/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_class.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
+
+#[AsEventListener]
+class SingleMethodListener
+{
+    public function __invoke()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
+
+#[AsEventListener]
+class SingleMethodListener
+{
+    public function __invoke()
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_class.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_class.php.inc
@@ -11,3 +11,5 @@ class SingleMethodListener
     {
     }
 }
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_methods.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_methods.php.inc
@@ -2,6 +2,8 @@
 
 namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
 
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
 class MultiMethodListener
 {
     #[AsEventListener]

--- a/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_methods.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_methods.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
+
+class MultiMethodListener
+{
+    #[AsEventListener]
+    public function onMethodA()
+    {
+    }
+
+    #[AsEventListener]
+    public function onMethodB()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
+
+class MultiMethodListener
+{
+    #[AsEventListener]
+    public function onMethodA()
+    {
+    }
+
+    #[AsEventListener]
+    public function onMethodB()
+    {
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_methods.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_methods.php.inc
@@ -16,3 +16,5 @@ class MultiMethodListener
     {
     }
 }
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_methods.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/skip_when_as_event_listener_attribute_exists_on_methods.php.inc
@@ -14,24 +14,3 @@ class MultiMethodListener
     {
     }
 }
-
-?>
------
-<?php
-
-namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
-
-class MultiMethodListener
-{
-    #[AsEventListener]
-    public function onMethodA()
-    {
-    }
-
-    #[AsEventListener]
-    public function onMethodB()
-    {
-    }
-}
-
-?>


### PR DESCRIPTION
Add 2 fixtures to cover Listener-Classes using AsEventListener-Attributes that are going to be changed to EventSubscriber without any need