### PR TITLE
[CodeQuality] Fix ControllerMethodInjectionToConstructorRector skipping services with Document/Model in class name

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/service_with_document_in_name.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/service_with_document_in_name.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class ServiceWithDocumentInName extends AbstractController
+{
+    #[Route('/some-action', name: 'some_action')]
+    public function someAction(
+        \Symfony\Component\HttpFoundation\Request $request,
+        \App\Service\DocumentService $documentService
+    ) {
+        $documentService->process();
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class ServiceWithDocumentInName extends AbstractController
+{
+    public function __construct(private readonly \App\Service\DocumentService $documentService)
+    {
+    }
+    #[Route('/some-action', name: 'some_action')]
+    public function someAction(
+        \Symfony\Component\HttpFoundation\Request $request
+    ) {
+        $this->documentService->process();
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
+++ b/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
@@ -39,7 +39,7 @@ final class ControllerMethodInjectionToConstructorRector extends AbstractRector
     /**
      * @var string[]
      */
-    private const array COMMON_ENTITY_CONTAINS_SUBNAMESPACES = ["\\Entity\\", "\\Document", "\\Model"];
+    private const array COMMON_ENTITY_CONTAINS_SUBNAMESPACES = ["\\Entity\\", "\\Document\\", "\\Model\\"];
 
     public function __construct(
         private readonly ControllerAnalyzer $controllerAnalyzer,


### PR DESCRIPTION
Fixes rectorphp/rector#9794

`ControllerMethodInjectionToConstructorRector` skipped any service whose class name contains `Document` or `Model`, e.g. `App\Service\DocumentService`.

## Cause

The skip list for entity-like namespaces used substring matching without a trailing backslash:

```php
private const array COMMON_ENTITY_CONTAINS_SUBNAMESPACES = ["\\Entity\\", "\\Document", "\\Model"];
```

So `str_contains('App\Service\DocumentService', '\Document')` returned `true` and the service was skipped. The intent was to skip **namespace segments** (`\Document\`, `\Model\` ODM / param-converter entities), not class-name prefixes. `\Entity\` already had the trailing slash.

## Fix

```diff
-    private const array COMMON_ENTITY_CONTAINS_SUBNAMESPACES = ["\\Entity\\", "\\Document", "\\Model"];
+    private const array COMMON_ENTITY_CONTAINS_SUBNAMESPACES = ["\\Entity\\", "\\Document\\", "\\Model\\"];
```

## Before / after

```diff
 final class SomeController extends AbstractController
 {
-    public function someAction(Request $request, \App\Service\DocumentService $documentService)
-    {
-        $documentService->process();
+    public function __construct(private readonly \App\Service\DocumentService $documentService)
+    {
+    }
+    public function someAction(Request $request)
+    {
+        $this->documentService->process();
     }
 }
```

Existing skip fixture for real namespace segments (`\App\Document\SomeEntity`) still matches and is skipped, so param-converter / ODM entities are unaffected.
