### PR TITLE
Skip excluded tag in container

### DIFF
--- a/rules-tests/Configs/Rector/Closure/ServiceSetStringNameToClassNameRector/Fixture/skip_excluded_tag.php.inc
+++ b/rules-tests/Configs/Rector/Closure/ServiceSetStringNameToClassNameRector/Fixture/skip_excluded_tag.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Symfony\Tests\Configs\Rector\Closure\ServiceSetStringNameToClassNameRector\Fixture;
+
+use Rector\Symfony\Tests\Configs\Rector\Closure\ServiceSetStringNameToClassNameRector\Source\ExcludedService;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set('excluded', ExcludedService::class);
+};

--- a/rules-tests/Configs/Rector/Closure/ServiceSetStringNameToClassNameRector/Source/ExcludedService.php
+++ b/rules-tests/Configs/Rector/Closure/ServiceSetStringNameToClassNameRector/Source/ExcludedService.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\Closure\ServiceSetStringNameToClassNameRector\Source;
+
+final class ExcludedService
+{
+
+}

--- a/rules-tests/Configs/Rector/Closure/ServiceSetStringNameToClassNameRector/xml/services.xml
+++ b/rules-tests/Configs/Rector/Closure/ServiceSetStringNameToClassNameRector/xml/services.xml
@@ -5,5 +5,8 @@
         <service id="second_use" class="Rector\Symfony\Tests\Configs\Rector\Closure\ServiceSetStringNameToClassNameRector\Source\SomeServiceType"></service>
 
         <service id="some_unique_name" class="Rector\Symfony\Tests\Configs\Rector\Closure\ServiceSetStringNameToClassNameRector\Source\UniqueServiceType"></service>
+        <service id="excluded" class="Rector\Symfony\Tests\Configs\Rector\Closure\ServiceSetStringNameToClassNameRector\Source\ExcludedService">
+            <tag name="container.excluded"/>
+        </service>
     </services>
 </container>

--- a/src/ValueObjectFactory/ServiceMapFactory.php
+++ b/src/ValueObjectFactory/ServiceMapFactory.php
@@ -47,6 +47,10 @@ final class ServiceMapFactory
             $def = $this->convertXmlToArray($def);
             $tags = $this->createTagFromXmlElement($def);
 
+            if (in_array('container.excluded', array_column($tags, 'name'), true)) {
+                continue;
+            }
+
             $service = $this->createServiceFromXmlAndTagsData($attrs, $tags);
             if ($service->getAlias() !== null) {
                 $aliases[] = $service;


### PR DESCRIPTION
Since https://github.com/symfony/symfony/pull/46279, Symfony Dependency Injection add the "container.exclude" to auto-discovered classes that are excluded by manual config. I also have made a pull request https://github.com/symfony/symfony/pull/50452 which solved the problem with displaying services in the console. But Rector does not consider this in any way. This PR solves this problem and also closes the issue #709