### PR TITLE
[Symfony 6.2] Improve SecurityAttributeToIsGrantedAttributeRector

### DIFF
--- a/rules-tests/Symfony62/Rector/Class_/SecurityAttributeToIsGrantedAttributeRector/Fixture/single_is_granted.php.inc
+++ b/rules-tests/Symfony62/Rector/Class_/SecurityAttributeToIsGrantedAttributeRector/Fixture/single_is_granted.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony62\Rector\Class_\SecurityAttributeToIsGrantedAttributeRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+final class SingleIsGranted
+{
+    #[Security("is_granted('ROLE_ADMIN')")]
+    public function index()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony62\Rector\Class_\SecurityAttributeToIsGrantedAttributeRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+final class SingleIsGranted
+{
+    #[\Symfony\Component\Security\Http\Attribute\IsGranted('ROLE_ADMIN')]
+    public function index()
+    {
+    }
+}
+
+?>

--- a/rules-tests/Symfony62/Rector/Class_/SecurityAttributeToIsGrantedAttributeRector/Fixture/single_is_granted.php.inc
+++ b/rules-tests/Symfony62/Rector/Class_/SecurityAttributeToIsGrantedAttributeRector/Fixture/single_is_granted.php.inc
@@ -22,7 +22,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
 final class SingleIsGranted
 {
-    #[\Symfony\Component\Security\Http\Attribute\IsGranted('ROLE_ADMIN')]
+    #[\Symfony\Component\Security\Http\Attribute\IsGranted(attribute: 'ROLE_ADMIN')]
     public function index()
     {
     }

--- a/rules-tests/Symfony62/Rector/Class_/SecurityAttributeToIsGrantedAttributeRector/Fixture/with_second_arg.php.inc
+++ b/rules-tests/Symfony62/Rector/Class_/SecurityAttributeToIsGrantedAttributeRector/Fixture/with_second_arg.php.inc
@@ -4,9 +4,9 @@ namespace Rector\Symfony\Tests\Symfony62\Rector\Class_\SecurityAttributeToIsGran
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
-final class SimpleSecurity
+final class WithSecondArg
 {
-    #[Security("is_granted('ROLE_ADMIN') and is_granted('ROLE_FRIENDLY_USER')")]
+    #[Security("is_granted('ROLE_ADMIN', someArea)")]
     public function index()
     {
     }
@@ -20,9 +20,9 @@ namespace Rector\Symfony\Tests\Symfony62\Rector\Class_\SecurityAttributeToIsGran
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 
-final class SimpleSecurity
+final class WithSecondArg
 {
-    #[\Symfony\Component\Security\Http\Attribute\IsGranted(attribute: new \Symfony\Component\ExpressionLanguage\Expression("is_granted('ROLE_ADMIN') and is_granted('ROLE_FRIENDLY_USER')"))]
+    #[\Symfony\Component\Security\Http\Attribute\IsGranted(attribute: 'ROLE_ADMIN', subject: 'someArea')]
     public function index()
     {
     }

--- a/rules/Configs/NodeVisitor/CollectServiceArgumentsNodeVisitor.php
+++ b/rules/Configs/NodeVisitor/CollectServiceArgumentsNodeVisitor.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Rector\Symfony\Configs\NodeVisitor;
 
-use PhpParser\Node\Scalar\LNumber;
-use PhpParser\Node\Expr\Array_;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeVisitorAbstract;

--- a/rules/Configs/Rector/Class_/AutowireAttributeRector.php
+++ b/rules/Configs/Rector/Class_/AutowireAttributeRector.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Rector\Symfony\Configs\Rector\Class_;
 
-use PhpParser\Node\Expr;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;

--- a/rules/Symfony62/Rector/Class_/SecurityAttributeToIsGrantedAttributeRector.php
+++ b/rules/Symfony62/Rector/Class_/SecurityAttributeToIsGrantedAttributeRector.php
@@ -117,6 +117,7 @@ CODE_SAMPLE
                 $attribute->name = new FullyQualified(self::IS_GRANTED_ATTRIBUTE);
 
                 $firstArg = $attribute->args[0];
+                $firstArg->name = new Node\Identifier('attribute');
                 $attribute->args[0]->value = $this->wrapToNewExpression($firstArg->value);
 
                 $hasChanged = true;


### PR DESCRIPTION
Follow up to https://github.com/rectorphp/rector-symfony/pull/622

Covered cases:

```diff
-#[Security("is_granted('ROLE_ADMIN')")]
+#[\Symfony\Component\Security\Http\Attribute\IsGranted(attribute: 'ROLE_ADMIN')]
```

```diff
-#[Security("is_granted('ROLE_ADMIN', someArea)")]
+#[\Symfony\Component\Security\Http\Attribute\IsGranted(attribute: 'ROLE_ADMIN', subject: 'someArea')]
```

I've looked at the other cases, but due to it's stringy nature, we can't parse it and covert it into different structures.
This is the best we can automate, the rest would have to be dealt with manually.

<br>

Closes https://github.com/rectorphp/rector-symfony/issues/393