### PR TITLE
[CodeQuality] Respect typeGuardedClasses and skip closure-only returns in ResponseReturnTypeControllerActionRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/skip_return_in_closure_only.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Fixture/skip_return_in_closure_only.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class SkipReturnInClosureOnly extends AbstractController
+{
+    #[Route]
+    public function detail()
+    {
+        $callback = function () {
+            return 'hey';
+        };
+
+        $callback();
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/FixtureTypeGuarded/final_controller.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/FixtureTypeGuarded/final_controller.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\FixtureTypeGuarded;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class FinalController extends AbstractController
+{
+    #[Route]
+    public function detail()
+    {
+        return $this->render('some_template');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\FixtureTypeGuarded;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class FinalController extends AbstractController
+{
+    #[Route]
+    public function detail(): \Symfony\Component\HttpFoundation\Response
+    {
+        return $this->render('some_template');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/FixtureTypeGuarded/non_guarded_controller.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/FixtureTypeGuarded/non_guarded_controller.php.inc
@@ -2,10 +2,10 @@
 
 namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\FixtureTypeGuarded;
 
-use Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source\AbstractCustomController;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
-final class FinalController extends AbstractCustomController
+class NonGuardedController extends AbstractController
 {
     #[Route]
     public function detail()
@@ -20,10 +20,10 @@ final class FinalController extends AbstractCustomController
 
 namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\FixtureTypeGuarded;
 
-use Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source\AbstractCustomController;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 
-final class FinalController extends AbstractCustomController
+class NonGuardedController extends AbstractController
 {
     #[Route]
     public function detail(): \Symfony\Component\HttpFoundation\Response

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/FixtureTypeGuarded/skip_type_guarded_controller.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/FixtureTypeGuarded/skip_type_guarded_controller.php.inc
@@ -2,10 +2,10 @@
 
 namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\FixtureTypeGuarded;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source\AbstractCustomController;
 use Symfony\Component\Routing\Annotation\Route;
 
-class SkipTypeGuardedController extends AbstractController
+class SkipTypeGuardedController extends AbstractCustomController
 {
     #[Route]
     public function detail()

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/FixtureTypeGuarded/skip_type_guarded_controller.php.inc
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/FixtureTypeGuarded/skip_type_guarded_controller.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\FixtureTypeGuarded;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+class SkipTypeGuardedController extends AbstractController
+{
+    #[Route]
+    public function detail()
+    {
+        return $this->render('some_template');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/ResponseReturnTypeControllerActionRectorTypeGuardedTest.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/ResponseReturnTypeControllerActionRectorTypeGuardedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ResponseReturnTypeControllerActionRectorTypeGuardedTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureTypeGuarded');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/type_guarded_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Source/AbstractCustomController.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/Source/AbstractCustomController.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+abstract class AbstractCustomController extends AbstractController
+{
+}

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/config/type_guarded_rule.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/config/type_guarded_rule.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Symfony\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Rector\Symfony\Tests\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector\Source\AbstractCustomController;
 
 return RectorConfig::configure()
     ->withRules([ResponseReturnTypeControllerActionRector::class])
-    ->withTypeGuardedClasses([AbstractController::class]);
+    ->withTypeGuardedClasses([AbstractCustomController::class]);

--- a/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/config/type_guarded_rule.php
+++ b/rules-tests/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector/config/type_guarded_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+return RectorConfig::configure()
+    ->withRules([ResponseReturnTypeControllerActionRector::class])
+    ->withTypeGuardedClasses([AbstractController::class]);

--- a/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/ResponseReturnTypeControllerActionRector.php
@@ -30,6 +30,7 @@ use Rector\Symfony\TypeAnalyzer\ControllerAnalyzer;
 use Rector\TypeDeclaration\NodeAnalyzer\ReturnAnalyzer;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 use Rector\ValueObject\PhpVersionFeature;
+use Rector\VendorLocker\ParentClassMethodTypeOverrideGuard;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -45,7 +46,8 @@ final class ResponseReturnTypeControllerActionRector extends AbstractRector impl
         private readonly BetterNodeFinder $betterNodeFinder,
         private readonly ReturnAnalyzer $returnAnalyzer,
         private readonly StaticTypeMapper $staticTypeMapper,
-        private readonly ReturnTypeInferer $returnTypeInferer
+        private readonly ReturnTypeInferer $returnTypeInferer,
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
     ) {
     }
 
@@ -109,6 +111,11 @@ CODE_SAMPLE
         }
 
         if (! $this->controllerAnalyzer->isInsideController($node)) {
+            return null;
+        }
+
+        // adding a return type would break child classes of user-guarded classes
+        if ($this->parentClassMethodTypeOverrideGuard->isTypeGuardedClass($node)) {
             return null;
         }
 
@@ -188,7 +195,7 @@ CODE_SAMPLE
 
     private function hasReturn(ClassMethod $classMethod): bool
     {
-        return $this->betterNodeFinder->hasInstancesOf($classMethod, [Return_::class]);
+        return $this->betterNodeFinder->hasInstancesOfInFunctionLikeScoped($classMethod, Return_::class);
     }
 
     private function refactorResponse(ClassMethod $classMethod): ?ClassMethod


### PR DESCRIPTION
Two fixes for `ResponseReturnTypeControllerActionRector`.

## 1. Respect `typeGuardedClasses`

Follow-up to rectorphp/rector-src#8135. The rule wrote return types even into classes the user guarded via `withTypeGuardedClasses()`, which is a breaking change for their child classes. Now it bails out through `ParentClassMethodTypeOverrideGuard::isTypeGuardedClass()`.

With `->withTypeGuardedClasses([AbstractCustomController::class])`:

```diff
-class SomeController extends AbstractCustomController
+class SomeController extends AbstractCustomController // non-final = guarded, left alone
 {
     #[Route]
     public function detail()
     {
         return $this->render('some_template');
     }
 }
```

Final classes cannot be extended, so they are still refactored:

```diff
 final class SomeController extends AbstractCustomController
 {
     #[Route]
-    public function detail()
+    public function detail(): \Symfony\Component\HttpFoundation\Response
     {
         return $this->render('some_template');
     }
 }
```

Controllers outside the guarded tree are untouched by the option:

```diff
 class SomeController extends AbstractController
 {
     #[Route]
-    public function detail()
+    public function detail(): \Symfony\Component\HttpFoundation\Response
     {
         return $this->render('some_template');
     }
 }
```

## 2. Skip methods whose only `return` lives in a closure

`hasReturn()` used the unscoped `hasInstancesOf()`, so a closure body counted as the method's return. `isResponseReturnMethod()` then saw zero scoped returns and vacuously returned `true`, producing a bogus type on a method that returns nothing:

```diff
 final class SomeController extends AbstractController
 {
     #[Route]
-    public function detail()
+    public function detail(): \Symfony\Component\HttpFoundation\RedirectResponse
     {
         $callback = function () {
             return 'hey';
         };

         $callback();
     }
 }
```

Switched to `hasInstancesOfInFunctionLikeScoped()`.