### PR TITLE
[Symfony 7.3] Add Argument arguments: name, mode, description on InvokableCommandInputAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command.php.inc
@@ -45,7 +45,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class SomeCommand
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_method_chaining.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_method_chaining.php.inc
@@ -46,7 +46,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class SomeCommandWithMethodChaining
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
@@ -51,7 +51,7 @@ final class SomeCommandWithSetHelp
         $this->setHelp('argument');
     }
 
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_override.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_override.php.inc
@@ -47,7 +47,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class WithOverride
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {

--- a/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
@@ -83,7 +83,7 @@ use Symfony\Component\Console\Command\Option;
 final class SomeCommand
 {
     public function __invoke(
-        #[Argument]
+        #[Argument(name: 'argument', mode: Argument::REQUIRED, description: 'Argument description')]
         string $argument,
         #[Option]
         bool $option = false,

--- a/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
@@ -155,8 +155,6 @@ CODE_SAMPLE
         // 4. remove configure() method
         $this->removeConfigureClassMethod($node);
 
-
-
         // 5. decorate __invoke method with attributes
         $invokeParams = $this->commandInvokeParamsFactory->createParams($commandArguments, $commandOptions);
         $executeClassMethod->params = $invokeParams;

--- a/rules/Symfony73/ValueObject/CommandArgument.php
+++ b/rules/Symfony73/ValueObject/CommandArgument.php
@@ -4,17 +4,29 @@ declare(strict_types=1);
 
 namespace Rector\Symfony\Symfony73\ValueObject;
 
+use PhpParser\Node\Expr;
+
 final readonly class CommandArgument
 {
     public function __construct(
-        private string $name
-        // @todo type
-        // @todo default value
+        private Expr $name,
+        private Expr $mode,
+        private Expr $description
     ) {
     }
 
-    public function getName(): string
+    public function getName(): Expr
     {
         return $this->name;
+    }
+
+    public function getMode(): Expr
+    {
+        return $this->mode;
+    }
+
+    public function getDescription(): Expr
+    {
+        return $this->description;
     }
 }

--- a/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
+++ b/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
@@ -56,7 +56,7 @@ The <info>%command.name%</info> command will do some
 TXT)]
 final class SomeCommand
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description'))]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {

--- a/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
+++ b/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
@@ -56,7 +56,7 @@ The <info>%command.name%</info> command will do some
 TXT)]
 final class SomeCommand
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description'))]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option): int
     {


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-symfony/issues/770