### PR TITLE
fix ControllerMethodInjectionToConstructorRector - update call sites when params are moved to constructor

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/internal_method_call_arg_removal.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/internal_method_call_arg_removal.php.inc
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class InternalMethodCallArgRemoval extends AbstractController
+{
+    #[Route('/some-action', name: 'some_action')]
+    public function someAction(LoggerInterface $logger)
+    {
+        $this->problematic($logger);
+    }
+
+    public function problematic(LoggerInterface $logger, ?string $optional = 'test')
+    {
+        $logger->log('level', 'value');
+        dump($optional);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class InternalMethodCallArgRemoval extends AbstractController
+{
+    public function __construct(private readonly \Psr\Log\LoggerInterface $logger)
+    {
+    }
+    #[Route('/some-action', name: 'some_action')]
+    public function someAction()
+    {
+        $this->problematic();
+    }
+
+    public function problematic(?string $optional = 'test')
+    {
+        $this->logger->log('level', 'value');
+        dump($optional);
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
+++ b/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
@@ -7,6 +7,7 @@ namespace Rector\Symfony\CodeQuality\Rector\Class_;
 use Exception;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name\FullyQualified;
@@ -137,6 +138,9 @@ CODE_SAMPLE
         /** @var array<string, string[]> $methodParamNamesToReplace */
         $methodParamNamesToReplace = [];
 
+        /** @var array<string, int[]> $removedMethodArgPositions */
+        $removedMethodArgPositions = [];
+
         foreach ($node->getMethods() as $classMethod) {
             if ($this->shouldSkipClassMethod($classMethod)) {
                 continue;
@@ -223,6 +227,7 @@ CODE_SAMPLE
                 $paramsToRemove[] = [$classMethod, $key];
                 $propertyMetadatas[$paramName] = new PropertyMetadata($paramName, $paramType);
                 $methodParamNamesToReplace[$classMethod->name->toString()][] = $paramName;
+                $removedMethodArgPositions[$classMethod->name->toString()][] = $key;
             }
         }
 
@@ -254,7 +259,55 @@ CODE_SAMPLE
             $this->replaceParamUseWithPropertyFetch($classMethod, $methodParamNamesToReplace[$methodName]);
         }
 
+        $this->updateCallSitesForRemovedParams($node, $removedMethodArgPositions);
+
         return $node;
+    }
+
+    /**
+     * @param array<string, int[]> $removedArgPositionsByMethod
+     */
+    private function updateCallSitesForRemovedParams(Class_ $node, array $removedArgPositionsByMethod): void
+    {
+        if ($removedArgPositionsByMethod === []) {
+            return;
+        }
+
+        foreach ($node->getMethods() as $classMethod) {
+            if ($classMethod->stmts === null) {
+                continue;
+            }
+
+            $this->traverseNodesWithCallable($classMethod->stmts, function (Node $node) use (
+                $removedArgPositionsByMethod
+            ): ?MethodCall {
+                if (! $node instanceof MethodCall) {
+                    return null;
+                }
+
+                if (! $node->var instanceof Variable) {
+                    return null;
+                }
+
+                if (! $this->isName($node->var, 'this')) {
+                    return null;
+                }
+
+                $methodName = $this->getName($node->name);
+                if ($methodName === null || ! isset($removedArgPositionsByMethod[$methodName])) {
+                    return null;
+                }
+
+                $removedPositions = $removedArgPositionsByMethod[$methodName];
+                rsort($removedPositions);
+                foreach ($removedPositions as $position) {
+                    unset($node->args[$position]);
+                }
+
+                $node->args = array_values($node->args);
+                return $node;
+            });
+        }
     }
 
     private function shouldSkipClassMethod(ClassMethod $classMethod): bool

--- a/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
+++ b/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
@@ -267,13 +267,13 @@ CODE_SAMPLE
     /**
      * @param array<string, int[]> $removedArgPositionsByMethod
      */
-    private function updateCallSitesForRemovedParams(Class_ $node, array $removedArgPositionsByMethod): void
+    private function updateCallSitesForRemovedParams(Class_ $class, array $removedArgPositionsByMethod): void
     {
         if ($removedArgPositionsByMethod === []) {
             return;
         }
 
-        foreach ($node->getMethods() as $classMethod) {
+        foreach ($class->getMethods() as $classMethod) {
             if ($classMethod->stmts === null) {
                 continue;
             }
@@ -300,8 +300,8 @@ CODE_SAMPLE
 
                 $removedPositions = $removedArgPositionsByMethod[$methodName];
                 rsort($removedPositions);
-                foreach ($removedPositions as $position) {
-                    unset($node->args[$position]);
+                foreach ($removedPositions as $removedPosition) {
+                    unset($node->args[$removedPosition]);
                 }
 
                 $node->args = array_values($node->args);


### PR DESCRIPTION
## Problem

Fixes https://github.com/rectorphp/rector/issues/9695

When a controller has a helper method that takes both a service parameter **and** optional scalar parameters:

```php
final class SomeController extends AbstractController
{
    #[Route('/some-action')]
    public function someAction(LoggerInterface $logger)
    {
        $this->problematic($logger);
    }

    public function problematic(LoggerInterface $logger, ?string $optional = 'test')
    {
        $logger->log('level', 'value');
        dump($optional);
    }
}
```

The rule correctly moved `LoggerInterface $logger` out of both method signatures and into the constructor, and replaced `$logger` usages inside each method body with `$this->logger`. However, it did **not** update the **call site** `$this->problematic($logger)` in `someAction` — after `$logger` was replaced with `$this->logger` by the variable-replacement step, the call became `$this->problematic($this->logger)`, even though `problematic` no longer accepts that argument. This produced invalid code.

## Fix

After all param removals and variable replacements, a new `updateCallSitesForRemovedParams` step traverses every method body in the class. For any `$this->methodName(...)` call whose method had parameters removed, the corresponding positional arguments are removed from the call.

## Changes

- `rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php` — track removed param positions per method; add `updateCallSitesForRemovedParams()` that strips the stale arguments from internal call sites
- `rules-tests/.../Fixture/internal_method_call_arg_removal.php.inc` — new fixture reproducing the exact scenario from the issue

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNfB4GsBWmAqPas9n22r2H)_