### PR TITLE
[Symfony73] Remove extends AbstractExtension after apply change on GetFunctionsToAsTwigFunctionAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_difference_class.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_difference_class.php.inc
@@ -10,7 +10,6 @@ final class SkipDifferentClass extends AbstractExtension
     {
         return [
             new \Twig\TwigFunction('some_function', [DifferentClass::class, 'someFunction']),
-            new \Twig\TwigFunction('some_function', $this->someFunction(...)),
         ];
     }
 

--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/some_get_functions.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/some_get_functions.php.inc
@@ -37,6 +37,8 @@ final class SomeGetFunctions extends AbstractExtension
 
 namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector\Fixture;
 
+use Twig\Extension\AbstractExtension;
+
 final class SomeGetFunctions
 {
     #[\Twig\Attribute\AsTwigFunction('some_function')]


### PR DESCRIPTION
Closes #823 Fixes https://github.com/rectorphp/rector/issues/9361