### PR TITLE
 [Symfony 6.1] Skip abstract class on CommandConfigureToAttributeRector 

### DIFF
--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/skip_abstract_class.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/skip_abstract_class.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttributeRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+
+abstract class CommandWithLock extends Command
+{
+    public function configure()
+    {
+    }
+}

--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/skip_abstract_class.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/skip_abstract_class.php.inc
@@ -4,7 +4,7 @@ namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttribu
 
 use Symfony\Component\Console\Command\Command;
 
-abstract class CommandWithLock extends Command
+abstract class SkipAbstractClass extends Command
 {
     public function configure()
     {

--- a/rules/Symfony61/Rector/Class_/CommandConfigureToAttributeRector.php
+++ b/rules/Symfony61/Rector/Class_/CommandConfigureToAttributeRector.php
@@ -98,6 +98,10 @@ CODE_SAMPLE),
      */
     public function refactor(Node $node): ?Node
     {
+        if ($node->isAbstract()) {
+            return null;
+        }
+
         if (! $this->reflectionProvider->hasClass(SymfonyAnnotation::AS_COMMAND)) {
             return null;
         }


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector/issues/8799