### PR TITLE
Update Fixtures for GetFunctionsToAsTwigFunctionAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_difference_class.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_difference_class.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector\Fixture;
+
+use Twig\Extension\AbstractExtension;
+
+final class SkipDifferentClass extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new \Twig\TwigFunction('some_function', [DifferentClass::class, 'someFunction']),
+            new \Twig\TwigFunction('some_function', $this->someFunction(...)),
+        ];
+    }
+
+    public function someFunction($value)
+    {
+        return $value;
+    }
+}
+
+?>

--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/some_get_functions.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/some_get_functions.php.inc
@@ -37,9 +37,7 @@ final class SomeGetFunctions extends AbstractExtension
 
 namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector\Fixture;
 
-use Twig\Extension\AbstractExtension;
-
-final class SomeGetFunctions extends AbstractExtension
+final class SomeGetFunctions
 {
     #[\Twig\Attribute\AsTwigFunction('some_function')]
     public function someFunction($value)


### PR DESCRIPTION
As requested in rectorphp/rector#9361, here is a draft Pull Request with :
- New fixture for the case with a static method from an other class in the file
- Updated fixtures for the valid case to remove the extends of `AbstractExtension`