### PR TITLE
[Config] Add configurable AutowireAttributeRector to add #[Autowire(...)] to services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         "symfony/security-http": "^6.4",
         "symfony/validator": "^6.4",
         "symplify/easy-coding-standard": "^12.3",
-        "symplify/phpstan-extensions": "^11.1",
+        "symplify/phpstan-extensions": "^11.4",
         "symplify/phpstan-rules": "^13.0",
         "symplify/rule-doc-generator": "^12.2.2",
-        "symplify/vendor-patches": "^11.2",
+        "symplify/vendor-patches": "^11.3",
         "tomasvotruba/class-leak": "^0.2",
         "tracy/tracy": "^2.10"
     },

--- a/config/sets/symfony/symfony64.php
+++ b/config/sets/symfony/symfony64.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
@@ -33,7 +34,7 @@ return static function (RectorConfig $rectorConfig): void {
         new AddReturnTypeDeclaration(
             'Symfony\Component\Form\DataTransformerInterface',
             'transform',
-            new UnionType([new StringType(), new \PHPStan\Type\NullType()]),
+            new UnionType([new StringType(), new NullType()]),
         ),
         new AddReturnTypeDeclaration(
             'Symfony\Component\Form\DataTransformerInterface',

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# 82 Rules Overview
+# 83 Rules Overview
 
 ## ActionSuffixRemoverRector
 
@@ -117,6 +117,31 @@ Change `$this->authorizationChecker->isGranted([$a, $b])` to `$this->authorizati
 ```diff
 -if ($this->authorizationChecker->isGranted(['ROLE_USER', 'ROLE_ADMIN'])) {
 +if ($this->authorizationChecker->isGranted('ROLE_USER') || $this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+ }
+```
+
+<br>
+
+## AutowireAttributeRector
+
+Change explicit configuration parameter pass into #[Autowire] attributes
+
+:wrench: **configure it!**
+
+- class: [`Rector\Symfony\Configs\Rector\Class_\AutowireAttributeRector`](../rules/Configs/Rector/Class_/AutowireAttributeRector.php)
+
+```diff
++use Symfony\Component\DependencyInjection\Attribute\Autowire;
++
+ final class SomeClass
+ {
+     public function __construct(
++        #[Autowire(param: 'timeout')]
+         private int $timeout,
++        #[Autowire(env: 'APP_SECRET')]
+         private string $secret,
+     )  {
+     }
  }
 ```
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -39,3 +39,6 @@ parameters:
         # false positive
         - '#Parameters should have "PhpParser\\Node\\Expr\\Closure" types as the only types passed to this method#'
         - '#Parameter 1 should use "PHPStan\\BetterReflection\\Reflection\\Adapter\\ReflectionMethod" type as the only type passed to this method#'
+
+        # overly detailed
+        - '#Property Rector\\Symfony\\Configs\\NodeVisitor\\CollectServiceArgumentsNodeVisitor\:\:\$servicesArgumentsByClass (.*?) does not accept (.*?)#'

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/AutowireAttributeRectorTest.php
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/AutowireAttributeRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AutowireAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Fixture/another_configured_service.php.inc
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Fixture/another_configured_service.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture;
+
+final class AnotherConfiguredService
+{
+    public function __construct(
+        private $someParameter
+    ) {
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture;
+
+final class AnotherConfiguredService
+{
+    public function __construct(
+        #[\Symfony\Component\DependencyInjection\Attribute\Autowire(param: 'SOME_PARAM')]
+        private $someParameter
+    ) {
+    }
+}
+
+?>

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Fixture/fixture_duplicate.php.inc
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Fixture/fixture_duplicate.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture;
+
+final class SomeConfiguredService
+{
+    public function __construct(
+        private int $timeout,
+        private string $key
+    ) {
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture;
+
+final class SomeConfiguredService
+{
+    public function __construct(
+        #[\Symfony\Component\DependencyInjection\Attribute\Autowire(param: 'timeout')]
+        private int $timeout,
+        #[\Symfony\Component\DependencyInjection\Attribute\Autowire(env: 'APP_KEY')]
+        private string $key
+    ) {
+    }
+}
+
+?>

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Fixture/positioned_arg.php.inc
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Fixture/positioned_arg.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture;
+
+final class PositionedArg
+{
+    public function __construct(
+        private $anything,
+        private $canBeHere
+    ) {
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture;
+
+final class PositionedArg
+{
+    public function __construct(
+        #[\Symfony\Component\DependencyInjection\Attribute\Autowire(param: 'first_item')]
+        private $anything,
+        #[\Symfony\Component\DependencyInjection\Attribute\Autowire(param: 'second_item')]
+        private $canBeHere
+    ) {
+    }
+}
+
+?>

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Fixture/skip_service_without_constructor.php.inc
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Fixture/skip_service_without_constructor.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture;
+
+final class SkipServiceWithoutConstructor
+{
+    public function run(
+        int $timeout,
+        string $key
+    ) {
+    }
+}

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Source/configs/app_config.php
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Source/configs/app_config.php
@@ -1,0 +1,15 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(\Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\SomeConfiguredService::class)
+        ->arg('timeout', '%timeout%')
+        ->arg('key', '%env(APP_KEY)%');
+
+    $services->set(\Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\SkipServiceWithoutConstructor::class)
+        ->arg('timeout', '%timeout%')
+        ->arg('key', '%env(APP_KEY)%');
+};

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Source/configs/app_config.php
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Source/configs/app_config.php
@@ -1,5 +1,6 @@
 <?php
 
+use Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\AnotherConfiguredService;
 use Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\SkipServiceWithoutConstructor;
 use Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\SomeConfiguredService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -10,6 +11,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(SomeConfiguredService::class)
         ->arg('timeout', '%timeout%')
         ->arg('key', '%env(APP_KEY)%');
+
+    $services->set(AnotherConfiguredService::class)
+        ->arg('missing', '%MISSING_PARAM%')
+        ->arg('someParameter', '%SOME_PARAM%');
 
     // should be skipped
     $services->set(SkipServiceWithoutConstructor::class)

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Source/configs/app_config.php
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Source/configs/app_config.php
@@ -1,15 +1,18 @@
 <?php
 
+use Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\SkipServiceWithoutConstructor;
+use Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\SomeConfiguredService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(\Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\SomeConfiguredService::class)
+    $services->set(SomeConfiguredService::class)
         ->arg('timeout', '%timeout%')
         ->arg('key', '%env(APP_KEY)%');
 
-    $services->set(\Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\SkipServiceWithoutConstructor::class)
+    // should be skipped
+    $services->set(SkipServiceWithoutConstructor::class)
         ->arg('timeout', '%timeout%')
         ->arg('key', '%env(APP_KEY)%');
 };

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Source/configs/position_arg.php
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/Source/configs/position_arg.php
@@ -1,0 +1,12 @@
+<?php
+
+use Rector\Symfony\Tests\Configs\Rector\Class_\AutowireAttributeRector\Fixture\PositionedArg;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(PositionedArg::class)
+        ->arg(1, '%second_item%')
+        ->arg(0, '%first_item%');
+};

--- a/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/config/configured_rule.php
+++ b/rules-tests/Configs/Rector/Class_/AutowireAttributeRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Configs\Rector\Class_\AutowireAttributeRector;
+
+return RectorConfig::configure()
+    ->withConfiguredRule(AutowireAttributeRector::class, [
+        AutowireAttributeRector::CONFIGS_DIRECTORY => __DIR__ . '/../Source/configs',
+    ]);

--- a/rules/Configs/ConfigArrayHandler/SecurityAccessDecisionManagerConfigArrayHandler.php
+++ b/rules/Configs/ConfigArrayHandler/SecurityAccessDecisionManagerConfigArrayHandler.php
@@ -17,7 +17,7 @@ final class SecurityAccessDecisionManagerConfigArrayHandler
     /**
      * @return array<Expression<MethodCall>>
      */
-    public function handle(Array_ $array, Variable $configCaller, string $mainMethodName): array
+    public function handle(Array_ $array, Variable $variable, string $mainMethodName): array
     {
         if (! $array->items[0] instanceof ArrayItem) {
             return [];
@@ -31,7 +31,7 @@ final class SecurityAccessDecisionManagerConfigArrayHandler
         }
 
         // build accessControl() method call here
-        $accessDecisionManagerMethodCall = new MethodCall($configCaller, $mainMethodName);
+        $accessDecisionManagerMethodCall = new MethodCall($variable, $mainMethodName);
 
         foreach ($nestedArray->items as $nestedArrayItem) {
             if (! $nestedArrayItem instanceof ArrayItem) {

--- a/rules/Configs/NodeAnalyser/ConfigServiceArgumentsResolver.php
+++ b/rules/Configs/NodeAnalyser/ConfigServiceArgumentsResolver.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Rector\Symfony\Configs\NodeAnalyser;
 
 use PhpParser\NodeTraverser;
-use Rector\PhpParser\Parser\SimplePhpParser;
 use Rector\Symfony\Configs\NodeVisitor\CollectServiceArgumentsNodeVisitor;
 use Rector\Symfony\Configs\ValueObject\ServiceArguments;
+use Rector\Symfony\PhpParser\NamedSimplePhpParser;
 use Symfony\Component\Finder\SplFileInfo;
 
 final class ConfigServiceArgumentsResolver
@@ -17,7 +17,7 @@ final class ConfigServiceArgumentsResolver
     private CollectServiceArgumentsNodeVisitor $collectServiceArgumentsNodeVisitor;
 
     public function __construct(
-        private readonly SimplePhpParser $simplePhpParser
+        private readonly NamedSimplePhpParser $namedSimplePhpParser
     ) {
         $this->nodeTraverser = new NodeTraverser();
         $this->collectServiceArgumentsNodeVisitor = new CollectServiceArgumentsNodeVisitor();
@@ -34,7 +34,7 @@ final class ConfigServiceArgumentsResolver
 
         foreach ($phpConfigFileInfos as $phpConfigFileInfo) {
             // traverse and collect data
-            $configStmts = $this->simplePhpParser->parseString($phpConfigFileInfo->getContents());
+            $configStmts = $this->namedSimplePhpParser->parseString($phpConfigFileInfo->getContents());
             $this->nodeTraverser->traverse($configStmts);
 
             $servicesArguments = array_merge(

--- a/rules/Configs/NodeAnalyser/ConfigServiceArgumentsResolver.php
+++ b/rules/Configs/NodeAnalyser/ConfigServiceArgumentsResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Configs\NodeAnalyser;
+
+use PhpParser\NodeTraverser;
+use Rector\PhpParser\Parser\SimplePhpParser;
+use Rector\Symfony\Configs\NodeVisitor\CollectServiceArgumentsNodeVisitor;
+use Rector\Symfony\Configs\ValueObject\ServiceArguments;
+use Symfony\Component\Finder\SplFileInfo;
+
+final class ConfigServiceArgumentsResolver
+{
+    private NodeTraverser $nodeTraverser;
+
+    private CollectServiceArgumentsNodeVisitor $collectServiceArgumentsNodeVisitor;
+
+    public function __construct(
+        private readonly SimplePhpParser $simplePhpParser
+    ) {
+        $this->nodeTraverser = new NodeTraverser();
+        $this->collectServiceArgumentsNodeVisitor = new CollectServiceArgumentsNodeVisitor();
+        $this->nodeTraverser->addVisitor($this->collectServiceArgumentsNodeVisitor);
+    }
+
+    /**
+     * @param SplFileInfo[] $phpConfigFileInfos
+     * @return ServiceArguments[]
+     */
+    public function resolve(array $phpConfigFileInfos): array
+    {
+        $servicesArguments = [];
+
+        foreach ($phpConfigFileInfos as $phpConfigFileInfo) {
+            // traverse and collect data
+            $configStmts = $this->simplePhpParser->parseString($phpConfigFileInfo->getContents());
+            $this->nodeTraverser->traverse($configStmts);
+
+            $servicesArguments = array_merge(
+                $servicesArguments,
+                $this->collectServiceArgumentsNodeVisitor->getServicesArguments()
+            );
+        }
+
+        return $servicesArguments;
+    }
+}

--- a/rules/Configs/NodeAnalyser/SetServiceClassNameResolver.php
+++ b/rules/Configs/NodeAnalyser/SetServiceClassNameResolver.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Configs\NodeAnalyser;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\NodeFinder;
+
+final class SetServiceClassNameResolver
+{
+    /**
+     * Looks for
+     *
+     * $services->set(SomeClassName::Class)
+     *
+     * ↓
+     * "SomeClassName"
+     */
+    public function resolve(MethodCall $methodCall): ?string
+    {
+        $nodeFinder = new NodeFinder();
+
+        $serviceClassName = null;
+        $nodeFinder->findFirst($methodCall, function (Node $node) use (&$serviceClassName): ?bool {
+            if (! $node instanceof MethodCall) {
+                return null;
+            }
+
+            if (! $node->name instanceof Identifier) {
+                return null;
+            }
+
+            // we look for services variable
+            if (! $node->var instanceof Variable) {
+                return null;
+            }
+
+            if (! is_string($node->var->name)) {
+                return null;
+            }
+
+            $servicesName = $node->var->name;
+            if ($servicesName !== 'services') {
+                return null;
+            }
+
+            // dump($methodCall->var);
+            $args = $node->getArgs();
+            foreach ($args as $arg) {
+                if (! $arg->value instanceof ClassConstFetch) {
+                    continue;
+                }
+
+                $classConstFetch = $arg->value;
+                if (! $classConstFetch->name instanceof Identifier) {
+                    continue;
+                }
+
+                if ($classConstFetch->name->toString() !== 'class') {
+                    continue;
+                }
+
+                if (! $classConstFetch->class instanceof FullyQualified) {
+                    continue;
+                }
+
+                $serviceClassName = $classConstFetch->class->toString();
+                return true;
+            }
+
+            return false;
+        });
+        return $serviceClassName;
+    }
+}

--- a/rules/Configs/NodeAnalyser/SetServiceClassNameResolver.php
+++ b/rules/Configs/NodeAnalyser/SetServiceClassNameResolver.php
@@ -76,6 +76,7 @@ final class SetServiceClassNameResolver
 
             return false;
         });
+
         return $serviceClassName;
     }
 }

--- a/rules/Configs/NodeVisitor/CollectServiceArgumentsNodeVisitor.php
+++ b/rules/Configs/NodeVisitor/CollectServiceArgumentsNodeVisitor.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Configs\NodeVisitor;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt;
+//use PhpParser\NodeFinder;
+use PhpParser\NodeVisitorAbstract;
+use Rector\Exception\NotImplementedYetException;
+use Rector\Symfony\Configs\NodeAnalyser\SetServiceClassNameResolver;
+use Rector\Symfony\Configs\ValueObject\ServiceArguments;
+
+final class CollectServiceArgumentsNodeVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var string
+     */
+    private const ENVS = 'envs';
+
+    /**
+     * @var string
+     */
+    private const PARAMETERS = 'parameters';
+
+    /**
+     * @var array<string, array<self::ENVS|self::PARAMETERS, string[]>>
+     */
+    private array $servicesArgumentsByClass = [];
+
+    private readonly SetServiceClassNameResolver $setServiceClassNameResolver;
+
+    public function __construct()
+    {
+        $this->setServiceClassNameResolver = new SetServiceClassNameResolver();
+    }
+
+    /**
+     * @param Stmt[] $nodes
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        $this->servicesArgumentsByClass = [];
+
+        return parent::beforeTraverse($nodes);
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        $argMethodCall = $this->matchArgMethodCall($node);
+        if (! $argMethodCall instanceof MethodCall) {
+            return null;
+        }
+
+        // 1. detect arg name + value
+        $firstArg = $argMethodCall->getArgs()[0];
+        if (! $firstArg->value instanceof String_) {
+            throw new NotImplementedYetException(sprintf(
+                'Add support for non-string arg names like "%s"',
+                $firstArg->value::class
+            ));
+        }
+
+        $argumentName = $firstArg->value->value;
+
+        $secondArg = $argMethodCall->getArgs()[1];
+        if (! $secondArg->value instanceof String_) {
+            throw new NotImplementedYetException(sprintf(
+                'Add support for non-string arg values like "%s"',
+                $firstArg->value::class
+            ));
+        }
+
+        $serviceClassName = $this->setServiceClassNameResolver->resolve($argMethodCall);
+        if (! is_string($serviceClassName)) {
+            return null;
+        }
+
+        $argumentValue = $secondArg->value->value;
+
+        $match = Strings::match($argumentValue, '#%env\((?<env>[A-Z_]+)\)#');
+        if (isset($match['env'])) {
+            $this->servicesArgumentsByClass[$serviceClassName][self::ENVS][$argumentName] = (string) $match['env'];
+            return null;
+        }
+
+        $match = Strings::match($argumentValue, '#%(?<parameter>[\w]+)%#');
+        if (isset($match['parameter'])) {
+            $this->servicesArgumentsByClass[$serviceClassName][self::PARAMETERS][$argumentName] = (string) $match['parameter'];
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return ServiceArguments[]
+     */
+    public function getServicesArguments(): array
+    {
+        $serviceArguments = [];
+
+        foreach ($this->servicesArgumentsByClass as $serviceClass => $arguments) {
+            $parameters = $arguments[self::PARAMETERS] ?? [];
+            $envs = $arguments[self::ENVS] ?? [];
+
+            $serviceArguments[] = new ServiceArguments($serviceClass, $parameters, $envs);
+        }
+
+        return $serviceArguments;
+    }
+
+    /**
+     * We look for: ->arg(..., ...)
+     */
+    private function matchArgMethodCall(Node $node): ?MethodCall
+    {
+        if (! $node instanceof MethodCall) {
+            return null;
+        }
+
+        if (! $node->name instanceof Identifier) {
+            return null;
+        }
+
+        if ($node->name->toString() !== 'arg') {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/rules/Configs/Rector/Class_/AutowireAttributeRector.php
+++ b/rules/Configs/Rector/Class_/AutowireAttributeRector.php
@@ -122,7 +122,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            foreach ($constructClassMethod->params as $constructorParam) {
+            foreach ($constructClassMethod->params as $position => $constructorParam) {
                 if (! $constructorParam->var instanceof Variable) {
                     continue;
                 }
@@ -132,7 +132,7 @@ CODE_SAMPLE
                     continue;
                 }
 
-                $currentEnv = $serviceArgument->getEnvs()[$constructorParameterName] ?? null;
+                $currentEnv = $serviceArgument->getEnvs()[$constructorParameterName] ?? $serviceArgument->getEnvs()[$position] ?? null;
                 if ($currentEnv) {
                     $constructorParam->attrGroups[] = new AttributeGroup([
                         $this->createAutowireAttribute($currentEnv, 'env'),
@@ -142,7 +142,7 @@ CODE_SAMPLE
 
                 }
 
-                $currentParameter = $serviceArgument->getParams()[$constructorParameterName] ?? null;
+                $currentParameter = $serviceArgument->getParams()[$constructorParameterName] ?? $serviceArgument->getParams()[$position] ?? null;
                 if ($currentParameter) {
                     $constructorParam->attrGroups[] = new AttributeGroup([
                         $this->createAutowireAttribute($currentParameter, 'param'),

--- a/rules/Configs/Rector/Class_/AutowireAttributeRector.php
+++ b/rules/Configs/Rector/Class_/AutowireAttributeRector.php
@@ -21,7 +21,7 @@ use Rector\Symfony\Configs\NodeAnalyser\ConfigServiceArgumentsResolver;
 use Rector\ValueObject\MethodName;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
 
@@ -50,7 +50,7 @@ final class AutowireAttributeRector extends AbstractRector implements Configurab
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change explicit configuration parameter pass into #[Autowire] attributes', [
-            new CodeSample(
+            new ConfiguredCodeSample(
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {
@@ -71,11 +71,15 @@ final class SomeClass
         #[Autowire(param: 'timeout')]
         private int $timeout,
         #[Autowire(env: 'APP_SECRET')]
-        private string $secret
+        private string $secret,
     )  {
     }
 }
 CODE_SAMPLE
+                ,
+                [
+                    self::CONFIGS_DIRECTORY => __DIR__ . '/config',
+                ]
             )]);
     }
 

--- a/rules/Configs/ValueObject/ServiceArguments.php
+++ b/rules/Configs/ValueObject/ServiceArguments.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Configs\ValueObject;
+
+final readonly class ServiceArguments
+{
+    /**
+     * @param array<string, string> $params
+     * @param array<string, string> $envs
+     */
+    public function __construct(
+        private string $className,
+        private array $params,
+        private array $envs
+    ) {
+    }
+
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getEnvs(): array
+    {
+        return $this->envs;
+    }
+}

--- a/rules/Configs/ValueObject/ServiceArguments.php
+++ b/rules/Configs/ValueObject/ServiceArguments.php
@@ -7,8 +7,8 @@ namespace Rector\Symfony\Configs\ValueObject;
 final readonly class ServiceArguments
 {
     /**
-     * @param array<string, string> $params
-     * @param array<string, string> $envs
+     * @param array<string|int, string> $params
+     * @param array<string|int, string> $envs
      */
     public function __construct(
         private string $className,
@@ -23,7 +23,7 @@ final readonly class ServiceArguments
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string|int, string>
      */
     public function getParams(): array
     {
@@ -31,7 +31,7 @@ final readonly class ServiceArguments
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string|int, string>
      */
     public function getEnvs(): array
     {

--- a/rules/Symfony40/Rector/MethodCall/FormIsValidRector.php
+++ b/rules/Symfony40/Rector/MethodCall/FormIsValidRector.php
@@ -63,7 +63,7 @@ CODE_SAMPLE
 
         // mark child calls with known is submitted
         if ($this->isName($methodCall->name, 'isSubmitted')) {
-            $this->traverseNodesWithCallable($node->stmts, static function (Node $node) {
+            $this->traverseNodesWithCallable($node->stmts, static function (Node $node): null {
                 $node->setAttribute('has_is_submitted', true);
                 return null;
             });

--- a/rules/Symfony40/Rector/MethodCall/ProcessBuilderGetProcessRector.php
+++ b/rules/Symfony40/Rector/MethodCall/ProcessBuilderGetProcessRector.php
@@ -7,7 +7,6 @@ namespace Rector\Symfony\Symfony40\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
-use Rector\Contract\DependencyInjection\ResetableInterface;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;

--- a/rules/Symfony61/Rector/Class_/CommandConfigureToAttributeRector.php
+++ b/rules/Symfony61/Rector/Class_/CommandConfigureToAttributeRector.php
@@ -16,7 +16,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
-use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\Enum\SymfonyAnnotation;

--- a/src/PhpParser/NamedSimplePhpParser.php
+++ b/src/PhpParser/NamedSimplePhpParser.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\PhpParser;
+
+use PhpParser\Node\Stmt;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+final class NamedSimplePhpParser
+{
+    private Parser $phpParser;
+
+    public function __construct()
+    {
+        $parserFactory = new ParserFactory();
+        $this->phpParser = $parserFactory->create(ParserFactory::ONLY_PHP7);
+    }
+
+    /**
+     * @return Stmt[]
+     */
+    public function parseString(string $content): array
+    {
+        $stmts = $this->phpParser->parse($content);
+        if ($stmts === null) {
+            return [];
+        }
+
+        $nodeTraverser = new NodeTraverser();
+        $nodeTraverser->addVisitor(new NameResolver());
+        $nodeTraverser->traverse($stmts);
+
+        return $stmts;
+    }
+}

--- a/stubs/Symfony/Component/DependencyInjection/Loader/Configurator/ServiceConfigurator.php
+++ b/stubs/Symfony/Component/DependencyInjection/Loader/Configurator/ServiceConfigurator.php
@@ -8,7 +8,7 @@ if (class_exists('Symfony\Component\DependencyInjection\Loader\Configurator\Serv
 
 class ServiceConfigurator
 {
-    public function arg()
+    public function arg($name, $value)
     {
     }
 }

--- a/stubs/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
+++ b/stubs/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
@@ -8,7 +8,7 @@ if (class_exists('Symfony\Component\DependencyInjection\Loader\Configurator\Serv
 
 class ServicesConfigurator
 {
-    public function set(): ServiceConfigurator
+    public function set(string $className): ServiceConfigurator
     {
     }
 }


### PR DESCRIPTION
This is amazing feature from Symfony 6.1: https://symfony.com/blog/new-in-symfony-6-1-service-autowiring-attributes

All you need to do is provide path to your `/config` directory and rule is ready to go :+1: 

```php
// rector.php
use Rector\Config\RectorConfig;
use Rector\Symfony\Configs\Rector\Class_\AutowireAttributeRector;

return RectorConfig::configure()
    ->withConfiguredRule(AutowireAttributeRector::class, [
        AutowireAttributeRector::CONFIGS_DIRECTORY => __DIR__ . '/configs',
    ]);
```