### PR TITLE
Remove symplify/phpstan-extensions, use phpstan-rules built-in config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "symfony/validator": "^6.4",
         "symfony/web-link": "^6.4",
         "symplify/easy-coding-standard": "^13.1",
-        "symplify/phpstan-extensions": "^12.0",
         "symplify/phpstan-rules": "^14.10",
         "symplify/vendor-patches": "^11.5",
         "tomasvotruba/class-leak": "^2.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,7 @@ parameters:
     # https://github.com/symplify/phpstan-rules#symfonylaravel-container--get--make-return-type-extensions
     symplify:
         symfonyReturnType: true
+        pathStrings: true
 
     # see https://phpstan.org/writing-php-code/phpdoc-types#global-type-aliases
     typeAliases:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,10 @@ parameters:
     level: 8
     errorFormat: symplify
 
+    # https://github.com/symplify/phpstan-rules#symfonylaravel-container--get--make-return-type-extensions
+    symplify:
+        symfonyReturnType: true
+
     # see https://phpstan.org/writing-php-code/phpdoc-types#global-type-aliases
     typeAliases:
         StmtsAware: \PhpParser\Node\Stmt\Block | \PhpParser\Node\Expr\Closure | \PhpParser\Node\Stmt\Case_ | \PhpParser\Node\Stmt\Catch_ | \PhpParser\Node\Stmt\ClassMethod | \PhpParser\Node\Stmt\Do_ | \PhpParser\Node\Stmt\Else_ | \PhpParser\Node\Stmt\ElseIf_ | \PhpParser\Node\Stmt\Finally_ | \PhpParser\Node\Stmt\For_ | \PhpParser\Node\Stmt\Foreach_ | \PhpParser\Node\Stmt\Function_ | \PhpParser\Node\Stmt\If_ | \PhpParser\Node\Stmt\Namespace_ | \PhpParser\Node\Stmt\TryCatch | \PhpParser\Node\Stmt\While_ | \Rector\PhpParser\Node\FileNode


### PR DESCRIPTION
Drops the separate `symplify/phpstan-extensions` dev dependency. Its features now ship in `symplify/phpstan-rules` via `config/phpstan-extensions.neon` (auto-loaded through `phpstan/extension-installer`):

- `SymplifyErrorFormatter` — keeps `errorFormat: symplify` working
- Symfony container `->get()` return type extension — enabled via new `symplify.symfonyReturnType` parameter

See https://github.com/symplify/phpstan-rules#symfonylaravel-container--get--make-return-type-extensions

PHPStan: clean (718 files).