### PR TITLE
[Symfony 73] add ConstraintOptionsToNamedArgumentsRector

### DIFF
--- a/config/sets/symfony/symfony7/symfony73.php
+++ b/config/sets/symfony/symfony7/symfony73.php
@@ -10,4 +10,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/symfony73/symfony73-console.php');
     $rectorConfig->import(__DIR__ . '/symfony73/symfony73-security-core.php');
     $rectorConfig->import(__DIR__ . '/symfony73/symfony73-twig-bundle.php');
+    $rectorConfig->import(__DIR__ . '/symfony73/symfony73-validator.php');
 };

--- a/config/sets/symfony/symfony7/symfony73/symfony73-validator.php
+++ b/config/sets/symfony/symfony7/symfony73/symfony73-validator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([ConstraintOptionsToNamedArgumentsRector::class]);
+};

--- a/rules-tests/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector/ConstraintOptionsToNamedArgumentsRectorTest.php
+++ b/rules-tests/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector/ConstraintOptionsToNamedArgumentsRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConstraintOptionsToNamedArgumentsRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector/Fixture/some_form.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector/Fixture/some_form.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class SomeForm extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'constraints' => [
+                    new NotBlank(['message' => 'Name is required.']),
+                ],
+            ]);
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class SomeForm extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'constraints' => [
+                    new NotBlank(message: 'Name is required.'),
+                ],
+            ]);
+    }
+}
+?>

--- a/rules-tests/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector/config/configured_rule.php
+++ b/rules-tests/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ConstraintOptionsToNamedArgumentsRector::class);
+};

--- a/rules/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector.php
+++ b/rules/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Symfony73\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ConstraintOptionsToNamedArgumentsRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ValueResolver $valueResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Refactor Symfony constraints using array options to named arguments syntax for better readability and type safety.',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+$constraint = new NotBlank(['message' => 'This field should not be blank.']);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+$constraint = new NotBlank(message: 'This field should not be blank.');
+CODE_SAMPLE
+                )]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [New_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof New_) {
+            return null;
+        }
+
+        // Match classes starting with Symfony\Component\Validator\Constraints\
+        if (!$node->class instanceof FullyQualified && !$node->class instanceof Name) {
+            return null;
+        }
+
+        $className = $this->getName($node->class);
+        if (!is_string($className)) {
+            return null;
+        }
+
+        if (!str_starts_with($className, 'Symfony\Component\Validator\Constraints\\')) {
+            return null;
+        }
+
+        if (0 === count($node->args) || !$node->args[0]->value instanceof Array_) {
+            return null;
+        }
+
+        $array = $node->args[0]->value;
+        $namedArgs = [];
+
+        foreach ($array->items as $item) {
+            if (!$item instanceof ArrayItem || null === $item->key) {
+                continue;
+            }
+
+            $keyValue = $this->valueResolver->getValue($item->key);
+            if (!is_string($keyValue)) {
+                continue;
+            }
+
+            $arg = new Node\Arg($item->value);
+            $arg->name = new Node\Identifier($keyValue);
+
+            $namedArgs[] = $arg;
+        }
+
+        $node->args = $namedArgs;
+
+        return $node;
+    }
+}

--- a/src/Set/SetProvider/Symfony7SetProvider.php
+++ b/src/Set/SetProvider/Symfony7SetProvider.php
@@ -104,6 +104,12 @@ final class Symfony7SetProvider implements SetProviderInterface
                 '7.3',
                 __DIR__ . '/../../../config/sets/symfony/symfony7/symfony73/symfony73-twig-bundle.php'
             ),
+            new ComposerTriggeredSet(
+                SetGroup::SYMFONY,
+                'symfony/validator',
+                '7.3',
+                __DIR__ . '/../../../config/sets/symfony/symfony7/symfony73/symfony73-validator.php'
+            ),
         ];
     }
 }


### PR DESCRIPTION
This PR adds new rector to fix deprecation introduced in Symfony 7.3 validator

Passing an array of options to configure the "%s" constraint is deprecated, use named arguments instead.