### PR TITLE
[Symfony] Add attribute routing with mix other annotation

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineClassRoutePrefixRector/Fixture/attribute_routing_class_with_other_annotation.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineClassRoutePrefixRector/Fixture/attribute_routing_class_with_other_annotation.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\InlineClassRoutePrefixRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[\Symfony\Component\Routing\Attribute\Route("/city")]
+final class AttributeRoutingWithOtherAnnotation extends Controller
+{
+    /**
+     * @return string
+     */
+    #[\Symfony\Component\Routing\Attribute\Route("/street")]
+    public function some()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\InlineClassRoutePrefixRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class AttributeRoutingWithOtherAnnotation extends Controller
+{
+    /**
+     * @return string
+     */
+    #[\Symfony\Component\Routing\Attribute\Route('/city/street')]
+    public function some()
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
@TomasVotruba this is failing fixture for `findManyByMany()` method at

https://github.com/rectorphp/rector-doctrine/commit/10aecf948db92008c29cefd4cbd1abc6fc777c55#commitcomment-152604254