### PR TITLE
[PHPStan] Fix missingType.generics notice on phpstan.neon on PHPStan 1.11

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,9 +18,10 @@ parameters:
         - */Fixture/*
         - */Fixture*/*
 
-    checkGenericClassInNonGenericObjectType: false
-
     ignoreErrors:
+        -
+            identifier: missingType.generics
+
         # pointless check
         - '#expects class-string, string given#'
 

--- a/rules/SwiftMailer/Rector/ClassMethod/SwiftMessageToEmailRector.php
+++ b/rules/SwiftMailer/Rector/ClassMethod/SwiftMessageToEmailRector.php
@@ -21,6 +21,9 @@ use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
+/**
+ * @see \Rector\Symfony\Tests\SwiftMailer\Rector\ClassMethod\SwiftMessageToEmailRector\SwiftMessageToEmailRectorTest
+ */
 class SwiftMessageToEmailRector extends AbstractRector
 {
     public const EMAIL_FQN = 'Symfony\Component\Mime\Email';


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/5888