### PR TITLE
[CodeQuality] Add EventSubscriberMethodReturnVoidRector

### DIFF
--- a/config/sets/symfony/symfony-code-quality.php
+++ b/config/sets/symfony/symfony-code-quality.php
@@ -8,6 +8,7 @@ use Rector\Symfony\CodeQuality\Rector\BinaryOp\RequestIsMainRector;
 use Rector\Symfony\CodeQuality\Rector\BinaryOp\ResponseStatusCodeRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector;
+use Rector\Symfony\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\InlineClassRoutePrefixRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAnnotationRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\SplitAndSecurityAttributeToIsGrantedRector;
@@ -27,6 +28,7 @@ return static function (RectorConfig $rectorConfig): void {
         RedirectToRouteRector::class,
         EventListenerToEventSubscriberRector::class,
         ResponseReturnTypeControllerActionRector::class,
+        EventSubscriberMethodReturnVoidRector::class,
         // int and string literals to const fetches
         ResponseStatusCodeRector::class,
         LiteralGetToRequestClassConstantRector::class,

--- a/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/EventSubscriberMethodReturnVoidRectorTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/EventSubscriberMethodReturnVoidRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EventSubscriberMethodReturnVoidRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/early_return_in_condition.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/early_return_in_condition.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Source\SomeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class EarlyReturnInCondition implements EventSubscriberInterface
+{
+    public function onEvent(SomeEvent $event): SomeEvent
+    {
+        if (mt_rand(0, 1)) {
+            return $event->setResult('yes');
+        }
+
+        return $event->setFailed('no');
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return ['some_event' => 'onEvent'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Source\SomeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class EarlyReturnInCondition implements EventSubscriberInterface
+{
+    public function onEvent(SomeEvent $event): void
+    {
+        if (mt_rand(0, 1)) {
+            $event->setResult('yes');
+            return;
+        }
+
+        $event->setFailed('no');
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return ['some_event' => 'onEvent'];
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/listener_with_priority.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/listener_with_priority.php.inc
@@ -1,0 +1,69 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Source\SomeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ListenerWithPriority implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'first_event' => ['onFirst', 10],
+            'second_event' => [['onSecond', 5], ['onSecondToo']],
+        ];
+    }
+
+    public function onFirst(SomeEvent $event): SomeEvent
+    {
+        return $event->setResult('first');
+    }
+
+    public function onSecond(SomeEvent $event): SomeEvent
+    {
+        return $event->setResult('second');
+    }
+
+    public function onSecondToo(SomeEvent $event): SomeEvent
+    {
+        return $event->setResult('second too');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Source\SomeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ListenerWithPriority implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'first_event' => ['onFirst', 10],
+            'second_event' => [['onSecond', 5], ['onSecondToo']],
+        ];
+    }
+
+    public function onFirst(SomeEvent $event): void
+    {
+        $event->setResult('first');
+    }
+
+    public function onSecond(SomeEvent $event): void
+    {
+        $event->setResult('second');
+    }
+
+    public function onSecondToo(SomeEvent $event): void
+    {
+        $event->setResult('second too');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/skip_already_void.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/skip_already_void.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Source\SomeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class SkipAlreadyVoid implements EventSubscriberInterface
+{
+    public function onEvent(SomeEvent $event): void
+    {
+        $event->setResult('value');
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return ['some_event' => 'onEvent'];
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/skip_method_not_registered.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/skip_method_not_registered.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Source\SomeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class SkipMethodNotRegistered implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return ['some_event' => 'onEvent'];
+    }
+
+    public function onEvent(SomeEvent $event): void
+    {
+        $event->setResult('value');
+    }
+
+    public function notAHook(SomeEvent $event): SomeEvent
+    {
+        return $event->setResult('value');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/skip_non_event_return.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/skip_non_event_return.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Source\SomeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class SkipNonEventReturn implements EventSubscriberInterface
+{
+    public function onEvent(SomeEvent $event): bool
+    {
+        return $event->isPropagationStopped();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return ['some_event' => 'onEvent'];
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/skip_not_subscriber.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Fixture/skip_not_subscriber.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Source\SomeEvent;
+
+final class SkipNotSubscriber
+{
+    public function onEvent(SomeEvent $event): SomeEvent
+    {
+        return $event->setResult('value');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Source/SomeEvent.php
+++ b/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/Source/SomeEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\Source;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class SomeEvent extends Event
+{
+    private ?string $result = null;
+
+    public function setResult(string $result): self
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+
+    public function setFailed(string $message): self
+    {
+        return $this;
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/config/configured_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector;
+
+return RectorConfig::configure()
+    ->withRules([EventSubscriberMethodReturnVoidRector::class]);

--- a/rules/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector.php
+++ b/rules/CodeQuality/Rector/Class_/EventSubscriberMethodReturnVoidRector.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\CodeQuality\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeVisitor;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\ObjectType;
+use Rector\PhpParser\Enum\NodeGroup;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
+use Rector\Symfony\Enum\SymfonyClass;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Symfony\Tests\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector\EventSubscriberMethodReturnVoidRectorTest
+ */
+final class EventSubscriberMethodReturnVoidRector extends AbstractRector
+{
+    /**
+     * @var string[]
+     */
+    private const array EVENT_CLASSES = [
+        'Symfony\Contracts\EventDispatcher\Event',
+        'Symfony\Component\EventDispatcher\Event',
+    ];
+
+    public function __construct(
+        private readonly ReflectionResolver $reflectionResolver,
+        private readonly BetterNodeFinder $betterNodeFinder,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Event subscriber methods hooked in getSubscribedEvents() must return void, as the event is passed by reference and returning it has no effect',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class SomeEventSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return ['some_event' => 'onEvent'];
+    }
+
+    public function onEvent(Event $event): Event
+    {
+        return $event->setSomething('value');
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class SomeEventSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return ['some_event' => 'onEvent'];
+    }
+
+    public function onEvent(Event $event): void
+    {
+        $event->setSomething('value');
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($node);
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        if (! $classReflection->is(SymfonyClass::EVENT_SUBSCRIBER_INTERFACE)) {
+            return null;
+        }
+
+        $getSubscribedEventsClassMethod = $node->getMethod('getSubscribedEvents');
+        if (! $getSubscribedEventsClassMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        $hookMethodNames = $this->resolveHookMethodNames($getSubscribedEventsClassMethod);
+        if ($hookMethodNames === []) {
+            return null;
+        }
+
+        $hasChanged = false;
+        foreach ($hookMethodNames as $hookMethodName) {
+            $classMethod = $node->getMethod($hookMethodName);
+            if (! $classMethod instanceof ClassMethod) {
+                continue;
+            }
+
+            if ($this->refactorHookMethod($classMethod)) {
+                $hasChanged = true;
+            }
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function refactorHookMethod(ClassMethod $classMethod): bool
+    {
+        // void already
+        if ($classMethod->returnType instanceof Identifier && $classMethod->returnType->toString() === 'void') {
+            return false;
+        }
+
+        if (! $this->hasOnlyEventReturns($classMethod)) {
+            return false;
+        }
+
+        $this->rewriteEventReturns($classMethod);
+
+        $classMethod->returnType = new Identifier('void');
+
+        return true;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveHookMethodNames(ClassMethod $getSubscribedEventsClassMethod): array
+    {
+        $methodNames = [];
+
+        $returns = $this->betterNodeFinder->findInstancesOf(
+            (array) $getSubscribedEventsClassMethod->stmts,
+            [Return_::class]
+        );
+        foreach ($returns as $return) {
+            if (! $return->expr instanceof Array_) {
+                continue;
+            }
+
+            foreach ($return->expr->items as $arrayItem) {
+                foreach ($this->resolveMethodNamesFromValue($arrayItem->value) as $methodName) {
+                    $methodNames[] = $methodName;
+                }
+            }
+        }
+
+        return array_unique($methodNames);
+    }
+
+    /**
+     * Each event maps to: 'method', ['method', priority] or [['method', priority], ['method2']]
+     *
+     * @return string[]
+     */
+    private function resolveMethodNamesFromValue(Expr $expr): array
+    {
+        if ($expr instanceof String_) {
+            return [$expr->value];
+        }
+
+        if (! $expr instanceof Array_) {
+            return [];
+        }
+
+        $firstItem = $expr->items[0] ?? null;
+        if ($firstItem === null) {
+            return [];
+        }
+
+        // single listener: ['method', priority]
+        if ($firstItem->value instanceof String_) {
+            return [$firstItem->value->value];
+        }
+
+        // multiple listeners: [['method', priority], ['method2']]
+        $methodNames = [];
+        foreach ($expr->items as $arrayItem) {
+            if (! $arrayItem->value instanceof Array_) {
+                continue;
+            }
+
+            $nestedFirstItem = $arrayItem->value->items[0] ?? null;
+            if ($nestedFirstItem !== null && $nestedFirstItem->value instanceof String_) {
+                $methodNames[] = $nestedFirstItem->value->value;
+            }
+        }
+
+        return $methodNames;
+    }
+
+    private function hasOnlyEventReturns(ClassMethod $classMethod): bool
+    {
+        $returns = $this->betterNodeFinder->findReturnsScoped($classMethod);
+
+        $hasEventReturn = false;
+        foreach ($returns as $return) {
+            // bare "return;" is fine
+            if (! $return->expr instanceof Expr) {
+                continue;
+            }
+
+            if (! $this->isEventExpr($return->expr)) {
+                return false;
+            }
+
+            $hasEventReturn = true;
+        }
+
+        return $hasEventReturn;
+    }
+
+    private function isEventExpr(Expr $expr): bool
+    {
+        $exprType = $this->getType($expr);
+        if (! $exprType instanceof ObjectType) {
+            return false;
+        }
+
+        return array_any(
+            self::EVENT_CLASSES,
+            fn (string $eventClass): bool => $exprType->isInstanceOf($eventClass)
+                ->yes()
+        );
+    }
+
+    private function rewriteEventReturns(ClassMethod $classMethod): void
+    {
+        if ($classMethod->stmts === null) {
+            return;
+        }
+
+        $lastStmt = end($classMethod->stmts) ?: null;
+
+        $this->traverseNodesWithCallable($classMethod, function (Node $node) use ($lastStmt): ?int {
+            // do not touch nested function-like returns
+            if ($node instanceof Closure || $node instanceof Function_ || $node instanceof ArrowFunction) {
+                return NodeVisitor::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            if (! NodeGroup::isStmtAwareNode($node)) {
+                return null;
+            }
+
+            /** @var StmtsAware $node */
+            $this->rewriteStmts($node, $lastStmt);
+
+            return null;
+        });
+    }
+
+    /**
+     * @param StmtsAware $stmtsAware
+     */
+    private function rewriteStmts(Node $stmtsAware, ?Node $lastStmt): void
+    {
+        if ($stmtsAware->stmts === null) {
+            return;
+        }
+
+        $newStmts = [];
+        foreach ($stmtsAware->stmts as $stmt) {
+            if ($stmt instanceof Return_ && $stmt->expr instanceof Expr && $this->isEventExpr($stmt->expr)) {
+                $newStmts[] = new Expression($stmt->expr);
+
+                // keep early return to preserve control flow, unless it is the very last statement
+                if ($stmt !== $lastStmt) {
+                    $newStmts[] = new Return_();
+                }
+
+                continue;
+            }
+
+            $newStmts[] = $stmt;
+        }
+
+        $stmtsAware->stmts = $newStmts;
+    }
+}


### PR DESCRIPTION
Add new code quality rule `EventSubscriberMethodReturnVoidRector`.

Event subscriber methods that hook into an event must return `void` — the event is a class passed by reference, so returning it has no effect.

## How it works

1. Class implements `EventSubscriberInterface` and has `getSubscribedEvents()`.
2. Parses the `getSubscribedEvents()` return array to collect hook method names. Supports all formats:
   - `'event' => 'method'`
   - `'event' => ['method', $priority]`
   - `'event' => [['m1', 10], ['m2']]`
3. For each registered hook method that returns the event, sets return type to `void` and rewrites `return $event->setX(...)` into `$event->setX(...)` (keeping an early `return;` inside branches, dropping it on the final statement).
4. Skips methods already `void` or returning a non-event value. Non-registered methods are left untouched.

### Before

```php
public function onEvent(SomeEvent $event): SomeEvent
{
    if (...) {
        return $event->setResult($response);
    }

    return $event->setFailed(...);
}
```

### After

```php
public function onEvent(SomeEvent $event): void
{
    if (...) {
        $event->setResult($response);
        return;
    }

    $event->setFailed(...);
}
```

Registered in the `symfony-code-quality` set.