### PR TITLE
Hybrid CommandConfigureToAttributeRector

### DIFF
--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/hybrid.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/hybrid.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttributeRector\Fixture;
+
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'sunshine')]
+final class Hybrid extends \Symfony\Component\Console\Command\Command
+{
+    public function configure()
+    {
+        $this->setDescription('rising above');
+        $this->setAliases(['first', 'second']);
+        $this->setHidden(true);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttributeRector\Fixture;
+
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'sunshine', description: 'rising above', aliases: ['first', 'second'], hidden: true)]
+final class Hybrid extends \Symfony\Component\Console\Command\Command
+{
+    public function configure()
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
When you already have a AsCommand attribute, but still have things that are done in `configure`, move them over.