### PR TITLE
[Symfony 6.4] add support for symfony/serializer attributes

### DIFF
--- a/config/sets/symfony/symfony64.php
+++ b/config/sets/symfony/symfony64.php
@@ -27,6 +27,55 @@ return static function (RectorConfig $rectorConfig): void {
         ),
     ]);
 
+    $rectorConfig->ruleWithConfiguration(RenameAttributeRector::class, [
+        new RenameAttribute(
+            'Symfony\Component\Serializer\Annotation\Context',
+            'Symfony\Component\Serializer\Attribute\Context'
+        ),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameAttributeRector::class, [
+        new RenameAttribute(
+            'Symfony\Component\Serializer\Annotation\DiscriminatorMap',
+            'Symfony\Component\Serializer\Attribute\DiscriminatorMap'
+        ),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameAttributeRector::class, [
+        new RenameAttribute(
+            'Symfony\Component\Serializer\Annotation\Groups',
+            'Symfony\Component\Serializer\Attribute\Groups'
+        ),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameAttributeRector::class, [
+        new RenameAttribute(
+            'Symfony\Component\Serializer\Annotation\Ignore',
+            'Symfony\Component\Serializer\Attribute\Ignore'
+        ),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameAttributeRector::class, [
+        new RenameAttribute(
+            'Symfony\Component\Serializer\Annotation\MaxDepth',
+            'Symfony\Component\Serializer\Attribute\MaxDepth'
+        ),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameAttributeRector::class, [
+        new RenameAttribute(
+            'Symfony\Component\Serializer\Annotation\SerializedName',
+            'Symfony\Component\Serializer\Attribute\SerializedName'
+        ),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameAttributeRector::class, [
+        new RenameAttribute(
+            'Symfony\Component\Serializer\Annotation\SerializedPath',
+            'Symfony\Component\Serializer\Attribute\SerializedPath'
+        ),
+    ]);
+
     $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
         new AddReturnTypeDeclaration(
             'Symfony\Component\Form\DataTransformerInterface',


### PR DESCRIPTION
Replaces the symfony/serializer annotation with native attributes

https://github.com/symfony/symfony/blob/6.4/UPGRADE-6.4.md#serializer