### PR TITLE
Console attributes: wrong argument/option order 

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_multiple_arguments_options.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_multiple_arguments_options.php.inc
@@ -1,0 +1,71 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name')]
+final class SomeCommand extends Command
+{
+    public function configure()
+    {
+        $this
+            ->addArgument('argument1', InputArgument::REQUIRED, 'Argument1 description')
+            ->addArgument('argument2', InputArgument::REQUIRED, 'Argument2 description')
+            ->addOption('option1', 'o', InputOption::VALUE_NONE, 'Option1 description')
+            ->addOption('option2', 'p', InputOption::VALUE_NONE, 'Option2 description')
+        ;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $arg1 = $input->getArgument('argument1');
+        $arg2 = $input->getArgument('argument2');
+        $opt1 = $input->getOption('option1');
+        $opt2 = $input->getOption('option2');
+
+        // ...
+
+        return 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name')]
+final class SomeCommand
+{
+    public function __invoke(#[\Symfony\Component\Console\Attribute\Argument(name: 'argument1', description: 'Argument1 description')]
+    string $argument1, #[\Symfony\Component\Console\Attribute\Argument(name: 'argument2', description: 'Argument2 description')]
+    string $argument2, #[\Symfony\Component\Console\Attribute\Option]
+    $option1, #[\Symfony\Component\Console\Attribute\Option]
+    $option2, OutputInterface $output): int
+    {
+        $arg1 = $argument1;
+        $arg2 = $argument2;
+        $opt1 = $option1;
+        $opt2 = $option2;
+
+        // ...
+
+        return 1;
+    }
+}
+
+?>


### PR DESCRIPTION
When using chained methods in `configure`, the result contains the arguments/options in wrong order.