### PR TITLE
Twig attributes: make methods public

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/with_first_class_callable_filter.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/with_first_class_callable_filter.php.inc
@@ -10,10 +10,22 @@ final class WithFirstClassCallableFilter extends AbstractExtension
     {
         return [
             new \Twig\TwigFilter('some_filter', $this->someFilter(...)),
+            new \Twig\TwigFilter('another_filter', $this->anotherFilter(...)),
+            new \Twig\TwigFilter('third_filter', $this->thirdFilter(...)),
         ];
     }
 
     public function someFilter($value)
+    {
+        return $value;
+    }
+
+    protected function anotherFilter($value)
+    {
+        return $value;
+    }
+
+    private function thirdFilter($value)
     {
         return $value;
     }
@@ -31,6 +43,18 @@ final class WithFirstClassCallableFilter extends AbstractExtension
 {
     #[\Twig\Attribute\AsTwigFilter('some_filter')]
     public function someFilter($value)
+    {
+        return $value;
+    }
+
+    #[\Twig\Attribute\AsTwigFilter('another_filter')]
+    public function anotherFilter($value)
+    {
+        return $value;
+    }
+
+    #[\Twig\Attribute\AsTwigFilter('third_filter')]
+    public function thirdFilter($value)
     {
         return $value;
     }

--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/some_get_functions.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/some_get_functions.php.inc
@@ -11,6 +11,7 @@ final class SomeGetFunctions extends AbstractExtension
         return [
             new \Twig\TwigFunction('some_function', [$this, 'someFunction']),
             new \Twig\TwigFunction('another_function', $this->anotherFunction(...)),
+            new \Twig\TwigFunction('third_function', $this->thirdFunction(...)),
         ];
     }
 
@@ -19,7 +20,12 @@ final class SomeGetFunctions extends AbstractExtension
         return $value;
     }
 
-    public function anotherFunction($value)
+    protected function anotherFunction($value)
+    {
+        return $value;
+    }
+
+    private function thirdFunction($value)
     {
         return $value;
     }
@@ -43,6 +49,12 @@ final class SomeGetFunctions extends AbstractExtension
 
     #[\Twig\Attribute\AsTwigFunction('another_function')]
     public function anotherFunction($value)
+    {
+        return $value;
+    }
+
+    #[\Twig\Attribute\AsTwigFunction('third_function')]
+    public function thirdFunction($value)
     {
         return $value;
     }

--- a/rules/Symfony73/GetMethodToAsTwigAttributeTransformer.php
+++ b/rules/Symfony73/GetMethodToAsTwigAttributeTransformer.php
@@ -18,6 +18,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Symfony\Symfony73\NodeAnalyzer\LocalArrayMethodCallableMatcher;
 use Rector\Symfony\Symfony73\NodeRemover\ReturnEmptyArrayMethodRemover;
 
@@ -29,7 +30,8 @@ final readonly class GetMethodToAsTwigAttributeTransformer
     public function __construct(
         private LocalArrayMethodCallableMatcher $localArrayMethodCallableMatcher,
         private ReturnEmptyArrayMethodRemover $returnEmptyArrayMethodRemover,
-        private ReflectionProvider $reflectionProvider
+        private ReflectionProvider $reflectionProvider,
+        private VisibilityManipulator $visibilityManipulator
     ) {
     }
 
@@ -96,6 +98,7 @@ final readonly class GetMethodToAsTwigAttributeTransformer
                     }
 
                     $this->decorateMethodWithAttribute($localMethod, $attributeClass, $nameArg);
+                    $this->visibilityManipulator->makePublic($localMethod);
 
                     // remove old new fuction instance
                     unset($returnArray->items[$key]);


### PR DESCRIPTION
My twig function/filter methods are often private. But when using the new attributes, they have to be public.