### PR TITLE
[CodeQuality] Remove no returns check on ResponseReturnTypeControllerActionRector

### DIFF
--- a/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
@@ -205,11 +205,6 @@ CODE_SAMPLE
             return null;
         }
 
-        // no return, no type
-        if ($returns === []) {
-            return null;
-        }
-
         $responseReturnType = $this->resolveResponseOnlyReturnType($returns);
         if (! $responseReturnType instanceof \PHPStan\Type\Type) {
             return null;


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-symfony/pull/651#pullrequestreview-2207209590

the check already verified in above check:

```php
if (! $this->returnAnalyzer->hasOnlyReturnWithExpr($classMethod, $returns))
```

The fixture for it already exists at 

https://github.com/rectorphp/rector-symfony/blob/fcaedb34ce67a75db9ad18ed61c79de350837a58/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/skip_no_return.php.inc#L10-L13