### PR TITLE
Keep AsCommand in InvokableCommandInputAttributeRector documentation

### DIFF
--- a/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
@@ -82,10 +82,12 @@ final class SomeCommand extends Command
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Argument;
 use Symfony\Component\Console\Option;
 
+#[AsCommand(name: 'some_name')]
 final class SomeCommand
 {
     public function __invoke(


### PR DESCRIPTION
This rule does not touch the `AsCommand` attribute at all, as it shouldn't because otherwise it would no longer be a command!

See also for examples this [test](https://github.com/rectorphp/rector-symfony/blob/main/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/some_command.php.inc).