### PR TITLE
Rebuild scoped Rector after a pull request is merged

### DIFF
--- a/.github/workflows/dispatch_build_scoped_rector.yaml
+++ b/.github/workflows/dispatch_build_scoped_rector.yaml
@@ -1,0 +1,43 @@
+# github action that rebuilds https://github.com/rectorphp/rector
+# with the freshly merged rector-symfony main
+name: Dispatch Build Scoped Rector
+
+on:
+    pull_request:
+        types:
+            - closed
+
+jobs:
+    dispatch_build_scoped_rector:
+        # only for merged pull requests in this repository, not forks
+        if: github.event.pull_request.merged == true && github.repository == 'rectorphp/rector-symfony'
+
+        runs-on: ubuntu-latest
+
+        steps:
+            # a tagged main is already being published by the tag build of rector-src,
+            # dispatching a second build would race it for the push to rectorphp/rector
+            -
+                name: "Check whether rector-src main is a release tag commit"
+                id: release_tag
+                run: |
+                    RECTOR_SRC="https://github.com/rectorphp/rector-src.git"
+
+                    MAIN_SHA=$(git ls-remote $RECTOR_SRC refs/heads/main | cut -f1)
+                    if [ -z "$MAIN_SHA" ]; then
+                        echo "Could not resolve rector-src main"
+                        exit 1
+                    fi
+
+                    # lightweight tags are listed with the commit itself, annotated ones with a "^{}" line
+                    if git ls-remote --tags $RECTOR_SRC | grep -q "^${MAIN_SHA}"; then
+                        echo "rector-src main $MAIN_SHA is tagged, leaving the build to the tag itself"
+                        echo "tagged=true" >> $GITHUB_OUTPUT
+                    fi
+
+            -
+                name: "Trigger build_scoped_rector.yaml in rectorphp/rector-src"
+                if: steps.release_tag.outputs.tagged != 'true'
+                env:
+                    GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+                run: gh workflow run build_scoped_rector.yaml --repo rectorphp/rector-src --ref main


### PR DESCRIPTION
Port of rectorphp/rector-phpunit#730 and rectorphp/rector-phpunit#731 to this repository.

Merging a rule pull request here changes `rectorphp/rector` only once something else lands in `rector-src` main and retriggers its build. This dispatches that build directly instead.

New `.github/workflows/dispatch_build_scoped_rector.yaml`, identical to the `rector-phpunit` one except for the repository guard:

```yaml
on:
    pull_request:
        types:
            - closed

jobs:
    dispatch_build_scoped_rector:
        # only for merged pull requests in this repository, not forks
        if: github.event.pull_request.merged == true && github.repository == 'rectorphp/rector-symfony'
```

`pull_request: closed` fires on every close, so the `merged == true` check is what limits it to merges. Closed-without-merge dispatches nothing. Reuses the `ACCESS_TOKEN` secret already used by `rector.yaml.yml`.

## Tag check

Carried over from rector-phpunit#731. When `rector-src` main sits on a release tag commit, that commit is already being published to `rectorphp/rector` by the tag build. Dispatching a second build makes the two race each other for `git push origin main`, and the loser fails on a non fast forward push.

`git ls-remote --tags` is used rather than the tags API because `git/refs/tags` exposes the sha of the *tag object* for an annotated tag, not of the commit, so a comparison against a commit sha silently never matches. `ls-remote` lists a lightweight tag with the commit itself and an annotated tag with an extra `^{}` line, so matching on line start covers both.

## Verified

Preconditions checked against live repositories rather than assumed:

- `build_scoped_rector.yaml` in `rector-src` carries `workflow_dispatch: null`, commented "allows rector-* package repositories to rebuild after their pull request is merged", so `gh workflow run` resolves here. (This was the HTTP 422 blocker in rector-phpunit#730; rectorphp/rector-src#8188 has since landed.)
- `ACCESS_TOKEN` already exists in this repository, used by `rector.yaml.yml`.

The tag-check script was run as is against live `rector-src`:

- main `c607ef0`, untagged, writes no output, so the dispatch runs
- lightweight tag `2.5.7` (`653ec23`), detected, writes `tagged=true`, so the dispatch is skipped

## Two things worth confirming before merging

`ACCESS_TOKEN` needs `actions: write` on `rectorphp/rector-src`. `rector.yaml.yml` only uses it to push to this repository, so cross-repository scope is unconfirmed here just as it was in rector-phpunit#730 — if that has since been verified for `rector-phpunit`, the same token settings apply and this is a non-issue.

The dispatch fires at merge time, but the build resolves `rector-symfony` `dev-main` through Packagist, which can lag a merge by a few minutes. A dispatched build may rebuild against the previous `main`. A Packagist update hook on this repository is the fix; not included here.
