### PR TITLE
[Symfony73] Sort optional parameters last in InvokableCommandInputAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/DefaultValue/option_with_array_type.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/DefaultValue/option_with_array_type.php.inc
@@ -43,10 +43,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 class OptionWithOptionalValue
 {
     public function __invoke(
-        #[\Symfony\Component\Console\Attribute\Option(name: 'some-array', mode: InputOption::VALUE_IS_ARRAY)]
-        array $someArray = ['third value'],
         #[\Symfony\Component\Console\Attribute\Option(name: 'no-default-array', mode: InputOption::VALUE_IS_ARRAY)]
-        array $noDefaultArray
+        array $noDefaultArray,
+        #[\Symfony\Component\Console\Attribute\Option(name: 'some-array', mode: InputOption::VALUE_IS_ARRAY)]
+        array $someArray = ['third value']
     ): int
     {
     }

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_default_and_without_default_value.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/Fixture/with_default_and_without_default_value.php.inc
@@ -1,0 +1,63 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name')]
+final class WithDefaultAndWithoutDefaultValue extends Command
+{
+    protected function configure()
+    {
+        $this->addOption('option', 'o', InputOption::VALUE_NONE, 'Option description');
+        $this->addOption('another', 'a', InputOption::VALUE_REQUIRED, 'No default value');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $someOption = $input->getOption('option');
+        $another = $input->getOption('another');
+        $output->writeln('Using output too');
+        // ...
+        return 1;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\Fixture;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'some_name')]
+final class WithDefaultAndWithoutDefaultValue
+{
+    public function __invoke(
+        #[\Symfony\Component\Console\Attribute\Option(name: 'another', shortcut: 'a', mode: InputOption::VALUE_REQUIRED, description: 'No default value')]
+        $another,
+        OutputInterface $output,
+        #[\Symfony\Component\Console\Attribute\Option(name: 'option', shortcut: 'o', mode: InputOption::VALUE_NONE, description: 'Option description')]
+        bool $option = false
+    ): int
+    {
+        $someOption = $option;
+        $another = $another;
+        $output->writeln('Using output too');
+        // ...
+        return 1;
+    }
+}
+
+?>

--- a/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
@@ -6,6 +6,7 @@ namespace Rector\Symfony\Symfony73\Rector\Class_;
 
 use PhpParser\Modifiers;
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
@@ -160,7 +161,10 @@ CODE_SAMPLE
 
             $invokeParams = $this->createInvokeParams($node);
 
-            $invokeClassMethod->params = array_merge($invokeParams, [$executeClassMethod->params[1]]);
+            $allParams = array_merge($invokeParams, [$executeClassMethod->params[1]]);
+
+            // optional parameters (with a default value) must be listed last, to keep a valid signature
+            $invokeClassMethod->params = $this->sortRequiredParamsFirst($allParams);
 
             // 6. remove parent class
             $node->extends = null;
@@ -248,6 +252,26 @@ CODE_SAMPLE
 
         // the left-most var must be $this
         return $current instanceof Variable && $this->isName($current, 'this');
+    }
+
+    /**
+     * @param Param[] $params
+     * @return Param[]
+     */
+    private function sortRequiredParamsFirst(array $params): array
+    {
+        $requiredParams = [];
+        $optionalParams = [];
+
+        foreach ($params as $param) {
+            if ($param->default instanceof Expr) {
+                $optionalParams[] = $param;
+            } else {
+                $requiredParams[] = $param;
+            }
+        }
+
+        return array_merge($requiredParams, $optionalParams);
     }
 
     /**


### PR DESCRIPTION
Fixes rectorphp/rector#9546

`InvokableCommandInputAttributeRector` could emit `__invoke()` signatures where an optional parameter (one with a default value) appeared before a required one, producing an invalid PHP signature.

This sorts the generated parameters so all required parameters come first and optional ones last, while keeping their relative order otherwise. The `$output` parameter (no default) is treated as required and therefore stays among the leading params.

This is a fresh take on the approach from #899 (closed for inactivity); building the params array from scratch avoids the trailing-comma formatting glitches reported there.

Covered by:
- updated `Fixture/DefaultValue/option_with_array_type.php.inc` (previously asserted the buggy order)
- new `Fixture/with_default_and_without_default_value.php.inc`