### PR TITLE
[CodeQuality] Skip complex structure cause undefined method on StringExtensionToConfigBuilderRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector/Fixture/skip_undefined_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector/Fixture/skip_undefined_method.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Consenta\Infrastructure\Symfony\Security\SecurityUserProvider;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('security', [
+        'password_hashers' => [
+            PasswordAuthenticatedUserInterface::class => 'auto',
+        ],
+        'providers' => [
+            'app_user_provider' => [
+                'id' => SecurityUserProvider::class,
+            ],
+        ],
+        'firewalls' => [
+            'dev' => [
+                'pattern' => '^/(_(profiler|wdt)|css|images|js)/',
+                'security' => false,
+                'stateless' => false,
+            ],
+            'main' => [
+                'lazy' => true,
+                'provider' => 'app_user_provider',
+                'stateless' => false,
+                'json_login' => [
+                    'check_path' => 'api_login',
+                    'username_path' => 'email',
+                    'password_path' => 'password',
+                ],
+            ],
+        ],
+        'access_control' => null,
+    ]);
+};

--- a/rules/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector.php
+++ b/rules/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector.php
@@ -129,13 +129,17 @@ CODE_SAMPLE
         $configVariable = $this->createConfigVariable($configClass);
 
         $stmts = $this->createMethodCallStmts($extensionKeyAndConfiguration->getArray(), $configVariable);
+        if ($stmts === null) {
+            return null;
+        }
+
         return $this->symfonyClosureFactory->create($configClass, $node, $stmts);
     }
 
     /**
      * @return array<Expression<MethodCall>>
      */
-    private function createMethodCallStmts(Array_ $configurationArray, Variable $configVariable): array
+    private function createMethodCallStmts(Array_ $configurationArray, Variable $configVariable): ?array
     {
         $methodCallStmts = [];
 
@@ -183,6 +187,10 @@ CODE_SAMPLE
                     $currentConfigCaller = new MethodCall($configVariable, $methodCallName);
                 } else {
                     $currentConfigCaller = $configVariable;
+                }
+
+                if (! is_array($value)) {
+                    return null;
                 }
 
                 foreach ($value as $itemName => $itemConfiguration) {


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8496