### PR TITLE
fix: only convert Twig extensions fully reducible to AsTwig attributes

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/skip_remaining_get_tests.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/skip_remaining_get_tests.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector\Fixture;
+
+use Twig\Extension\AbstractExtension;
+
+final class SkipRemainingGetTests extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new \Twig\TwigFilter('some_filter', [$this, 'someFilter']),
+        ];
+    }
+
+    public function getTests(): array
+    {
+        return [
+            new \Twig\TwigTest('some_test', [$this, 'someTest']),
+        ];
+    }
+
+    public function someFilter($value)
+    {
+        return $value;
+    }
+
+    public function someTest($value)
+    {
+        return $value;
+    }
+}

--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_globals_interface.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_globals_interface.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector\Fixture;
+
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
+final class SkipGlobalsInterface extends AbstractExtension implements GlobalsInterface
+{
+    public function getFunctions(): array
+    {
+        return [
+            new \Twig\TwigFunction('some_function', [$this, 'someFunction']),
+        ];
+    }
+
+    public function getGlobals(): array
+    {
+        return [];
+    }
+
+    public function someFunction($value)
+    {
+        return $value;
+    }
+}

--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_injected_service_callable.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_injected_service_callable.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector\Fixture;
+
+use Twig\Extension\AbstractExtension;
+
+final class SkipInjectedServiceCallable extends AbstractExtension
+{
+    public function __construct(
+        private SomeInjectedService $myInjectedService
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new \Twig\TwigFunction('some_function', [$this, 'someFunction']),
+            new \Twig\TwigFunction('function_name', [$this->myInjectedService, 'serviceFunction']),
+        ];
+    }
+
+    public function someFunction($value)
+    {
+        return $value;
+    }
+}

--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_null_callable.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_null_callable.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector\Fixture;
+
+use Twig\Extension\AbstractExtension;
+
+final class SkipNullCallable extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new \Twig\TwigFunction('some_function', [$this, 'someFunction']),
+            new \Twig\TwigFunction('my_form_function', null, ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function someFunction($value)
+    {
+        return $value;
+    }
+}

--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_remaining_get_filters.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/skip_remaining_get_filters.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector\Fixture;
+
+use Twig\Extension\AbstractExtension;
+
+final class SkipRemainingGetFilters extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new \Twig\TwigFunction('some_function', [$this, 'someFunction']),
+        ];
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            new \Twig\TwigFilter('some_filter', [$this, 'someFilter']),
+        ];
+    }
+
+    public function someFunction($value)
+    {
+        return $value;
+    }
+
+    public function someFilter($value)
+    {
+        return $value;
+    }
+}

--- a/rules/Symfony73/GetMethodToAsTwigAttributeTransformer.php
+++ b/rules/Symfony73/GetMethodToAsTwigAttributeTransformer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Symfony\Symfony73;
 
 use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
@@ -19,10 +20,12 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Symfony\Enum\TwigClass;
 use Rector\Symfony\Symfony73\NodeAnalyzer\LocalArrayMethodCallableMatcher;
 use Rector\Symfony\Symfony73\NodeRemover\ReturnEmptyArrayMethodRemover;
+use Rector\Symfony\Symfony73\ValueObject\AsTwigAttributeConversion;
 
 /**
  * @see https://symfony.com/blog/new-in-symfony-7-3-twig-extension-attributes
@@ -38,11 +41,28 @@ final readonly class GetMethodToAsTwigAttributeTransformer
         'deprecation_info' => 'deprecationInfo',
     ];
 
+    /**
+     * Methods that keep a class registered as a classic Twig extension; while any of them is present,
+     * "extends AbstractExtension" must stay and the class cannot be turned into an attribute-based one.
+     *
+     * @var string[]
+     */
+    private const array TWIG_EXTENSION_METHODS = [
+        'getTokenParsers',
+        'getNodeVisitors',
+        'getFilters',
+        'getTests',
+        'getFunctions',
+        'getOperators',
+        'getGlobals',
+    ];
+
     public function __construct(
         private LocalArrayMethodCallableMatcher $localArrayMethodCallableMatcher,
         private ReturnEmptyArrayMethodRemover $returnEmptyArrayMethodRemover,
         private ReflectionProvider $reflectionProvider,
-        private VisibilityManipulator $visibilityManipulator
+        private VisibilityManipulator $visibilityManipulator,
+        private NodeNameResolver $nodeNameResolver
     ) {
     }
 
@@ -56,7 +76,6 @@ final readonly class GetMethodToAsTwigAttributeTransformer
         ObjectType $objectType,
         array $additionalOptionMapping = []
     ): bool {
-
         // check if attribute even exists
         if (! $this->reflectionProvider->hasClass($attributeClass)) {
             return false;
@@ -67,80 +86,171 @@ final readonly class GetMethodToAsTwigAttributeTransformer
             return false;
         }
 
-        $originalMethod = clone $getMethod;
+        $returnArray = $this->matchReturnArray($getMethod);
+        if (! $returnArray instanceof Array_) {
+            return false;
+        }
 
-        $hasChanged = false;
-        foreach ((array) $getMethod->stmts as $stmt) {
-            // handle return array simple case
+        // nothing to convert
+        if ($returnArray->items === []) {
+            return false;
+        }
+
+        // validate every registration before changing anything: a partial conversion would
+        // leave some filters/functions unregistered once "extends AbstractExtension" is removed
+        $conversions = [];
+        foreach ($returnArray->items as $key => $arrayItem) {
+            if (! $arrayItem instanceof ArrayItem) {
+                return false;
+            }
+
+            $conversion = $this->matchArrayItemConversion(
+                $key,
+                $arrayItem,
+                $class,
+                $objectType,
+                $additionalOptionMapping
+            );
+            if (! $conversion instanceof AsTwigAttributeConversion) {
+                return false;
+            }
+
+            $conversions[] = $conversion;
+        }
+
+        // attribute-based extensions and "extends AbstractExtension" are incompatible, so the class
+        // must not keep relying on the parent class for other registrations (e.g. getTests(), globals)
+        if ($this->stillRequiresAbstractExtension($class, $methodName)) {
+            return false;
+        }
+
+        foreach ($conversions as $conversion) {
+            $nameArg = $conversion->getNameArg();
+            $nameArg->name = new Identifier('name');
+
+            $this->decorateMethodWithAttribute(
+                $conversion->getClassMethod(),
+                $attributeClass,
+                [$nameArg, ...$conversion->getOptionArgs()]
+            );
+            $this->visibilityManipulator->makePublic($conversion->getClassMethod());
+
+            // remove old new function/filter instance
+            unset($returnArray->items[$conversion->getItemKey()]);
+        }
+
+        $this->returnEmptyArrayMethodRemover->removeClassMethodIfArrayEmpty($class, $returnArray, $methodName);
+
+        if ($class->extends instanceof FullyQualified && $class->extends->toString() === TwigClass::TWIG_EXTENSION) {
+            $class->extends = null;
+        }
+
+        return true;
+    }
+
+    private function matchReturnArray(ClassMethod $classMethod): ?Array_
+    {
+        $returnArray = null;
+        foreach ((array) $classMethod->stmts as $stmt) {
             if (! $stmt instanceof Return_) {
                 continue;
             }
 
+            // multiple/conditional returns cannot be converted safely
+            if ($returnArray instanceof Array_) {
+                return null;
+            }
+
             if (! $stmt->expr instanceof Array_) {
-                continue;
+                return null;
             }
 
             $returnArray = $stmt->expr;
-            foreach ($returnArray->items as $key => $arrayItem) {
-                if (! $arrayItem->value instanceof New_) {
-                    continue;
-                }
+        }
 
-                if ($arrayItem->value->isFirstClassCallable()) {
-                    continue;
-                }
+        return $returnArray;
+    }
 
-                $new = $arrayItem->value;
-                $argCount = count($new->getArgs());
-                if ($argCount > 3 || $argCount < 2) {
-                    continue;
-                }
+    /**
+     * @param array<string, string> $additionalOptionMapping
+     */
+    private function matchArrayItemConversion(
+        int $key,
+        ArrayItem $arrayItem,
+        Class_ $class,
+        ObjectType $objectType,
+        array $additionalOptionMapping
+    ): ?AsTwigAttributeConversion {
+        if (! $arrayItem->value instanceof New_) {
+            return null;
+        }
 
-                $nameArg = $new->getArgs()[0];
-                if (! $nameArg->value instanceof String_) {
-                    continue;
-                }
+        $new = $arrayItem->value;
+        if ($new->isFirstClassCallable()) {
+            return null;
+        }
 
-                $secondArg = $new->getArgs()[1];
-                $thirdArg = $new->getArgs()[2] ?? null;
+        $argCount = count($new->getArgs());
+        if ($argCount > 3 || $argCount < 2) {
+            return null;
+        }
 
-                if ($this->isLocalCallable($secondArg->value)) {
-                    $localMethodName = $this->localArrayMethodCallableMatcher->match($secondArg->value, $objectType);
-                    if (! is_string($localMethodName)) {
-                        $getMethod = $originalMethod;
-                        return false;
-                    }
+        $nameArg = $new->getArgs()[0];
+        if (! $nameArg->value instanceof String_) {
+            return null;
+        }
 
-                    $localMethod = $class->getMethod($localMethodName);
-                    if (! $localMethod instanceof ClassMethod) {
-                        continue;
-                    }
+        $secondArg = $new->getArgs()[1];
+        $thirdArg = $new->getArgs()[2] ?? null;
 
-                    $optionArguments = $this->getArgumentsFromOptionArray($thirdArg, $additionalOptionMapping);
-                    if ($optionArguments === null) {
-                        continue;
-                    }
+        // the callable must be a local method; external services, other classes or null callables
+        // cannot be expressed as an attribute on a method of this class
+        if (! $this->isLocalCallable($secondArg->value)) {
+            return null;
+        }
 
-                    $this->decorateMethodWithAttribute($localMethod, $attributeClass, [$nameArg, ...$optionArguments]);
-                    $this->visibilityManipulator->makePublic($localMethod);
+        $localMethodName = $this->localArrayMethodCallableMatcher->match($secondArg->value, $objectType);
+        if (! is_string($localMethodName)) {
+            return null;
+        }
 
-                    // remove old new function instance
-                    unset($returnArray->items[$key]);
+        $localMethod = $class->getMethod($localMethodName);
+        if (! $localMethod instanceof ClassMethod) {
+            return null;
+        }
 
-                    $nameArg->name = new Identifier('name');
+        $optionArguments = $this->getArgumentsFromOptionArray($thirdArg, $additionalOptionMapping);
+        if ($optionArguments === null) {
+            return null;
+        }
 
-                    $hasChanged = true;
-                }
+        return new AsTwigAttributeConversion($key, $localMethod, $nameArg, $optionArguments);
+    }
+
+    private function stillRequiresAbstractExtension(Class_ $class, string $convertedMethodName): bool
+    {
+        foreach ($class->getMethods() as $classMethod) {
+            $currentMethodName = $classMethod->name->toString();
+            if ($currentMethodName === $convertedMethodName) {
+                continue;
             }
 
-            $this->returnEmptyArrayMethodRemover->removeClassMethodIfArrayEmpty($class, $returnArray, $methodName);
+            if (in_array($currentMethodName, self::TWIG_EXTENSION_METHODS, true)) {
+                return true;
+            }
         }
 
-        if ($hasChanged && $class->extends instanceof FullyQualified && $class->extends->toString() === TwigClass::TWIG_EXTENSION) {
-            $class->extends = null;
+        foreach ($class->implements as $implement) {
+            if ($this->nodeNameResolver->isName($implement, TwigClass::GLOBALS_INTERFACE)) {
+                return true;
+            }
+
+            if ($this->nodeNameResolver->isName($implement, TwigClass::EXTENSION_INTERFACE)) {
+                return true;
+            }
         }
 
-        return $hasChanged;
+        return false;
     }
 
     /**

--- a/rules/Symfony73/ValueObject/AsTwigAttributeConversion.php
+++ b/rules/Symfony73/ValueObject/AsTwigAttributeConversion.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Symfony73\ValueObject;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Stmt\ClassMethod;
+
+final readonly class AsTwigAttributeConversion
+{
+    /**
+     * @param Arg[] $optionArgs
+     */
+    public function __construct(
+        private int $itemKey,
+        private ClassMethod $classMethod,
+        private Arg $nameArg,
+        private array $optionArgs
+    ) {
+    }
+
+    public function getItemKey(): int
+    {
+        return $this->itemKey;
+    }
+
+    public function getClassMethod(): ClassMethod
+    {
+        return $this->classMethod;
+    }
+
+    public function getNameArg(): Arg
+    {
+        return $this->nameArg;
+    }
+
+    /**
+     * @return Arg[]
+     */
+    public function getOptionArgs(): array
+    {
+        return $this->optionArgs;
+    }
+}

--- a/src/Enum/TwigClass.php
+++ b/src/Enum/TwigClass.php
@@ -13,4 +13,6 @@ final class TwigClass
     public const string AS_TWIG_FUNCTION_ATTRIBUTE = 'Twig\Attribute\AsTwigFunction';
 
     public const string EXTENSION_INTERFACE = 'Twig\Extension\ExtensionInterface';
+
+    public const string GLOBALS_INTERFACE = 'Twig\Extension\GlobalsInterface';
 }

--- a/stubs/Twig/Extension/GlobalsInterface.php
+++ b/stubs/Twig/Extension/GlobalsInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twig\Extension;
+
+if (interface_exists('Twig\Extension\GlobalsInterface')) {
+    return;
+}
+
+interface GlobalsInterface
+{
+}


### PR DESCRIPTION
Fixes rectorphp/rector#9775

## Problem

`GetFiltersToAsTwigFilterAttributeRector` and `GetFunctionsToAsTwigFunctionAttributeRector` removed `extends AbstractExtension` even when the class still needed it, leaving some filters/functions unregistered (and producing broken extensions).

This happened in several cases reported in the issue:

- A registration whose callable cannot become an attribute on a local method, e.g. a `null` callable or an injected-service callable:
  ```php
  new TwigFunction('my_form_function', null, ['is_safe' => ['html']]),
  new TwigFunction('function_name', [$this->myInjectedService, 'serviceFunction']),
  ```
  These items were silently left in `getFunctions()`/`getFilters()` while `extends AbstractExtension` was still dropped.
- The class still defines other Twig extension hooks (`getTests()`, `getGlobals()`, the *other* `get*()` method when only one of the two rules runs, …) or implements `GlobalsInterface`. The parent class is still required to register those, but it was removed.

## Fix

The shared `GetMethodToAsTwigAttributeTransformer` is now **all-or-nothing**:

1. Every item in the returned array is validated *before* any mutation. If a single registration cannot be fully expressed as an attribute on a local method, the class is left untouched (also fixes a latent partial-mutation bug where earlier items were already rewritten before a later item caused a bail-out).
2. `extends AbstractExtension` is only removed — and the conversion only applied — when the class no longer needs the parent extension, i.e. it has no other Twig registration methods (`getTokenParsers`, `getNodeVisitors`, `getFilters`, `getTests`, `getFunctions`, `getOperators`, `getGlobals`) and does not implement `GlobalsInterface`/`ExtensionInterface`.

This guarantees the rules never produce an extension where some filters/functions silently stop being registered.

## Tests

Added skip fixtures covering the reported scenarios:

- `null` callable mixed with a convertible one
- injected-service callable `[$this->service, 'method']`
- remaining `getFilters()` when converting `getFunctions()` (and `getTests()` when converting `getFilters()`)
- class implementing `GlobalsInterface`

All existing fixtures (full, single-method conversions) still convert as before.