### PR TITLE
[Symfony 7.3] Remove Argument argument: mode on InvokableCommandInputAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command.php.inc
@@ -45,7 +45,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class SomeCommand
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option, OutputInterface $output): int
     {

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_method_chaining.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_method_chaining.php.inc
@@ -46,7 +46,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class SomeCommandWithMethodChaining
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option, OutputInterface $output): int
     {

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
@@ -51,7 +51,7 @@ final class SomeCommandWithSetHelp
         $this->setHelp('argument');
     }
 
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option, OutputInterface $output): int
     {

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_optional_argument.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_optional_argument.php.inc
@@ -45,7 +45,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class WithOptionalArgument
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::OPTIONAL, description: 'Argument description')]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', description: 'Argument description')]
     ?string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option, OutputInterface $output): int
     {

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_override.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_override.php.inc
@@ -47,7 +47,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class WithOverride
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option, OutputInterface $output): int
     {

--- a/rules/Symfony73/NodeFactory/CommandInvokeParamsFactory.php
+++ b/rules/Symfony73/NodeFactory/CommandInvokeParamsFactory.php
@@ -65,7 +65,6 @@ final readonly class CommandInvokeParamsFactory
                     new FullyQualified(SymfonyAttribute::COMMAND_ARGUMENT),
                     [
                         new Arg(value: $commandArgument->getName(), name: new Identifier('name')),
-                        new Arg(value: $commandArgument->getMode(), name: new Identifier('mode')),
                         new Arg(value: $commandArgument->getDescription(), name: new Identifier('description')),
                     ]
                 ),

--- a/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
@@ -83,7 +83,7 @@ use Symfony\Component\Console\Command\Option;
 final class SomeCommand
 {
     public function __invoke(
-        #[Argument(name: 'argument', mode: Argument::REQUIRED, description: 'Argument description')]
+        #[Argument(name: 'argument', description: 'Argument description')]
         string $argument,
         #[Option]
         bool $option = false,

--- a/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
+++ b/tests/Set/Symfony73/Fixture/command_remove_config.php.inc
@@ -56,7 +56,7 @@ The <info>%command.name%</info> command will do some
 TXT)]
 final class SomeCommand
 {
-    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', mode: InputArgument::REQUIRED, description: 'Argument description')]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument', description: 'Argument description')]
     string $argument, #[\Symfony\Component\Console\Attribute\Command\Option]
     $option, OutputInterface $output): int
     {


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-symfony/issues/770