### PR TITLE
[Symfony 7.3] Make __invoke() public in InvokableCommandInputAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/name_from_constant.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/name_from_constant.php.inc
@@ -52,7 +52,7 @@ class NameFromConstant
 {
     private const string ARGUMENT_NAME = 'name';
 
-    protected function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: self::ARGUMENT_NAME, description: 'The name of the person to greet.')]
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: self::ARGUMENT_NAME, description: 'The name of the person to greet.')]
     ?string $name, OutputInterface $output): int
     {
         $name = $name;

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command_with_set_help.php.inc
@@ -12,14 +12,14 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class SomeCommandWithSetHelp extends Command
 {
-    public function configure()
+    protected function configure()
     {
         $this->setHelp('argument');
         $this->addArgument('argument', InputArgument::REQUIRED, 'Argument description');
         $this->addOption('option', 'o', InputOption::VALUE_NONE, 'Option description');
     }
 
-    public function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $someArgument = $input->getArgument('argument');
         $someOption = $input->getOption('option');
@@ -46,7 +46,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class SomeCommandWithSetHelp
 {
-    public function configure()
+    protected function configure()
     {
         $this->setHelp('argument');
     }

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_optional_argument.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_optional_argument.php.inc
@@ -12,13 +12,13 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'some_name')]
 final class WithOptionalArgument extends Command
 {
-    public function configure()
+    protected function configure()
     {
         $this->addArgument('argument', InputArgument::OPTIONAL, 'Argument description');
         $this->addOption('option', 'o', InputOption::VALUE_NONE, 'Option description');
     }
 
-    public function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $someArgument = $input->getArgument('argument');
         $someOption = $input->getOption('option');

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_override.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_override.php.inc
@@ -13,14 +13,14 @@ use Symfony\Component\Console\Input\InputOption;
 final class WithOverride extends Command
 {
     #[\Override]
-    public function configure()
+    protected function configure()
     {
         $this->addArgument('argument', InputArgument::REQUIRED, 'Argument description');
         $this->addOption('option', 'o', InputOption::VALUE_NONE, 'Option description');
     }
 
     #[\Override]
-    public function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $someArgument = $input->getArgument('argument');
         $someOption = $input->getOption('option');

--- a/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Stmt\Expression;
 use Rector\Doctrine\NodeAnalyzer\AttributeFinder;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\Enum\CommandMethodName;
 use Rector\Symfony\Enum\SymfonyAttribute;
@@ -42,7 +43,8 @@ final class InvokableCommandInputAttributeRector extends AbstractRector
         private readonly AttributeFinder $attributeFinder,
         private readonly CommandArgumentsAndOptionsResolver $commandArgumentsAndOptionsResolver,
         private readonly CommandInvokeParamsFactory $commandInvokeParamsFactory,
-        private readonly ValueResolver $valueResolver
+        private readonly ValueResolver $valueResolver,
+        private readonly VisibilityManipulator $visibilityManipulator,
     ) {
     }
 
@@ -147,6 +149,7 @@ CODE_SAMPLE
         }
 
         $executeClassMethod->name = new Identifier('__invoke');
+        $this->visibilityManipulator->makePublic($executeClassMethod);
 
         // 3. create arguments and options parameters
         // @todo


### PR DESCRIPTION
```
Warning: The magic method App\Command\HelloCommand::__invoke() must have public visibility
```

Ref #770 