### PR TITLE
Fix TemplateGuesser to snake case controller classes and actions

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/basic.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/basic.php.inc
@@ -45,12 +45,12 @@ class ClassWithNamedService15Controller extends AbstractController
 {
     public function indexAction(): \Symfony\Component\HttpFoundation\Response
     {
-        return $this->render('@App/Class_With_Named_Service15/index.html.twig');
+        return $this->render('@App/class_with_named_service15/index.html.twig');
     }
 
     public function index2Action(): \Symfony\Component\HttpFoundation\Response
     {
-        return $this->render('@App/Class_With_Named_Service15/index2.html.twig', ['someKey' => 'someValue']);
+        return $this->render('@App/class_with_named_service15/index2.html.twig', ['someKey' => 'someValue']);
     }
 
     public function index3Action(): \Symfony\Component\HttpFoundation\Response

--- a/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/empty_body.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/empty_body.php.inc
@@ -28,7 +28,7 @@ class EmptyBodyController extends AbstractController
 {
     public function indexAction(): \Symfony\Component\HttpFoundation\Response
     {
-        return $this->render('@App/Empty_Body/index.html.twig');
+        return $this->render('@App/empty_body/index.html.twig');
     }
 }
 

--- a/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/fixture3.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/fixture3.php.inc
@@ -49,7 +49,7 @@ class ClassWithNamedService35Controller extends AbstractController
             return $this->redirectToRoute('rector_is_cool');
         }
 
-        return $this->render('@App/Class_With_Named_Service35/index.html.twig', array(
+        return $this->render('@App/class_with_named_service35/index.html.twig', array(
             'form' => $form->createView()
         ));
     }

--- a/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/fixture5.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/fixture5.php.inc
@@ -14,6 +14,14 @@ class ClassWithNamedService55Controller extends AbstractController
     {
         return [];
     }
+
+    /**
+     * @Template()
+     */
+    public function camelCase()
+    {
+        return [];
+    }
 }
 
 ?>
@@ -29,7 +37,12 @@ class ClassWithNamedService55Controller extends AbstractController
 {
     public function index(): \Symfony\Component\HttpFoundation\Response
     {
-        return $this->render('Class_With_Named_Service55/index.html.twig');
+        return $this->render('class_with_named_service55/index.html.twig');
+    }
+
+    public function camelCase(): \Symfony\Component\HttpFoundation\Response
+    {
+        return $this->render('class_with_named_service55/camel_case.html.twig');
     }
 }
 

--- a/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/if_else_array_response.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/if_else_array_response.php.inc
@@ -42,11 +42,11 @@ class ClassIfElseArrayController extends AbstractController
     public function indexAction(): \Symfony\Component\HttpFoundation\Response
     {
         if (mt_rand(0, 100)) {
-            return $this->render('@App/Class_If_Else_Array/index.html.twig', [
+            return $this->render('@App/class_if_else_array/index.html.twig', [
                 'key' => 'value'
             ]);
         } elseif (mt_rand(0, 200)) {
-            return $this->render('@App/Class_If_Else_Array/index.html.twig', [
+            return $this->render('@App/class_if_else_array/index.html.twig', [
                 'key' => 'value2'
             ]);
         } else {

--- a/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/inner_return_with_only_vars.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/inner_return_with_only_vars.php.inc
@@ -36,7 +36,7 @@ class InnerReturnWithOnlyVarsController extends AbstractController
         function (Post $post) {
             return $post;
         };
-        return $this->render('@App/Inner_Return_With_Only_Vars/index.html.twig', ['post' => $post]);
+        return $this->render('@App/inner_return_with_only_vars/index.html.twig', ['post' => $post]);
     }
 }
 

--- a/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/try_catch_array_response.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/try_catch_array_response.php.inc
@@ -40,7 +40,7 @@ class ClassTryCatchArrayResponseController extends AbstractController
     public function indexAction(): \Symfony\Component\HttpFoundation\Response
     {
         try {
-            return $this->render('@App/Class_Try_Catch_Array_Response/index.html.twig', [
+            return $this->render('@App/class_try_catch_array_response/index.html.twig', [
                 'key' => 'value'
             ]);
         } catch (Throwable $throwable) {

--- a/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/with_only_vars.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector/Fixture/with_only_vars.php.inc
@@ -30,7 +30,7 @@ class WithOnlyVarsController extends AbstractController
 {
     public function index(Post $post): \Symfony\Component\HttpFoundation\Response
     {
-        return $this->render('@App/With_Only_Vars/index.html.twig', ['post' => $post]);
+        return $this->render('@App/with_only_vars/index.html.twig', ['post' => $post]);
     }
 }
 

--- a/src/Helper/TemplateGuesser.php
+++ b/src/Helper/TemplateGuesser.php
@@ -89,16 +89,22 @@ final readonly class TemplateGuesser
 
         $action = Strings::replace($method, self::ACTION_MATCH_REGEX, '');
 
+        $action = Strings::replace(
+            $action,
+            self::SMALL_LETTER_BIG_LETTER_REGEX,
+            '\\1_\\2'
+        );
+
         $fullPath = '';
         if ($bundle !== '') {
             $fullPath .= $bundle . '/';
         }
 
         if ($controller !== '') {
-            $fullPath .= $controller . '/';
+            $fullPath .= strtolower($controller) . '/';
         }
 
-        return $fullPath . $action . '.html.twig';
+        return $fullPath . strtolower($action) . '.html.twig';
     }
 
     private function resolveBundle(string $class, string $namespace): string


### PR DESCRIPTION
Currently, TemplateAnnotationToThisRenderRector is leaving the action method names camel cased. It was also leaving the controller capitalized with underscores. I believe this fix makes it work according to the docs at: https://symfony.com/bundles/SensioFrameworkExtraBundle/current/annotations/view.html