### PR TITLE
[SYMFONY 5 & 6] Security add missing param

### DIFF
--- a/config/sets/symfony/symfony50.php
+++ b/config/sets/symfony/symfony50.php
@@ -2,15 +2,45 @@
 
 declare(strict_types=1);
 
+use PHPStan\Type\StringType;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
 
 # https://github.com/symfony/symfony/blob/5.0/UPGRADE-5.0.md
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/symfony50-types.php');
+
+    $rectorConfig->ruleWithConfiguration(AddParamTypeDeclarationRector::class, [
+        new AddParamTypeDeclaration(
+            'Symfony\Component\Security\Core\User\UserProviderInterface',
+            'loadUserByUsername',
+            0,
+            new StringType(),
+        ),
+        new AddParamTypeDeclaration(
+            'Symfony\Component\Security\Core\User\UserProviderInterface',
+            'supportsClass',
+            0,
+            new StringType(),
+        ),
+        new AddParamTypeDeclaration(
+            'Symfony\Bridge\Doctrine\Security\User\EntityUserProvider',
+            'loadUserByUsername',
+            0,
+            new StringType(),
+        ),
+        new AddParamTypeDeclaration(
+            'Symfony\Bridge\Doctrine\Security\User\EntityUserProvider',
+            'supportsClass',
+            0,
+            new StringType(),
+        ),
+    ]);
 
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Symfony\Component\Debug\Debug' => 'Symfony\Component\ErrorHandler\Debug',

--- a/config/sets/symfony/symfony60.php
+++ b/config/sets/symfony/symfony60.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
@@ -36,7 +37,18 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->ruleWithConfiguration(AddParamTypeDeclarationRector::class, [
-        new AddParamTypeDeclaration('Symfony\Component\Config\Loader\LoaderInterface', 'load', 0, new MixedType(true)),
+        new AddParamTypeDeclaration(
+            'Symfony\Component\Config\Loader\LoaderInterface',
+            'load',
+            0,
+            new MixedType(true)
+        ),
+        new AddParamTypeDeclaration(
+            'Symfony\Component\Config\Loader\LoaderInterface',
+            'supports',
+            0,
+            new MixedType(true)
+        ),
         new AddParamTypeDeclaration(
             'Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait',
             'configureRoutes',


### PR DESCRIPTION
See: 
https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Core/User/UserProviderInterface.php vs https://github.com/symfony/symfony/blob/5.0/src/Symfony/Component/Security/Core/User/UserProviderInterface.php

and

https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php vs https://github.com/symfony/symfony/blob/5.0/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php


and
https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Config/Loader/LoaderInterface.php vs 
https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/Config/Loader/LoaderInterface.php
