### PR TITLE
Order optional command parameters last in InvokableCommandInputAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/optional_option_before_required.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/optional_option_before_required.php.inc
@@ -1,0 +1,62 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name')]
+final class OptionalOptionBeforeRequired extends Command
+{
+    public function configure()
+    {
+        $this->addOption('option', 'o', InputOption::VALUE_NONE, 'Option description');
+        $this->addOption('another', 'a', InputOption::VALUE_REQUIRED, 'No default value');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $someOption = $input->getOption('option');
+        $another = $input->getOption('another');
+
+        // ...
+
+        return 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name')]
+final class OptionalOptionBeforeRequired
+{
+    public function __invoke(
+        #[\Symfony\Component\Console\Attribute\Option(name: 'another', shortcut: 'a', mode: InputOption::VALUE_REQUIRED, description: 'No default value')]
+        $another,
+        #[\Symfony\Component\Console\Attribute\Option(name: 'option', shortcut: 'o', mode: InputOption::VALUE_NONE, description: 'Option description')]
+        bool $option = false
+    ): int
+    {
+        $someOption = $option;
+        $another = $another;
+        // ...
+        return 1;
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes rectorphp/rector#9546

## Problem

`InvokableCommandInputAttributeRector` emitted `__invoke()` parameters in the same order the `addArgument()`/`addOption()` calls appeared in `configure()`. When an optional parameter (one with a default value) was declared before a required one, the generated method ended up with an optional parameter in front of a required parameter — which is invalid PHP and would have to be fixed up afterwards by `OptionalParametersAfterRequiredRector`.

## Fix

After building the `__invoke()` parameter list, parameters are partitioned so required parameters (no default) keep their relative order and come first, followed by optional parameters (with a default). This guarantees optional parameters are always listed last.

This is a fresh, passing take on the previously-closed #899 — the trailing-comma formatting problem reported there no longer reproduces with the current printer.

## Tests

- Updated `option_with_array_type.php.inc` fixture to reflect the corrected order.
- Added `optional_option_before_required.php.inc` fixture covering an optional option declared before a required one.