### PR TITLE
[Symfony62] Add new rule for `Command` `configure()` return type

### DIFF
--- a/config/sets/symfony/symfony6/symfony62.php
+++ b/config/sets/symfony/symfony6/symfony62.php
@@ -19,6 +19,7 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttribute('Sensio\Bundle\FrameworkExtraBundle\Configuration\Template'),
     ]);
 
+    $rectorConfig->import(__DIR__ . '/symfony62/symfony62-console.php');
     $rectorConfig->import(__DIR__ . '/symfony62/symfony62-security-bundle.php');
     $rectorConfig->import(__DIR__ . '/symfony62/symfony62-security-http.php');
     $rectorConfig->import(__DIR__ . '/symfony62/symfony62-mime.php');

--- a/config/sets/symfony/symfony6/symfony62/symfony62-console.php
+++ b/config/sets/symfony/symfony6/symfony62/symfony62-console.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\VoidType;
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    // @see https://github.com/symfony/symfony/pull/49347
+    $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
+        new AddReturnTypeDeclaration('Symfony\Component\Console\Command\Command', 'configure', new VoidType()),
+    ]);
+};


### PR DESCRIPTION
Based on rules in 6.0 set, this handle `configure()` return type for class extending `Command`