### PR TITLE
[Symfony44] Return 1 instead of (int) false in ConsoleExecuteReturnIntRector

### DIFF
--- a/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/return_false.php.inc
+++ b/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/return_false.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ReturnFalseCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        return false;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ReturnFalseCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return 1;
+    }
+}
+
+?>

--- a/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -203,6 +203,12 @@ CODE_SAMPLE
             return;
         }
 
+        // false means the command failed, that is the 1 exit code
+        if ($this->valueResolver->isFalse($return->expr)) {
+            $return->expr = new \PhpParser\Node\Scalar\Int_(1);
+            return;
+        }
+
         if ($return->expr instanceof Coalesce && $this->valueResolver->isNull($return->expr->right)) {
             $return->expr->right = new \PhpParser\Node\Scalar\Int_(0);
             return;


### PR DESCRIPTION
Casting `false` to int yields `0` — the **SUCCESS** exit code. But a command returning `false` means it *failed*, so the cast silently inverts the intent.

This maps `return false;` to `return 1;` (`Command::FAILURE`) instead.

```diff
 final class ReturnFalseCommand extends Command
 {
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
-        return false;
+        return 1;
     }
 }
```

Before this change, the rule produced `return (int) false;` — a command that reported success on failure.

## Note on `return true;`

The mirror case is still cast: `return true;` becomes `return (int) true;` = `1` = FAILURE, when the intent is success (`0`). Left out of this PR to keep the scope tight — happy to follow up if wanted.