### PR TITLE
[Twig30] Add new set for Twig 30

### DIFF
--- a/config/sets/twig/twig30.php
+++ b/config/sets/twig/twig30.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\MixedType;
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
+
+return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
+        new AddReturnTypeDeclaration('Twig\Extension\ExtensionInterface', 'getFilters', new ArrayType(new MixedType(), new MixedType())),
+        new AddReturnTypeDeclaration('Twig\Extension\ExtensionInterface', 'getTests', new ArrayType(new MixedType(), new MixedType())),
+        new AddReturnTypeDeclaration('Twig\Extension\ExtensionInterface', 'getFunctions', new ArrayType(new MixedType(), new MixedType())),
+    ]);
+};
+

--- a/src/Set/SetProvider/TwigSetProvider.php
+++ b/src/Set/SetProvider/TwigSetProvider.php
@@ -53,6 +53,12 @@ final class TwigSetProvider implements SetProviderInterface
                 '2.4',
                 __DIR__ . '/../../../config/sets/twig/twig24.php'
             ),
+            new ComposerTriggeredSet(
+                SetGroup::TWIG,
+                'twig/twig',
+                '3.0',
+                __DIR__ . '/../../../config/sets/twig/twig30.php'
+            ),
         ];
     }
 }

--- a/src/Set/TwigSetList.php
+++ b/src/Set/TwigSetList.php
@@ -21,5 +21,7 @@ final class TwigSetList
 
     public const string TWIG_24 = __DIR__ . '/../../config/sets/twig/twig24.php';
 
+    public const string TWIG_30 = __DIR__ . '/../../config/sets/twig/twig30.php';
+
     public const string TWIG_UNDERSCORE_TO_NAMESPACE = __DIR__ . '/../../config/sets/twig/twig-underscore-to-namespace.php';
 }


### PR DESCRIPTION
Twig 3 is the first one requiring PHP 8.1, which is triggering deprecations if return type is not present