### PR TITLE
Do not change method if name does not need to change

### DIFF
--- a/rules/CodeQuality/Rector/ClassMethod/ActionSuffixRemoverRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ActionSuffixRemoverRector.php
@@ -72,16 +72,18 @@ CODE_SAMPLE
             return null;
         }
 
-        $this->removeSuffix($node, 'Action');
-
-        return $node;
+        return $this->removeSuffix($node, 'Action');
     }
 
-    private function removeSuffix(ClassMethod $classMethod, string $suffixToRemove): void
+    private function removeSuffix(ClassMethod $classMethod, string $suffixToRemove): ?ClassMethod
     {
         $name = $this->nodeNameResolver->getName($classMethod);
 
         $newName = Strings::replace($name, sprintf('#%s$#', $suffixToRemove), '');
+        if ($newName === $name) {
+            return null;
+        }
         $classMethod->name = new Identifier($newName);
+        return $classMethod;
     }
 }


### PR DESCRIPTION
The `ActionSuffixRemoverRector` did not check if the new name was the same as the previous name and always tried to change it, resulting in the rule being reapplied with no need for it. This PR checks if the name needs to change and only updates the method if that is the case