### PR TITLE
Allow null values for domain and locale in Translator

### DIFF
--- a/config/sets/symfony/symfony50-types.php
+++ b/config/sets/symfony/symfony50-types.php
@@ -267,13 +267,13 @@ return static function (RectorConfig $rectorConfig): void {
             'Symfony\Contracts\Translation\TranslatorInterface',
             'trans',
             2,
-            new StringType()
+            \PHPStan\Type\TypeCombinator::addNull(new StringType())
         ),
         new AddParamTypeDeclaration(
             'Symfony\Contracts\Translation\TranslatorInterface',
             'trans',
             3,
-            new StringType()
+            \PHPStan\Type\TypeCombinator::addNull(new StringType())
         ),
         new AddParamTypeDeclaration('Symfony\Component\Form\AbstractExtension', 'getType', 0, new StringType()),
         new AddParamTypeDeclaration('Symfony\Component\Form\AbstractExtension', 'hasType', 0, new StringType()),

--- a/tests/Set/Symfony50/Fixture/skip_translator_that_already_uses_string_types.php.inc
+++ b/tests/Set/Symfony50/Fixture/skip_translator_that_already_uses_string_types.php.inc
@@ -4,7 +4,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class Translator implements TranslatorInterface
 {
-    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string
+    public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
     {
         return 'translated';
     }

--- a/tests/Set/Symfony50/Fixture/translator_not_using_params_types.php.inc
+++ b/tests/Set/Symfony50/Fixture/translator_not_using_params_types.php.inc
@@ -23,7 +23,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class Translator implements TranslatorInterface
 {
-    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string
+    public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
     {
         return 'translated';
     }


### PR DESCRIPTION
The 'trans' method in the Translator class has been updated to allow null values for 'domain' and 'locale' parameters.

Closes #592 