### PR TITLE
[CodeQuality] Handle crash on no extensions on StringExtensionToConfigBuilderRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector/Fixture/skip_no_extension.php.inc
+++ b/rules-tests/CodeQuality/Rector/Closure/StringExtensionToConfigBuilderRector/Fixture/skip_no_extension.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Http\Discovery\Psr17Factory;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->alias(RequestFactoryInterface::class, 'http_discovery.psr17_factory');
+
+    $services->alias(ResponseFactoryInterface::class, 'http_discovery.psr17_factory');
+
+    $services->alias(ServerRequestFactoryInterface::class, 'http_discovery.psr17_factory');
+
+    $services->alias(StreamFactoryInterface::class, 'http_discovery.psr17_factory');
+
+    $services->alias(UploadedFileFactoryInterface::class, 'http_discovery.psr17_factory');
+
+    $services->alias(UriFactoryInterface::class, 'http_discovery.psr17_factory');
+
+    $services->set('http_discovery.psr17_factory', Psr17Factory::class);
+};

--- a/src/NodeAnalyzer/SymfonyClosureExtensionMatcher.php
+++ b/src/NodeAnalyzer/SymfonyClosureExtensionMatcher.php
@@ -29,6 +29,10 @@ final readonly class SymfonyClosureExtensionMatcher
                 return null;
             }
 
+            if ($extensionNames === []) {
+                return null;
+            }
+
             // warn use early about it, to avoid silent skip
             $errorMessage = sprintf(
                 'Split extensions "%s" to multiple separated files first',


### PR DESCRIPTION
Fixes https://github.com/rectorphp/rector-symfony/issues/663
Ref https://getrector.com/demo/de776077-7f25-484f-bfea-1f5cf23a0443

instead of crash, this patch skip it.