### PR TITLE
[Symfony81] Add new rule for Filesystem

### DIFF
--- a/config/sets/symfony/symfony8/symfony81.php
+++ b/config/sets/symfony/symfony8/symfony81.php
@@ -9,4 +9,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/symfony81/symfony81-dependency-injection.php');
     $rectorConfig->import(__DIR__ . '/symfony81/symfony81-uid.php');
     $rectorConfig->import(__DIR__ . '/symfony81/symfony81-serializer.php');
+    $rectorConfig->import(__DIR__ . '/symfony81/symfony81-filesystem.php');
 };

--- a/config/sets/symfony/symfony8/symfony81/symfony81-filesystem.php
+++ b/config/sets/symfony/symfony8/symfony81/symfony81-filesystem.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([RenameCopyOnWindowsOptionToFollowSymlinksRector::class]);
+};

--- a/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/Fixture/rename_copy_on_windows_to_follow_symlinks.php.inc
+++ b/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/Fixture/rename_copy_on_windows_to_follow_symlinks.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector\Fixture;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+final class Foo
+{
+    public function __construct(private Filesystem $filesystem) {}
+
+    public function bar($originDir, $targetDir): void
+    {
+        $this->filesystem->mirror($originDir, $targetDir, null, $options = ['copy_on_windows' => true]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector\Fixture;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+final class Foo
+{
+    public function __construct(private Filesystem $filesystem) {}
+
+    public function bar($originDir, $targetDir): void
+    {
+        $this->filesystem->mirror($originDir, $targetDir, null, $options = ['follow_symlinks' => true]);
+    }
+}
+
+?>

--- a/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/Fixture/rename_copy_on_windows_to_follow_symlinks_not_present.php.inc
+++ b/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/Fixture/rename_copy_on_windows_to_follow_symlinks_not_present.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector\Fixture;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+final class Foo
+{
+    public function __construct(private Filesystem $filesystem) {}
+
+    public function bar($originDir, $targetDir): void
+    {
+        $this->filesystem->mirror($targetDir, $originDir, $options = ['override' => true]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector\Fixture;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+final class Foo
+{
+    public function __construct(private Filesystem $filesystem) {}
+
+    public function bar($originDir, $targetDir): void
+    {
+        $this->filesystem->mirror($targetDir, $originDir, $options = ['override' => true]);
+    }
+}
+
+?>

--- a/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/Fixture/rename_copy_on_windows_to_follow_symlinks_with_named_arguments.php.inc
+++ b/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/Fixture/rename_copy_on_windows_to_follow_symlinks_with_named_arguments.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector\Fixture;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+final class Foo
+{
+    public function __construct(private Filesystem $filesystem) {}
+
+    public function bar($originDir, $targetDir): void
+    {
+        $this->filesystem->mirror(targetDir: $originDir, originDir: $targetDir, options: ['copy_on_windows' => true]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector\Fixture;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+final class Foo
+{
+    public function __construct(private Filesystem $filesystem) {}
+
+    public function bar($originDir, $targetDir): void
+    {
+        $this->filesystem->mirror(targetDir: $originDir, originDir: $targetDir, options: ['follow_symlinks' => true]);
+    }
+}
+
+?>

--- a/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/RenameCopyOnWindowsOptionToFollowSymlinksRectorTest.php
+++ b/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/RenameCopyOnWindowsOptionToFollowSymlinksRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RenameCopyOnWindowsOptionToFollowSymlinksRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/config/configured_rule.php
+++ b/rules-tests/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RenameCopyOnWindowsOptionToFollowSymlinksRector::class);
+};

--- a/rules/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector.php
+++ b/rules/Symfony81/Rector/MethodCall/RenameCopyOnWindowsOptionToFollowSymlinksRector.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Symfony81\Rector\MethodCall;
+
+use PHPStan\Type\ObjectType;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://github.com/symfony/symfony/blob/8.1/UPGRADE-8.1.md#filesystem
+ *
+ * @see \Rector\Symfony\Tests\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector\RenameCopyOnWindowsOptionToFollowSymlinksRectorTest
+ */
+final class RenameCopyOnWindowsOptionToFollowSymlinksRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Rename copy_on_windows option to follow_symlinks in Filesystem::mirror()',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                        use Symfony\Component\Filesystem\Filesystem;
+
+                        final class Foo
+                        {
+                            public function __construct(private Filesystem $filesystem) {}
+
+                            public function bar($originDir, $targetDir): void
+                            {
+                                $this->filesystem->mirror(targetDir: $originDir, originDir: $targetDir, options: $options = ['copy_on_windows' => true]);
+                            }
+                        }
+                        CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+                        use Symfony\Component\Filesystem\Filesystem;
+
+                        final class Foo
+                        {
+                            public function __construct(private Filesystem $filesystem) {}
+
+                            public function bar($originDir, $targetDir): void
+                            {
+                                $this->filesystem->mirror(targetDir: $originDir, originDir: $targetDir, options: $options = ['follow_symlinks' => true]);
+                            }
+                        }
+                        CODE_SAMPLE
+                    ,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isObjectType($node->var, new ObjectType('Symfony\Component\Filesystem\Filesystem'))) {
+            return null;
+        }
+
+        if (! $this->isName($node->name, 'mirror')) {
+            return null;
+        }
+
+        $optionsArg = null;
+        foreach ($node->args as $index => $arg) {
+            if (! $arg instanceof Arg) {
+                continue;
+            }
+
+            if ($arg->name instanceof Identifier && $arg->name->toString() === 'options') {
+                $optionsArg = $arg;
+                break;
+            }
+
+            if (! $arg->name instanceof Identifier && $index === 3) {
+                $optionsArg = $arg;
+                break;
+            }
+        }
+
+        if (! $optionsArg instanceof Arg) {
+            return null;
+        }
+
+        $options = $optionsArg->value;
+
+        if ($options instanceof Assign) {
+            $options = $options->expr;
+        }
+
+        if (! $options instanceof Array_) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($options->items as $item) {
+            if (! $item instanceof ArrayItem) {
+                continue;
+            }
+
+            if (! $item->key instanceof String_) {
+                continue;
+            }
+
+            if ($item->key->value !== 'copy_on_windows') {
+                continue;
+            }
+
+            $item->key = new String_('follow_symlinks');
+
+            $hasChanged = true;
+        }
+
+        return $hasChanged ? $node : null;
+    }
+}

--- a/src/Set/SetProvider/Symfony8SetProvider.php
+++ b/src/Set/SetProvider/Symfony8SetProvider.php
@@ -41,6 +41,12 @@ final class Symfony8SetProvider implements SetProviderInterface
                 '8.1',
                 __DIR__ . '/../../../config/sets/symfony/symfony8/symfony81/symfony81-serializer.php'
             ),
+            new ComposerTriggeredSet(
+                SetGroup::SYMFONY,
+                'symfony/filesystem',
+                '8.1',
+                __DIR__ . '/../../../config/sets/symfony/symfony8/symfony81/symfony81-filesystem.php'
+            ),
         ];
     }
 }


### PR DESCRIPTION
New rule for Filesystem component in Symfony 8.1

[Upgrade guide](https://github.com/symfony/symfony/blob/8.2/UPGRADE-8.1.md#filesystem)

> Deprecate calling Filesystem::mirror() with option copy_on_windows, use option follow_symlinks instead
