### PR TITLE
[Symfony 7.3] Fix typo Symfony Argument class attribute

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command.php.inc
@@ -45,7 +45,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class SomeCommand
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Command\Argument]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_method_chaining.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_method_chaining.php.inc
@@ -46,7 +46,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class SomeCommandWithMethodChaining
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Command\Argument]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
@@ -51,7 +51,7 @@ final class SomeCommandWithSetHelp
         $this->setHelp('argument');
     }
 
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Command\Argument]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {

--- a/src/Enum/SymfonyAttribute.php
+++ b/src/Enum/SymfonyAttribute.php
@@ -24,7 +24,7 @@ final class SymfonyAttribute
     /**
      * @var string
      */
-    public const COMMAND_ARGUMENT = 'Symfony\Component\Console\Attribute\Command\Argument';
+    public const COMMAND_ARGUMENT = 'Symfony\Component\Console\Attribute\Argument';
 
     /**
      * @var string

--- a/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
+++ b/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
@@ -56,7 +56,7 @@ The <info>%command.name%</info> command will do some
 TXT)]
 final class SomeCommand
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Command\Argument]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {


### PR DESCRIPTION
Ref https://github.com/symfony/symfony/blob/0b4d21c3f91dd2cd2cc49739ab31a1457cf001ea/src/Symfony/Component/Console/Attribute/Argument.php#L22

Ref https://github.com/rectorphp/rector-symfony/issues/770