### PR TITLE
Update GetBySymfonyStringToConstructorInjectionRector fixture test to cover rector-srv:tv-readonly-add-ctor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^11.4",
-        "rector/rector-src": "dev-main",
+        "rector/rector-src": "dev-tv-readonly-add-ctor",
         "symfony/config": "^6.4",
         "symfony/dependency-injection": "^6.4",
         "symfony/http-kernel": "~6.3",

--- a/rules-tests/DependencyInjection/Rector/Class_/GetBySymfonyStringToConstructorInjectionRector/Fixture/prefer_required_setter.php.inc
+++ b/rules-tests/DependencyInjection/Rector/Class_/GetBySymfonyStringToConstructorInjectionRector/Fixture/prefer_required_setter.php.inc
@@ -33,20 +33,17 @@ namespace Rector\Symfony\Tests\DependencyInjection\Rector\Class_\GetBySymfonyStr
 
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class PreferRequiredSetter extends Controller
 {
     private EventDispatcherInterface $eventDispatcher;
-
-    private ValidatorInterface $validator;
+    private \Symfony\Component\Validator\Validator\ValidatorInterface $validator;
 
     /**
      * @required
      */
     public function autowire(
-        EventDispatcherInterface $eventDispatcher,
-        ValidatorInterface $validator
+        EventDispatcherInterface $eventDispatcher, \Symfony\Component\Validator\Validator\ValidatorInterface $validator
     ) {
         $this->eventDispatcher = $eventDispatcher;
         $this->validator = $validator;


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/6652