### PR TITLE
[Symfony 7.3] Keep $output param on InvokableCommandInputAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command.php.inc
@@ -47,7 +47,7 @@ final class SomeCommand
 {
     public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
-    $option): int
+    $option, OutputInterface $output): int
     {
         $someArgument = $argument;
         $someOption = $option;

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_method_chaining.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_method_chaining.php.inc
@@ -48,7 +48,7 @@ final class SomeCommandWithMethodChaining
 {
     public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
-    $option): int
+    $option, OutputInterface $output): int
     {
         $someArgument = $argument;
         $someOption = $option;

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
@@ -53,7 +53,7 @@ final class SomeCommandWithSetHelp
 
     public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
-    $option): int
+    $option, OutputInterface $output): int
     {
         $someArgument = $argument;
         $someOption = $option;

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_override.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_override.php.inc
@@ -49,7 +49,7 @@ final class WithOverride
 {
     public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
-    $option): int
+    $option, OutputInterface $output): int
     {
         $someArgument = $argument;
         $someOption = $option;

--- a/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
@@ -157,7 +157,7 @@ CODE_SAMPLE
 
         // 5. decorate __invoke method with attributes
         $invokeParams = $this->commandInvokeParamsFactory->createParams($commandArguments, $commandOptions);
-        $executeClassMethod->params = $invokeParams;
+        $executeClassMethod->params = array_merge($invokeParams, [$executeClassMethod->params[1]]);
 
         // 6. remove parent class
         $node->extends = null;

--- a/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
+++ b/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
@@ -58,7 +58,7 @@ final class SomeCommand
 {
     public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
-    $option): int
+    $option, OutputInterface $output): int
     {
         $someArgument = $argument;
         $someOption = $option;


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-symfony/issues/770