### PR TITLE
[Symfony 7.3] Make nullable argument param type on Optional InputArgument::OPTIONAL on InvokableCommandInputAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_optional_argument.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_optional_argument.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name')]
+final class WithOptionalArgument extends Command
+{
+    public function configure()
+    {
+        $this->addArgument('argument', InputArgument::OPTIONAL, 'Argument description');
+        $this->addOption('option', 'o', InputOption::VALUE_NONE, 'Option description');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $someArgument = $input->getArgument('argument');
+        $someOption = $input->getOption('option');
+
+        // ...
+
+        return 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name')]
+final class WithOptionalArgument
+{
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::OPTIONAL, description: 'Argument description')]
+    ?string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
+    $option, OutputInterface $output): int
+    {
+        $someArgument = $argument;
+        $someOption = $option;
+
+        // ...
+
+        return 1;
+    }
+}
+
+?>

--- a/rules/Symfony73/NodeFactory/CommandInvokeParamsFactory.php
+++ b/rules/Symfony73/NodeFactory/CommandInvokeParamsFactory.php
@@ -10,6 +10,7 @@ use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Symfony\Enum\SymfonyAttribute;
@@ -50,6 +51,12 @@ final readonly class CommandInvokeParamsFactory
             )));
 
             $argumentParam->type = new Identifier('string');
+
+            $modeValue = $this->valueResolver->getValue($commandArgument->getMode());
+            if ($modeValue === null || $modeValue === 2) {
+                $argumentParam->type = new NullableType($argumentParam->type);
+            }
+
             // @todo fill type or default value
             // @todo default string, multiple values array
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-symfony/issues/770