### PR TITLE
[CodeQuality] Skip first class callable on StringCastDebugResponseRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/StringCastDebugResponseRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/StringCastDebugResponseRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\MethodCall\StringCastDebugResponseRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SkipFirstClassCallable extends TestCase
+{
+    public function test(Response $response)
+    {
+        $this->assertSame(...);
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/StringCastDebugResponseRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/StringCastDebugResponseRector.php
@@ -82,6 +82,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+
         // there cannot be any custom message
         $args = $node->getArgs();
         if (count($args) !== 3) {


### PR DESCRIPTION
Avoid error:

```
There was 1 failure:

1) Rector\Symfony\Tests\CodeQuality\Rector\MethodCall\StringCastDebugResponseRector\StringCastDebugResponseRectorTest::test with data set #0 ('/Users/samsonasik/www/rector-...hp.inc')
assert(!$this->isFirstClassCallable())

/Users/samsonasik/www/rector-symfony/vendor/nikic/php-parser/lib/PhpParser/Node/Expr/CallLike.php:32
/Users/samsonasik/www/rector-symfony/rules/CodeQuality/Rector/MethodCall/StringCastDebugResponseRector.php:86
```