### PR TITLE
[Symfony81] Add new rule for Security component

### DIFF
--- a/config/sets/symfony/symfony8/symfony81/symfony81-security.php
+++ b/config/sets/symfony/symfony8/symfony81/symfony81-security.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([RemoveEraseCredentialsFromAuthenticatorManagerRector::class]);
+};

--- a/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager.php.inc
+++ b/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            $authenticators,
+            $tokenStorage,
+            $eventDispatcher,
+            $firewallName,
+            null,
+            true
+        );                                
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            $authenticators,
+            $tokenStorage,
+            $eventDispatcher,
+            $firewallName,
+            null
+        );                                
+    }
+}
+
+?>

--- a/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager_not_present.php.inc
+++ b/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager_not_present.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            $authenticators,
+            $tokenStorage,
+            $eventDispatcher,
+            $firewallName
+        );                                
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            $authenticators,
+            $tokenStorage,
+            $eventDispatcher,
+            $firewallName
+        );                                
+    }
+}
+
+?>

--- a/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager_with_new_named_arguments.php.inc
+++ b/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager_with_new_named_arguments.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            authenticators: $authenticators,
+            tokenStorageInterface: $tokenStorage,
+            eventDispatcherInterface: $eventDispatcher,
+            firewallName: $firewallName,
+            exposeSecurityErrors: false
+        );                                
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            authenticators: $authenticators,
+            tokenStorageInterface: $tokenStorage,
+            eventDispatcherInterface: $eventDispatcher,
+            firewallName: $firewallName
+        );                                
+    }
+}
+
+?>

--- a/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager_with_old_named_arguments.php.inc
+++ b/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager_with_old_named_arguments.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            authenticators: $authenticators,
+            tokenStorageInterface: $tokenStorage,
+            eventDispatcherInterface: $eventDispatcher,
+            firewallName: $firewallName,
+            eraseCredentials: false
+        );                                
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            authenticators: $authenticators,
+            tokenStorageInterface: $tokenStorage,
+            eventDispatcherInterface: $eventDispatcher,
+            firewallName: $firewallName
+        );                                
+    }
+}
+
+?>

--- a/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager_with_valid_value.php.inc
+++ b/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/Fixture/remove_erase_credentials_from_authenticator_manager_with_valid_value.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+use Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            $authenticators,
+            $tokenStorage,
+            $eventDispatcher,
+            $firewallName,
+            null,
+            ExposeSecurityLevel::All
+        );                                
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\Fixture;
+
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+use Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel;
+
+final class Foo
+{
+    public function bar(): void
+    {
+        new AuthenticatorManager(
+            $authenticators,
+            $tokenStorage,
+            $eventDispatcher,
+            $firewallName,
+            null,
+            ExposeSecurityLevel::All
+        );                                
+    }
+}
+
+?>

--- a/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/RemoveEraseCredentialsFromAuthenticatorManagerRectorTest.php
+++ b/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/RemoveEraseCredentialsFromAuthenticatorManagerRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveEraseCredentialsFromAuthenticatorManagerRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/config/configured_rule.php
+++ b/rules-tests/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RemoveEraseCredentialsFromAuthenticatorManagerRector::class);
+};

--- a/rules/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector.php
+++ b/rules/Symfony81/Rector/New_/RemoveEraseCredentialsFromAuthenticatorManagerRector.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Symfony81\Rector\New_;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\New_;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see https://github.com/symfony/symfony/blob/8.2/UPGRADE-8.1.md#security
+ *
+ * @see \Rector\Symfony\Tests\Symfony81\Rector\New_\RemoveEraseCredentialsFromAuthenticatorManagerRector\RemoveEraseCredentialsFromAuthenticatorManagerRectorTest
+ */
+final class RemoveEraseCredentialsFromAuthenticatorManagerRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove unused $eraseCredentials argument from AuthenticatorManager constructor',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                        use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+                        final class Foo
+                        {
+                            public function bar(): void
+                            {
+                                new AuthenticatorManager(
+                                    $authenticators,
+                                    $tokenStorage,
+                                    $eventDispatcher,
+                                    $firewallName,
+                                    true
+                                );                                
+                            }
+                        }    
+                        CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+                        use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+
+                        final class Foo
+                        {
+                            public function bar(): void
+                            {
+                                new AuthenticatorManager(
+                                    $authenticators,
+                                    $tokenStorage,
+                                    $eventDispatcher,
+                                    $firewallName,
+                                );                                
+                            }
+                        }    
+                        CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [New_::class];
+    }
+
+    /**
+     * @param New_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node instanceof New_) {
+            return null;
+        }
+
+        if (! $this->isName($node->class, 'Symfony\Component\Security\Http\Authentication\AuthenticatorManager')) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($node->args as $key => $arg) {
+            if (! $arg instanceof Arg) {
+                continue;
+            }
+
+            if (
+                $arg->name !== null
+                && ($this->isName($arg->name, 'exposeSecurityErrors') || $this->isName($arg->name, 'eraseCredentials'))
+                && $this->valueResolver->isTrueOrFalse($arg->value)
+            ) {
+                unset($node->args[$key]);
+
+                $hasChanged = true;
+            }
+        }
+
+        if (! $hasChanged
+        && isset($node->args[5])
+        && $node->args[5] instanceof Arg
+        && $this->valueResolver->isTrueOrFalse($node->args[5]->value)) {
+            unset($node->args[5]);
+
+            $hasChanged = true;
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        $node->args = array_values($node->args);
+
+        return $node;
+    }
+}

--- a/src/Set/SetProvider/Symfony8SetProvider.php
+++ b/src/Set/SetProvider/Symfony8SetProvider.php
@@ -47,6 +47,12 @@ final class Symfony8SetProvider implements SetProviderInterface
                 '8.1',
                 __DIR__ . '/../../../config/sets/symfony/symfony8/symfony81/symfony81-filesystem.php'
             ),
+            new ComposerTriggeredSet(
+                SetGroup::SYMFONY,
+                'symfony/security',
+                '8.1',
+                __DIR__ . '/../../../config/sets/symfony/symfony8/symfony81/symfony81-security.php'
+            ),
         ];
     }
 }


### PR DESCRIPTION
Add a new rule for [Security component](https://github.com/symfony/symfony/blob/8.2/UPGRADE-8.1.md#security)

> Deprecate passing the $eraseCredentials argument to AuthenticatorManager::__construct(), as the eraseCredentials() method was removed in Symfony 8.0

Code implementation is a bit more precise : 
>      * @param ExposeSecurityLevel                     $exposeSecurityErrors Passing a bool is deprecated since Symfony 8.1

[Codebase for reference](https://github.com/symfony/symfony/blob/179bc110d25737b7dc01df43c63f257b53cc7186/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php#L49-L66)