### PR TITLE
[SYMFONY 5.1] replace Cookie withSameSite argument values with constants

### DIFF
--- a/config/sets/symfony/symfony5/symfony51.php
+++ b/config/sets/symfony/symfony5/symfony51.php
@@ -16,5 +16,4 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/symfony51/symfony51-inflector.php');
     $rectorConfig->import(__DIR__ . '/symfony51/symfony51-notifier.php');
     $rectorConfig->import(__DIR__ . '/symfony51/symfony51-security-http.php');
-
 };

--- a/config/sets/symfony/symfony5/symfony51/symfony51-http-foundation.php
+++ b/config/sets/symfony/symfony5/symfony51/symfony51-http-foundation.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Rector\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector;
+use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\Config\RectorConfig;
 use Rector\Transform\Rector\StaticCall\StaticCallToNewRector;
 use Rector\Transform\ValueObject\StaticCallToNew;
@@ -12,5 +14,28 @@ return static function (RectorConfig $rectorConfig): void {
         new StaticCallToNew('Symfony\Component\HttpFoundation\JsonResponse', 'create'),
         new StaticCallToNew('Symfony\Component\HttpFoundation\RedirectResponse', 'create'),
         new StaticCallToNew('Symfony\Component\HttpFoundation\StreamedResponse', 'create'),
+    ]);
+    $rectorConfig->ruleWithConfiguration(ReplaceArgumentDefaultValueRector::class, [
+        new ReplaceArgumentDefaultValue(
+            'Symfony\Component\HttpFoundation\Cookie',
+            'withSameSite',
+            0,
+            'none',
+            'Symfony\Component\HttpFoundation\Cookie::SAMESITE_NONE'
+        ),
+        new ReplaceArgumentDefaultValue(
+            'Symfony\Component\HttpFoundation\Cookie',
+            'withSameSite',
+            0,
+            'lax',
+            'Symfony\Component\HttpFoundation\Cookie::SAMESITE_LAX'
+        ),
+        new ReplaceArgumentDefaultValue(
+            'Symfony\Component\HttpFoundation\Cookie',
+            'withSameSite',
+            0,
+            'strict',
+            'Symfony\Component\HttpFoundation\Cookie::SAMESITE_STRICT'
+        ),
     ]);
 };

--- a/tests/Set/Symfony51/Fixture/replace_cookie_with_same_site_parameter_value.php.inc
+++ b/tests/Set/Symfony51/Fixture/replace_cookie_with_same_site_parameter_value.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Symfony\Tests\Set\Symfony51\Fixture;
+
+use Symfony\Component\HttpFoundation\Cookie;
+
+class ReplaceCookieWithSameSiteParameterValue
+{
+    public function run()
+    {
+        $cookie = Cookie::create('name');
+        $cookie->withSameSite('none');
+
+        return $cookie;
+    }
+}
+
+?>
+
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Set\Symfony51\Fixture;
+
+use Symfony\Component\HttpFoundation\Cookie;
+
+class ReplaceCookieWithSameSiteParameterValue
+{
+    public function run()
+    {
+        $cookie = Cookie::create('name');
+        $cookie->withSameSite(\Symfony\Component\HttpFoundation\Cookie::SAMESITE_NONE);
+
+        return $cookie;
+    }
+}
+
+?>

--- a/tests/Set/Symfony51/Symfony51Test.php
+++ b/tests/Set/Symfony51/Symfony51Test.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Set\Symfony51;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Symfony51Test extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/symfony51.php';
+    }
+}

--- a/tests/Set/Symfony51/config/symfony51.php
+++ b/tests/Set/Symfony51/config/symfony51.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([SymfonySetList::SYMFONY_51]);
+};


### PR DESCRIPTION
See: https://github.com/rectorphp/rector/issues/9256

On hold see: https://github.com/rectorphp/rector-src/pull/7068