### PR TITLE
Update fixture on parent construct empty usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpstan/phpstan": "^2.1.8",
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^11.4",
-        "rector/rector-src": "dev-main",
+        "rector/rector-src": "dev-follow-empty-param",
         "rector/type-perfect": "^2.0",
         "symfony/config": "^6.4",
         "symfony/dependency-injection": "^6.4",

--- a/rules-tests/DependencyInjection/Rector/Class_/CommandGetByTypeToConstructorInjectionRector/CommandGetByTypeToConstructorInjectionRectorTest.php
+++ b/rules-tests/DependencyInjection/Rector/Class_/CommandGetByTypeToConstructorInjectionRector/CommandGetByTypeToConstructorInjectionRectorTest.php
@@ -6,8 +6,10 @@ namespace Rector\Symfony\Tests\DependencyInjection\Rector\Class_\CommandGetByTyp
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunClassInSeparateProcess;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
+#[RunClassInSeparateProcess]
 final class CommandGetByTypeToConstructorInjectionRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]

--- a/rules-tests/DependencyInjection/Rector/Class_/GetBySymfonyStringToConstructorInjectionRector/Fixture/command_validator.php.inc
+++ b/rules-tests/DependencyInjection/Rector/Class_/GetBySymfonyStringToConstructorInjectionRector/Fixture/command_validator.php.inc
@@ -24,6 +24,7 @@ final class CommandValidator extends ContainerAwareCommand
 {
     public function __construct(private readonly \Symfony\Component\Validator\Validator\ValidatorInterface $validator)
     {
+        parent::__construct();
     }
     public function configure()
     {

--- a/rules-tests/DependencyInjection/Rector/Class_/GetBySymfonyStringToConstructorInjectionRector/GetBySymfonyStringToConstructorInjectionRectorTest.php
+++ b/rules-tests/DependencyInjection/Rector/Class_/GetBySymfonyStringToConstructorInjectionRector/GetBySymfonyStringToConstructorInjectionRectorTest.php
@@ -6,8 +6,10 @@ namespace Rector\Symfony\Tests\DependencyInjection\Rector\Class_\GetBySymfonyStr
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunClassInSeparateProcess;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
+#[RunClassInSeparateProcess]
 final class GetBySymfonyStringToConstructorInjectionRectorTest extends AbstractRectorTestCase
 {
     #[DataProvider('provideData')]


### PR DESCRIPTION
Ref use of rector-src dev-follow-empty-param

- https://github.com/rectorphp/rector-src/pull/6855

use `#[RunClassInSeparateProcess]` as seems `ClassReflection` share cached across test parent.