### PR TITLE
Remove NodeNameResolver->getShortName() on Rector rules

### DIFF
--- a/rules/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector.php
+++ b/rules/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
+use Rector\CodingStyle\Naming\ClassNaming;
 use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\ApplicationMetadata\ListenerServiceDefinitionProvider;
@@ -42,6 +43,7 @@ final class EventListenerToEventSubscriberRector extends AbstractRector
         private readonly GetSubscribedEventsClassMethodFactory $getSubscribedEventsClassMethodFactory,
         private readonly ClassAnalyzer $classAnalyzer,
         private readonly PhpAttributeAnalyzer $phpAttributeAnalyzer,
+        private readonly ClassNaming $classNaming
     ) {
         $this->eventNamesToClassConstants = [
             // kernel events
@@ -151,7 +153,7 @@ CODE_SAMPLE
     {
         $class->implements[] = new FullyQualified(SymfonyClass::EVENT_SUBSCRIBER_INTERFACE);
 
-        $classShortName = $this->nodeNameResolver->getShortName($class);
+        $classShortName = $this->classNaming->getShortName($class);
 
         // remove suffix
         $classShortName = Strings::replace($classShortName, self::LISTENER_MATCH_REGEX, '$1');

--- a/rules/Symfony30/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
+++ b/rules/Symfony30/Rector/ClassMethod/RemoveDefaultGetBlockPrefixRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
+use Rector\CodingStyle\Naming\ClassNaming;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -24,7 +25,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class RemoveDefaultGetBlockPrefixRector extends AbstractRector
 {
     public function __construct(
-        private readonly ValueResolver $valueResolver
+        private readonly ValueResolver $valueResolver,
+        private readonly ClassNaming $classNaming
     ) {
     }
 
@@ -101,7 +103,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $shortClassName = $this->nodeNameResolver->getShortName($className);
+            $shortClassName = $this->classNaming->getShortName($className);
             if (\str_ends_with($shortClassName, 'Type')) {
                 $shortClassName = (string) Strings::before($shortClassName, 'Type');
             }


### PR DESCRIPTION
To clear use of protected property of NodeNameResolver on rector rules, use ClassNaming instead, Ref https://github.com/rectorphp/rector-symfony/pull/768#pullrequestreview-2834093699