### PR TITLE
fix: Normalize variable names by replacing hyphens with underscores in Symfony73 command argument and option processing

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/name_with_hyphen.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/name_with_hyphen.php.inc
@@ -1,0 +1,56 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:hello',
+)]
+class NameWithHyphen extends Command
+{
+    protected function configure(): void
+    {
+        $this->addArgument('argument-with-hyphen', InputArgument::OPTIONAL, 'Argument description');
+        $this->addOption('option-with-hyphen');
+    }
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $argument = $input->getArgument('argument-with-hyphen');
+        $option = $input->getOption('option-with-hyphen');
+        return Command::SUCCESS;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:hello',
+)]
+class NameWithHyphen
+{
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument-with-hyphen', description: 'Argument description')]
+    ?string $argument_with_hyphen, #[\Symfony\Component\Console\Attribute\Command\Option]
+    $option_with_hyphen, OutputInterface $output): int
+    {
+        $argument = $argument_with_hyphen;
+        $option = $option_with_hyphen;
+        return Command::SUCCESS;
+    }
+}
+
+?>

--- a/rules/Symfony73/NodeFactory/CommandInvokeParamsFactory.php
+++ b/rules/Symfony73/NodeFactory/CommandInvokeParamsFactory.php
@@ -46,9 +46,10 @@ final readonly class CommandInvokeParamsFactory
         $argumentParams = [];
 
         foreach ($commandArguments as $commandArgument) {
-            $argumentParam = new Param(new Variable((string) $this->valueResolver->getValue(
-                $commandArgument->getName()
-            )));
+            $argumentName = (string) $this->valueResolver->getValue($commandArgument->getName());
+            $variableName = str_replace('-', '_', $argumentName);
+
+            $argumentParam = new Param(new Variable($variableName));
 
             $argumentParam->type = new Identifier('string');
 
@@ -85,8 +86,10 @@ final readonly class CommandInvokeParamsFactory
         $optionParams = [];
 
         foreach ($commandOptions as $commandOption) {
-            $optionParam = new Param(new Variable($commandOption->getName()));
+            $optionName = $commandOption->getName();
+            $variableName = str_replace('-', '_', $optionName);
 
+            $optionParam = new Param(new Variable($variableName));
             // @todo fill type or default value
             $optionParam->attrGroups[] = new AttributeGroup([
                 new Attribute(new FullyQualified(SymfonyAttribute::COMMAND_OPTION)),

--- a/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
@@ -259,7 +259,8 @@ CODE_SAMPLE
                 ->value;
 
             if ($firstArgValue instanceof ClassConstFetch || $firstArgValue instanceof ConstFetch) {
-                return new Variable($this->valueResolver->getValue($firstArgValue));
+                $variableName = $this->valueResolver->getValue($firstArgValue);
+                return new Variable(str_replace('-', '_', $variableName));
             }
 
             if (! $firstArgValue instanceof String_) {
@@ -267,7 +268,8 @@ CODE_SAMPLE
                 throw new ShouldNotHappenException();
             }
 
-            return new Variable($firstArgValue->value);
+            $variableName = $firstArgValue->value;
+            return new Variable(str_replace('-', '_', $variableName));
         });
     }
 


### PR DESCRIPTION
Normalize variable names by replacing hyphens with underscores in Symfony73 command argument and option processing

Fixes https://github.com/rectorphp/rector/issues/9205