### PR TITLE
fix(CommandHelpToAttributeRector): support concatenated string in setHelp()

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/CommandHelpToAttributeRector/Fixture/add_help_concatenated_string.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/CommandHelpToAttributeRector/Fixture/add_help_concatenated_string.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\CommandHelpToAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name')]
+final class ConcatenatedHelpStringCommand extends Command
+{
+    public function configure()
+    {
+        $this
+            ->setHelp("First line of help.\n"
+                . "Second line of help.\n"
+                . "Third line of help.")
+            ->addOption('run', null, InputOption::VALUE_NONE, 'Run mode');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\CommandHelpToAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name', help: <<<'TXT'
+First line of help.
+Second line of help.
+Third line of help.
+TXT)]
+final class ConcatenatedHelpStringCommand extends Command
+{
+    public function configure()
+    {
+        $this
+            ->addOption('run', null, InputOption::VALUE_NONE, 'Run mode');
+    }
+}
+
+?>

--- a/rules/Symfony73/Rector/Class_/CommandHelpToAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/CommandHelpToAttributeRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
@@ -150,6 +151,7 @@ CODE_SAMPLE
 
     /**
      * Returns the argument passed to setHelp() and removes the MethodCall node.
+     * Supports plain string literals and concatenated string expressions.
      */
     private function findAndRemoveSetHelpExpr(ClassMethod $configureClassMethod): ?String_
     {
@@ -174,11 +176,13 @@ CODE_SAMPLE
                     return null;
                 }
 
-                $argExpr = $node->getArgs()[0]
-                    ->value;
-                if ($argExpr instanceof String_) {
-                    $helpString = $argExpr;
+                $argExpr = $node->getArgs()[0]->value;
+                $resolvedValue = $this->resolveStringExpr($argExpr);
+                if ($resolvedValue === null) {
+                    return null;
                 }
+
+                $helpString = new String_($resolvedValue);
 
                 $parent = $node->getAttribute('parent');
                 if ($parent instanceof Expression) {
@@ -196,6 +200,31 @@ CODE_SAMPLE
         }
 
         return $helpString;
+    }
+
+    /**
+     * Resolves a scalar string expression — a plain String_ literal or a tree
+     * of Concat nodes — to its runtime string value. Returns null for any
+     * expression that contains non-literal parts (variables, function calls, …).
+     */
+    private function resolveStringExpr(Expr $expr): ?string
+    {
+        if ($expr instanceof String_) {
+            return $expr->value;
+        }
+
+        if ($expr instanceof Concat) {
+            $left = $this->resolveStringExpr($expr->left);
+            $right = $this->resolveStringExpr($expr->right);
+
+            if ($left === null || $right === null) {
+                return null;
+            }
+
+            return $left . $right;
+        }
+
+        return null;
     }
 
     private function isExpressionVariableThis(Stmt $stmt): bool


### PR DESCRIPTION
Previously the rule only handled plain String_ literals. When `setHelp()` received a Concat expression (e.g. "line one\n" . "line two") it silently dropped the call without migrating the text to `#[AsCommand(help: ...)]`, leaving the help text permanently lost.

Introduce `resolveStringExpr()` that recursively folds a Concat tree of String_ literals into a single string value. Non-literal sub-expressions (variables, function calls, …) cause the method to return null, which now also prevents the `setHelp()` removal — fixing the silent data-loss bug.

## Problem                                                                                                                                                                                                                           

   `CommandHelpToAttributeRector` only handles a plain `String_` literal as the argument to `setHelp()`. When the argument is a **concatenated string** (a tree of `Concat` nodes), the rule exhibits two bugs:

   1. **Silent data loss** — `setHelp()` is removed from the method chain (via `return $node->var` in the traversal callback) even though `$helpString` is never set, so the help text is permanently discarded.
   2. **No migration** — because `$helpString` stays `null`, `refactor()` returns `null` and nothing is added to `#[AsCommand(help: ...)]`.

   Example that triggered the bug:
   ```php
   $this
       ->setHelp("First line.\n"
           . "Second line.\n"
           . "Third line.")
       ->addOption(...)
   ```

   ## Fix

   - Add `resolveStringExpr(Expr): ?string` — recursively folds a `Concat` tree of `String_` literals into a single string value. Returns `null` for any non-literal sub-expression (variables, function calls, …).
   - Replace the inline `instanceof String_` check with a call to `resolveStringExpr()`.
   - **Crucially**, `return $node->var` (which removes `setHelp()`) now only executes when `$resolvedValue !== null` — so non-resolvable expressions are left untouched instead of being silently dropped.

   ## Test

   Added `add_help_concatenated_string.php.inc` fixture covering a `setHelp()` call with a multi-line concatenated string alongside another chained method call (`addOption`).