### PR TITLE
feat: add web_profiler as config builder

### DIFF
--- a/rules/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector.php
+++ b/rules/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector.php
@@ -46,6 +46,7 @@ final class StringExtensionToConfigBuilderRector extends AbstractRector
         'doctrine' => 'Symfony\Config\DoctrineConfig',
         'doctrine_migrations' => 'Symfony\Config\DoctrineMigrationsConfig',
         'sentry' => 'Symfony\Config\SentryConfig',
+        'web_profiler' => 'Symfony\Config\WebProfilerConfig',
     ];
 
     public function __construct(


### PR DESCRIPTION
While converting my Symfony configs I ran into [this issue](https://github.com/rectorphp/rector/issues/8705).