### PR TITLE
[CodeQuality] Skip posible return array + response on ResponseReturnTypeControllerActionRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/skip_possible_return_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/skip_possible_return_array.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class SkipPossibleReturnArray extends AbstractController
+{
+    /**
+     * @Route("/new", name="some_new")
+     *
+     * @Template(template="Foo:Bar:edit.html.twig")
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|array{x: xy, form: \Symfony\Component\Form\FormView}
+     */
+    public function newAction()
+    {
+        $form = $this->createForm(Some::class, $type);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            return $this->redirect($this->generateUrl('some'));
+        }
+
+        return [
+            'x' => 'xy',
+            'form' => $form->createView(),
+        ];
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/skip_possible_return_array_or_response.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/skip_possible_return_array_or_response.php.inc
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Routing\Annotation\Route;
 
-final class SkipPossibleReturnArray extends AbstractController
+final class SkipPossibleReturnArrayOrResponse extends AbstractController
 {
     /**
      * @Route("/new", name="some_new")

--- a/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
             $this->attrinationFinder->hasByOne($node, SymfonyAnnotation::TWIG_TEMPLATE)) {
 
             $returnType = $this->returnTypeInferer->inferFunctionLike($node);
-            $types = $returnType instanceof UnionType ? $returnType->getTypes() : $returnType;
+            $types = $returnType instanceof UnionType ? $returnType->getTypes() : [$returnType];
             $objectType = new ObjectType('Symfony\Component\HttpFoundation\Response');
 
             foreach ($types as $type) {

--- a/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
@@ -125,14 +125,10 @@ CODE_SAMPLE
             $this->attrinationFinder->hasByOne($node, SymfonyAnnotation::TWIG_TEMPLATE)) {
 
             $returnType = $this->returnTypeInferer->inferFunctionLike($node);
-
-            if (! $returnType instanceof UnionType) {
-                $node->returnType = new NullableType(new Identifier('array'));
-                return $node;
-            }
-
+            $types = $returnType instanceof UnionType ? $returnType->getTypes() : $returnType;
             $objectType = new ObjectType('Symfony\Component\HttpFoundation\Response');
-            foreach ($returnType->getTypes() as $type) {
+
+            foreach ($types as $type) {
                 if ($type instanceof ObjectType && $objectType->isSuperTypeOf($type)->yes()) {
                     return null;
                 }

--- a/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
@@ -28,6 +28,7 @@ use Rector\Symfony\Enum\SensioAttribute;
 use Rector\Symfony\Enum\SymfonyAnnotation;
 use Rector\Symfony\TypeAnalyzer\ControllerAnalyzer;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
+use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -44,6 +45,7 @@ final class ResponseReturnTypeControllerActionRector extends AbstractRector impl
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly ReturnAnalyzer $returnAnalyzer,
         private readonly StaticTypeMapper $staticTypeMapper,
+        private readonly ReturnTypeInferer $returnTypeInferer
     ) {
     }
 
@@ -121,6 +123,21 @@ CODE_SAMPLE
         if (
             $this->attrinationFinder->hasByOne($node, SensioAttribute::TEMPLATE) ||
             $this->attrinationFinder->hasByOne($node, SymfonyAnnotation::TWIG_TEMPLATE)) {
+
+            $returnType = $this->returnTypeInferer->inferFunctionLike($node);
+
+            if (! $returnType instanceof UnionType) {
+                $node->returnType = new NullableType(new Identifier('array'));
+                return $node;
+            }
+
+            $objectType = new ObjectType('Symfony\Component\HttpFoundation\Response');
+            foreach ($returnType->getTypes() as $type) {
+                if ($type instanceof ObjectType && $objectType->isSuperTypeOf($type)->yes()) {
+                    return null;
+                }
+            }
+
             $node->returnType = new NullableType(new Identifier('array'));
             return $node;
         }


### PR DESCRIPTION
ref https://github.com/rectorphp/rector-src/pull/6200#pullrequestreview-2207245293

it currently got incorrect return:

```diff
-    public function editAction(Request $request, $id = null)
+    public function editAction(Request $request, $id = null): ?array

Applied rules:
 * ResponseReturnTypeControllerActionRector
```

This PR fix it.