### PR TITLE
[Symfony81] Add new rule for deprecated validator test usages

### DIFF
--- a/config/sets/symfony/symfony8/symfony81.php
+++ b/config/sets/symfony/symfony8/symfony81.php
@@ -11,4 +11,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/symfony81/symfony81-serializer.php');
     $rectorConfig->import(__DIR__ . '/symfony81/symfony81-filesystem.php');
     $rectorConfig->import(__DIR__ . '/symfony81/symfony81-security.php');
+    $rectorConfig->import(__DIR__ . '/symfony81/symfony81-validator.php');
 };

--- a/config/sets/symfony/symfony8/symfony81/symfony81-validator.php
+++ b/config/sets/symfony/symfony8/symfony81/symfony81-validator.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rules([
+        ConstraintValidatorValidateToValidateInContextRector::class,
+    ]);
+};

--- a/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/ConstraintValidatorValidateToValidateInContextRectorTest.php
+++ b/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/ConstraintValidatorValidateToValidateInContextRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConstraintValidatorValidateToValidateInContextRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/constraint_validator_test_case.php.inc
+++ b/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/constraint_validator_test_case.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector\Fixture;
+
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class SomeValidatorTest extends ConstraintValidatorTestCase
+{
+    public function testValidate(): void
+    {
+        $this->validator->validate('value', new NotNull());
+    }
+}
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector\Fixture;
+
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class SomeValidatorTest extends ConstraintValidatorTestCase
+{
+    public function testValidate(): void
+    {
+        $this->validate('value', new NotNull());
+    }
+}
+?>

--- a/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/migrate_validate_in_context_in_test_case.php.inc
+++ b/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/migrate_validate_in_context_in_test_case.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector\Fixture;
+
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class AlreadyMigratedValidatorTest extends ConstraintValidatorTestCase
+{
+    public function testValidate(): void
+    {
+        $this->validator->validateInContext('value', new NotNull(), $this->context);
+    }
+}
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector\Fixture;
+
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class AlreadyMigratedValidatorTest extends ConstraintValidatorTestCase
+{
+    public function testValidate(): void
+    {
+        $this->validate('value', new NotNull());
+    }
+}
+?>

--- a/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/skip_contextual_validator.php.inc
+++ b/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/skip_contextual_validator.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Constraints\NotNull;
+
+final class SomeConstraintValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        $validator = $this->context->getValidator()->inContext($this->context);
+        $validator->validate($value, $constraint);
+    }
+}
+?>

--- a/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/skip_self_validate.php.inc
+++ b/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/skip_self_validate.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Constraints\NotNull;
+
+final class RecursiveConstraintValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (\is_array($value)) {
+            foreach ($value as $item) {
+                $this->validate($item, $constraint);
+            }
+
+            return;
+        }
+
+        \assert($constraint instanceof NotNull);
+    }
+}
+?>

--- a/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/skip_validator_interface.php.inc
+++ b/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/Fixture/skip_validator_interface.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class SomeKernelTest extends KernelTestCase
+{
+    private ValidatorInterface $validator;
+
+    public function testValidate(): void
+    {
+        $this->validator->validate(new \stdClass(), null);
+    }
+}
+?>

--- a/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/config/configured_rule.php
+++ b/rules-tests/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ConstraintValidatorValidateToValidateInContextRector::class);
+};

--- a/rules/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector.php
+++ b/rules/Symfony81/Rector/MethodCall/ConstraintValidatorValidateToValidateInContextRector.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Symfony81\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ObjectType;
+use Rector\PHPStan\ScopeFetcher;
+use Rector\Rector\AbstractRector;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://github.com/symfony/symfony/blob/8.1/CHANGELOG.md#validator
+ * @see https://symfony.com/blog/new-in-symfony-8-1-validator-improvements
+ *
+ * @see \Rector\Symfony\Tests\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector\ConstraintValidatorValidateToValidateInContextRectorTest
+ */
+final class ConstraintValidatorValidateToValidateInContextRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Migrate deprecated ConstraintValidatorInterface::validate() in ConstraintValidatorTestCase tests to $this->validate(), otherwise to validateInContext() (Symfony 8.1+).',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class SomeValidatorTest extends ConstraintValidatorTestCase
+{
+    public function test(): void
+    {
+        $this->validator->validate($value, $constraint);
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+final class SomeValidatorTest extends ConstraintValidatorTestCase
+{
+    public function test(): void
+    {
+        $this->validate($value, $constraint);
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isThisValidatorPropertyFetch($node->var)) {
+            return null;
+        }
+
+        if ($this->isObjectType($node->var, new ObjectType(ContextualValidatorInterface::class))) {
+            return null;
+        }
+
+        if ($this->isObjectType($node->var, new ObjectType(ValidatorInterface::class))) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node->var, new ObjectType(ConstraintValidatorInterface::class))) {
+            return null;
+        }
+
+        if ($this->isInsideConstraintValidatorTestCase($node)) {
+            return $this->refactorConstraintValidatorTestCaseCall($node);
+        }
+
+        return $this->refactorConstraintValidatorCall($node);
+    }
+
+    private function refactorConstraintValidatorTestCaseCall(MethodCall $node): ?Node
+    {
+        if ($this->isName($node->name, 'validate') && \count($node->args) === 2) {
+            return $this->createThisValidateMethodCall($node->args[0], $node->args[1]);
+        }
+
+        if ($this->isName($node->name, 'validateInContext') && \count($node->args) === 3) {
+            return $this->createThisValidateMethodCall($node->args[0], $node->args[1]);
+        }
+
+        return null;
+    }
+
+    private function refactorConstraintValidatorCall(MethodCall $node): ?Node
+    {
+        if (! $this->isName($node->name, 'validate')) {
+            return null;
+        }
+
+        if (\count($node->args) !== 2) {
+            return null;
+        }
+
+        if (! $this->isInsideConstraintValidator($node)) {
+            return null;
+        }
+
+        $node->name = new Identifier('validateInContext');
+        $node->args[] = new Arg($this->nodeFactory->createPropertyFetch(new Variable('this'), 'context'));
+
+        return $node;
+    }
+
+    /**
+     * @param Arg $firstArg
+     * @param Arg $secondArg
+     */
+    private function createThisValidateMethodCall(Arg $firstArg, Arg $secondArg): MethodCall
+    {
+        return new MethodCall(
+            new Variable('this'),
+            new Identifier('validate'),
+            [$firstArg, $secondArg],
+        );
+    }
+
+    private function isThisValidatorPropertyFetch(Expr $node): bool
+    {
+        if (! $node instanceof PropertyFetch) {
+            return false;
+        }
+
+        if (! $this->isName($node->name, 'validator')) {
+            return false;
+        }
+
+        return $node->var instanceof Variable && $this->isName($node->var, 'this');
+    }
+
+    private function isInsideConstraintValidatorTestCase(MethodCall $node): bool
+    {
+        return $this->isInsideClassSubclassOf($node, ConstraintValidatorTestCase::class);
+    }
+
+    private function isInsideConstraintValidator(MethodCall $node): bool
+    {
+        return $this->isInsideClassSubclassOf($node, ConstraintValidator::class);
+    }
+
+    private function isInsideClassSubclassOf(MethodCall $node, string $className): bool
+    {
+        $scope = ScopeFetcher::fetch($node);
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        return $classReflection->isSubclassOfClass($this->reflectionProvider->getClass($className));
+    }
+}


### PR DESCRIPTION
According to https://symfony.com/blog/new-in-symfony-8-1-validator-improvements the validator usage needs to change with Symfony 8.1

Tests using ConstraintValidatorTestCase should call $this->validate(...) (a new helper) instead of $this->validator->validate(...).