### PR TITLE
[CodeQuality] Add union and method call return type support to ResponseReturnTypeControllerActionRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/action_suffix_no_route.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/action_suffix_no_route.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class ActionSuffixNoRoute extends AbstractController
+{
+    /**
+     * Deletes an entity.
+     *
+     * @param int $id Entity ID
+     */
+    public function deleteEntityAction($id)
+    {
+        return $this->redirectToRoute('some_route', ['id' => $id]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class ActionSuffixNoRoute extends AbstractController
+{
+    /**
+     * Deletes an entity.
+     *
+     * @param int $id Entity ID
+     */
+    public function deleteEntityAction($id): \Symfony\Component\HttpFoundation\RedirectResponse
+    {
+        return $this->redirectToRoute('some_route', ['id' => $id]);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/handle_view_trait.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/handle_view_trait.php.inc
@@ -1,0 +1,69 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source\ControllerTrait;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class HandleViewTrait extends AbstractController
+{
+    use ControllerTrait;
+
+    /**
+     * @Route()
+     */
+    public function sendAction()
+    {
+        if (mt_rand(0, 1)) {
+            return new JsonResponse('disabled');
+        }
+
+        if (mt_rand(0, 1)) {
+            return new Response('error', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        $view = $this->view(['success' => true], Response::HTTP_OK);
+
+        return $this->handleView($view);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source\ControllerTrait;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class HandleViewTrait extends AbstractController
+{
+    use ControllerTrait;
+
+    /**
+     * @Route()
+     */
+    public function sendAction(): \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
+    {
+        if (mt_rand(0, 1)) {
+            return new JsonResponse('disabled');
+        }
+
+        if (mt_rand(0, 1)) {
+            return new Response('error', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        $view = $this->view(['success' => true], Response::HTTP_OK);
+
+        return $this->handleView($view);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/handle_view_trait_only.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/handle_view_trait_only.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source\ControllerTrait;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class HandleViewTraitOnly extends AbstractController
+{
+    use ControllerTrait;
+
+    /**
+     * @Route()
+     */
+    public function listAction()
+    {
+        $view = $this->view(['ok' => true]);
+
+        return $this->handleView($view);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source\ControllerTrait;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class HandleViewTraitOnly extends AbstractController
+{
+    use ControllerTrait;
+
+    /**
+     * @Route()
+     */
+    public function listAction(): \Symfony\Component\HttpFoundation\Response
+    {
+        $view = $this->view(['ok' => true]);
+
+        return $this->handleView($view);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/union_json_and_response.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/union_json_and_response.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class UnionJsonAndResponse extends AbstractController
+{
+    /**
+     * @Route()
+     */
+    public function sendAction()
+    {
+        if (mt_rand(0, 1)) {
+            return new JsonResponse('yes');
+        }
+
+        return new Response('no');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class UnionJsonAndResponse extends AbstractController
+{
+    /**
+     * @Route()
+     */
+    public function sendAction(): \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
+    {
+        if (mt_rand(0, 1)) {
+            return new JsonResponse('yes');
+        }
+
+        return new Response('no');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Source/ControllerTrait.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Source/ControllerTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Mimics FOS\RestBundle\Controller\ControllerTrait
+ */
+trait ControllerTrait
+{
+    /**
+     * @return View
+     */
+    protected function view($data = null, ?int $statusCode = null, array $headers = [])
+    {
+        return View::create($data, $statusCode, $headers);
+    }
+
+    /**
+     * @return Response
+     */
+    protected function handleView(View $view)
+    {
+        return new Response();
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Source/View.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Source/View.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source;
+
+final class View
+{
+    public static function create($data = null, ?int $statusCode = null, array $headers = []): self
+    {
+        return new self();
+    }
+}

--- a/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->attrinationFinder->hasByOne($node, SymfonyAnnotation::ROUTE)) {
+        if (! $this->isActionClassMethod($node)) {
             return null;
         }
 
@@ -175,6 +175,15 @@ CODE_SAMPLE
         }
 
         return true;
+    }
+
+    private function isActionClassMethod(ClassMethod $classMethod): bool
+    {
+        if ($this->attrinationFinder->hasByOne($classMethod, SymfonyAnnotation::ROUTE)) {
+            return true;
+        }
+
+        return str_ends_with($this->getName($classMethod), 'Action');
     }
 
     private function hasReturn(ClassMethod $classMethod): bool

--- a/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
@@ -7,12 +7,12 @@ namespace Rector\Symfony\CodeQuality\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\UnionType as PhpParserUnionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -214,16 +214,11 @@ CODE_SAMPLE
             return $classMethod;
         }
 
-        return $this->refatorWithNew($classMethod);
+        return $this->refactorReturnedType($classMethod);
     }
 
-    private function refatorWithNew(ClassMethod $classMethod): ?ClassMethod
+    private function refactorReturnedType(ClassMethod $classMethod): ?ClassMethod
     {
-        // early check
-        if (! $this->betterNodeFinder->hasInstancesOf($classMethod, [New_::class])) {
-            return null;
-        }
-
         $returns = $this->betterNodeFinder->findReturnsScoped($classMethod);
         if (! $this->returnAnalyzer->hasOnlyReturnWithExpr($classMethod, $returns)) {
             return null;
@@ -235,7 +230,7 @@ CODE_SAMPLE
         }
 
         $returnType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($responseReturnType, TypeKind::RETURN);
-        if (! $returnType instanceof FullyQualified) {
+        if (! $returnType instanceof FullyQualified && ! $returnType instanceof PhpParserUnionType) {
             return null;
         }
 


### PR DESCRIPTION
Two gaps in `ResponseReturnTypeControllerActionRector`.

## 1. Union return types were resolved, then dropped

The rule already built a `UnionType` of the returned Response types, but only accepted `FullyQualified` back from the type mapper. A union maps to a `PhpParser\Node\UnionType`, so the rule silently bailed:

```diff
 final class UnionJsonAndResponse extends AbstractController
 {
     #[Route]
-    public function sendAction()
+    public function sendAction(): \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
     {
         if (mt_rand(0, 1)) {
             return new JsonResponse('yes');
         }

         return new Response('no');
     }
 }
```

## 2. Actions returning a Response from a method call only were skipped

`refatorWithNew()` early-returned unless the action contained a `new` anywhere. That excluded actions whose Response comes purely from a method call - e.g. FOSRestBundle `ControllerTrait::handleView()`, which is annotated `@return Response`:

```diff
 final class HandleViewTraitOnly extends AbstractController
 {
     use ControllerTrait;

     #[Route]
-    public function listAction()
+    public function listAction(): \Symfony\Component\HttpFoundation\Response
     {
         $view = $this->view(['ok' => true]);

         return $this->handleView($view);
     }
 }
```

The `new` check was only a shortcut; `resolveResponseOnlyReturnType()` already gates on every return being a `Response` descendant, so non-Response returns are still skipped.

Both combine on the real-world FOSRestBundle shape that motivated this - mixed `new JsonResponse()` / `new Response()` / `$this->handleView($view)` returns now get `JsonResponse|Response`.

## 3. Public `*Action()` methods without a Route are now matched

Only methods carrying a `Route` annotation/attribute were considered actions. Legacy controllers configure routing outside the class and rely on the `Action` suffix instead, so they were skipped:

```diff
 final class ActionSuffixNoRoute extends AbstractController
 {
     /**
      * Deletes an entity.
      *
      * @param int $id Entity ID
      */
-    public function deleteEntityAction($id)
+    public function deleteEntityAction($id): \Symfony\Component\HttpFoundation\RedirectResponse
     {
         return $this->redirectToRoute('some_route', ['id' => $id]);
     }
 }
```

A public method is now treated as an action if it has a `Route` **or** its name ends with `Action`. Public non-action methods without the suffix (e.g. `detail()`) stay skipped.
