### PR TITLE
Add the Symfony 7.0 set to SymfonySetList.php

### DIFF
--- a/src/Set/SymfonySetList.php
+++ b/src/Set/SymfonySetList.php
@@ -149,6 +149,11 @@ final class SymfonySetList implements SetListInterface
     /**
      * @var string
      */
+    final public const SYMFONY_70 = __DIR__ . '/../../config/sets/symfony/symfony70.php';
+
+    /**
+     * @var string
+     */
     final public const SYMFONY_71 = __DIR__ . '/../../config/sets/symfony/symfony71.php';
 
     /**


### PR DESCRIPTION
Every other Symfony release has its set listed, so this looks like an oversight?