### PR TITLE
Added return type declaration rules for FormTypeInterface

### DIFF
--- a/config/sets/symfony/symfony6/symfony-return-types.php
+++ b/config/sets/symfony/symfony6/symfony-return-types.php
@@ -14,6 +14,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
+use PHPStan\Type\VoidType;
 use Rector\Config\RectorConfig;
 use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
@@ -279,6 +280,8 @@ return static function (RectorConfig $rectorConfig): void {
             new StringType()
         ),
         new AddReturnTypeDeclaration('Symfony\Component\Form\FormTypeInterface', 'getParent', $nullableStringType),
+        new AddReturnTypeDeclaration('Symfony\Component\Form\FormTypeInterface', 'buildForm', new VoidType()),
+        new AddReturnTypeDeclaration('Symfony\Component\Form\FormTypeInterface', 'configureOptions', new VoidType()),
         new AddReturnTypeDeclaration(
             'Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface',
             'isOptional',


### PR DESCRIPTION
Return type declaration rules for `FormTypeInterface::buildForm` and `FormTypeInterface::configureOptions` were missing.