### PR TITLE
Add missing 'Serializer/Context' class to the list of "annotation to attribute" rule

### DIFF
--- a/config/sets/symfony/symfony52-validator-attributes.php
+++ b/config/sets/symfony/symfony52-validator-attributes.php
@@ -70,6 +70,7 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Url'),
         new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Uuid'),
         new AnnotationToAttribute('Symfony\Component\Validator\Constraints\Valid'),
+        new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\Context'),
         new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\DiscriminatorMap'),
         new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\Groups'),
         new AnnotationToAttribute('Symfony\Component\Serializer\Annotation\Ignore'),


### PR DESCRIPTION
This  MR add a missing class to the list of configured "annotation to attributes" set list: the class `Symfony\Component\Serializer\Annotation\Context`, which was not yet configured.