### PR TITLE
[CodeQuality] Skip first class callable on ParameterBagTypedGetMethodCallRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/MethodCall/ParameterBagTypedGetMethodCallRector/Fixture/skip_first_class_callable.php.inc
+++ b/rules-tests/CodeQuality/Rector/MethodCall/ParameterBagTypedGetMethodCallRector/Fixture/skip_first_class_callable.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\MethodCall\ParameterBagTypedGetMethodCallRector\Fixture;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class SkipFirstClassCallable
+{
+    public function run(Request $request)
+    {
+        $debug = (bool) $request->query->get(...);
+    }
+}

--- a/rules/CodeQuality/Rector/MethodCall/ParameterBagTypedGetMethodCallRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/ParameterBagTypedGetMethodCallRector.php
@@ -88,6 +88,10 @@ CODE_SAMPLE
 
     private function refactorMethodCall(MethodCall $methodCall): ?MethodCall
     {
+        if ($methodCall->isFirstClassCallable()) {
+            return null;
+        }
+
         // default value must be defined
         if (count($methodCall->getArgs()) !== 2) {
             return null;


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-symfony/pull/834#pullrequestreview-3173259447