### PR TITLE
Correct return type definition for DataTransformerInterface

### DIFF
--- a/config/sets/symfony/symfony64.php
+++ b/config/sets/symfony/symfony64.php
@@ -2,10 +2,7 @@
 
 declare(strict_types=1);
 
-use PHPStan\Type\NullType;
-use PHPStan\Type\ObjectWithoutClassType;
-use PHPStan\Type\StringType;
-use PHPStan\Type\UnionType;
+use PHPStan\Type\MixedType;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Class_\RenameAttributeRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
@@ -34,12 +31,12 @@ return static function (RectorConfig $rectorConfig): void {
         new AddReturnTypeDeclaration(
             'Symfony\Component\Form\DataTransformerInterface',
             'transform',
-            new UnionType([new StringType(), new NullType()]),
+            new MixedType(),
         ),
         new AddReturnTypeDeclaration(
             'Symfony\Component\Form\DataTransformerInterface',
             'reverseTransform',
-            new UnionType([new StringType(), new ObjectWithoutClassType()]),
+            new MixedType(),
         ),
     ]);
 };


### PR DESCRIPTION
Corrects the problem introduced #624 and fixes https://github.com/rectorphp/rector/issues/8730.

The correct return type is mixed (see https://github.com/symfony/symfony/blob/7.0/src/Symfony/Component/Form/DataTransformerInterface.php), the comment in https://github.com/rectorphp/rector-symfony/issues/537#issue-1957058803 where the change was based on was just an example for a particular scenario.