### PR TITLE
Fix typo cause error in return statement

### DIFF
--- a/rules/Configs/Rector/Closure/ServiceSettersToSettersAutodiscoveryRector.php
+++ b/rules/Configs/Rector/Closure/ServiceSettersToSettersAutodiscoveryRector.php
@@ -218,7 +218,7 @@ CODE_SAMPLE
     {
         $relativeDirectoryPath = $this->filesystem->makePathRelative(
             dirname($classFilePath),
-            dirname($this->getFile()->getFilePath())
+            dirname((string) $this->getFile()->getFilePath())
         );
 
         $distConstFetch = new ConstFetch(new Name('__DIR__'));

--- a/rules/Symfony30/Rector/MethodCall/StringFormTypeToClassRector.php
+++ b/rules/Symfony30/Rector/MethodCall/StringFormTypeToClassRector.php
@@ -73,7 +73,6 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var String_ $stringNode */
         $stringNode = $firstArg->value;
 
         // not a form type string

--- a/rules/Symfony43/Rector/MethodCall/ConvertRenderTemplateShortNotationToBundleSyntaxRector.php
+++ b/rules/Symfony43/Rector/MethodCall/ConvertRenderTemplateShortNotationToBundleSyntaxRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
         }
 
         if (! isset($matches[0])) {
-            return null;t
+            return null;
         }
 
         $newValue = '@' .

--- a/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -163,13 +163,11 @@ CODE_SAMPLE
 
     private function isIntegerTernaryIfElse(Ternary $ternary): bool
     {
-        /** @var Expr|null $if */
         $if = $ternary->if;
         if (! $if instanceof Expr) {
             $if = $ternary->cond;
         }
 
-        /** @var Expr $else */
         $else = $ternary->else;
         $ifType = $this->getType($if);
         $elseType = $this->getType($else);


### PR DESCRIPTION
@TomasVotruba commit https://github.com/rectorphp/rector-symfony/commit/7e762047bb3bbd6d6fdacb1afa8fa274a784a908#diff-9a0550d9d66fe528e4abdae40f66d7ad52032c1efa68f97b05490454e168cb7c has typo that cause error

![Screenshot_20260408_022405_Firefox](https://github.com/user-attachments/assets/0dfcd513-91d3-470b-8790-16102572b77c)

