### PR TITLE
[Symfony81] add rule for Serialiazer method change

### DIFF
--- a/config/sets/symfony/symfony8/symfony81.php
+++ b/config/sets/symfony/symfony8/symfony81.php
@@ -8,4 +8,5 @@ use Rector\Config\RectorConfig;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/symfony81/symfony81-dependency-injection.php');
     $rectorConfig->import(__DIR__ . '/symfony81/symfony81-uid.php');
+    $rectorConfig->import(__DIR__ . '/symfony81/symfony81-serializer.php');
 };

--- a/config/sets/symfony/symfony8/symfony81/symfony81-serializer.php
+++ b/config/sets/symfony/symfony8/symfony81/symfony81-serializer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        // @see https://github.com/symfony/symfony/blob/8.1/UPGRADE-8.1.md#serializer
+        new MethodCallRename('Symfony\Component\Serializer\Exception\PartialDenormalizationException', 'getErrors', 'getNotNormalizableValueErrors'),
+    ]);
+};

--- a/src/Set/SetProvider/Symfony8SetProvider.php
+++ b/src/Set/SetProvider/Symfony8SetProvider.php
@@ -35,6 +35,12 @@ final class Symfony8SetProvider implements SetProviderInterface
                 '8.1',
                 __DIR__ . '/../../../config/sets/symfony/symfony8/symfony81/symfony81-uid.php'
             ),
+            new ComposerTriggeredSet(
+                SetGroup::SYMFONY,
+                'symfony/serializer',
+                '8.1',
+                __DIR__ . '/../../../config/sets/symfony/symfony8/symfony81/symfony81-serializer.php'
+            ),
         ];
     }
 }


### PR DESCRIPTION
https://github.com/symfony/symfony/blob/8.1/UPGRADE-8.1.md#serializer

> Deprecate PartialDenormalizationException::getErrors(), use getNotNormalizableValueErrors() instead
