### PR TITLE
[Symfony61] Remove now empty configure() method in CommandConfigureToAttributeRector

### DIFF
--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/do_not_re_add_to_attribute_when_exists.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/do_not_re_add_to_attribute_when_exists.php.inc
@@ -37,11 +37,6 @@ use Symfony\Component\Console\Command\Command;
 )]
 class DoNotReAddToAttributeWhenExists extends Command
 {
-
-    protected function configure(): void
-    {
-        parent::configure();
-    }
 }
 
 ?>

--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/hybrid.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/hybrid.php.inc
@@ -22,9 +22,6 @@ namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttribu
 #[\Symfony\Component\Console\Attribute\AsCommand(name: 'sunshine', description: 'rising above', aliases: ['first', 'second'], hidden: true)]
 final class Hybrid extends \Symfony\Component\Console\Command\Command
 {
-    public function configure()
-    {
-    }
 }
 
 ?>

--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_aliases.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_aliases.php.inc
@@ -20,9 +20,6 @@ namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttribu
 #[\Symfony\Component\Console\Attribute\AsCommand(name: 'sunshine', aliases: ['first', 'second'])]
 final class NameAndAliases extends \Symfony\Component\Console\Command\Command
 {
-    public function configure()
-    {
-    }
 }
 
 ?>

--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_description_fluent.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_description_fluent.php.inc
@@ -20,9 +20,6 @@ namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttribu
 #[\Symfony\Component\Console\Attribute\AsCommand(name: 'sunshine', description: 'rising above')]
 final class NameAndDescriptionFluent extends \Symfony\Component\Console\Command\Command
 {
-    public function configure()
-    {
-    }
 }
 
 ?>

--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_hidden.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_hidden.php.inc
@@ -21,9 +21,6 @@ namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttribu
 #[\Symfony\Component\Console\Attribute\AsCommand(name: 'sunshine', aliases: ['first', 'second'], hidden: true)]
 final class NameAndHidden extends \Symfony\Component\Console\Command\Command
 {
-    public function configure()
-    {
-    }
 }
 
 ?>

--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_hidden_false.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_hidden_false.php.inc
@@ -20,9 +20,6 @@ namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttribu
 #[\Symfony\Component\Console\Attribute\AsCommand(name: 'sunshine', hidden: false)]
 final class NameAndHiddenFalse extends \Symfony\Component\Console\Command\Command
 {
-    public function configure()
-    {
-    }
 }
 
 ?>

--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_parent_configure.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/name_and_parent_configure.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttributeRector\Fixture;
+
+final class NameAndParentConfigure extends \Symfony\Component\Console\Command\Command
+{
+    protected function configure(): void
+    {
+        $this->setName('mautic:fake:command');
+
+        parent::configure();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttributeRector\Fixture;
+
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'mautic:fake:command')]
+final class NameAndParentConfigure extends \Symfony\Component\Console\Command\Command
+{
+}
+
+?>

--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/some_command.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/some_command.php.inc
@@ -19,9 +19,6 @@ namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttribu
 #[\Symfony\Component\Console\Attribute\AsCommand(name: 'sunshine')]
 final class SomeCommand extends \Symfony\Component\Console\Command\Command
 {
-    public function configure()
-    {
-    }
 }
 
 ?>

--- a/rules/Symfony61/Rector/Class_/CommandConfigureToAttributeRector.php
+++ b/rules/Symfony61/Rector/Class_/CommandConfigureToAttributeRector.php
@@ -9,8 +9,10 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -177,7 +179,52 @@ CODE_SAMPLE),
             }
         }
 
+        // remove now empty configure() method, only a possible parent::configure() call left
+        if ($this->isEmptyConfigureClassMethod($configureClassMethod)) {
+            foreach ($node->stmts as $key => $classStmt) {
+                if ($classStmt === $configureClassMethod) {
+                    unset($node->stmts[$key]);
+                    break;
+                }
+            }
+        }
+
         return $node;
+    }
+
+    private function isEmptyConfigureClassMethod(ClassMethod $classMethod): bool
+    {
+        foreach ((array) $classMethod->stmts as $stmt) {
+            if ($this->isParentConfigureCall($stmt)) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isParentConfigureCall(Stmt $stmt): bool
+    {
+        if (! $stmt instanceof Expression) {
+            return false;
+        }
+
+        if (! $stmt->expr instanceof StaticCall) {
+            return false;
+        }
+
+        $staticCall = $stmt->expr;
+        if (! $staticCall->class instanceof Name) {
+            return false;
+        }
+
+        if (! $staticCall->class->isSpecialClassName() || $staticCall->class->toString() !== 'parent') {
+            return false;
+        }
+
+        return $this->isName($staticCall->name, 'configure');
     }
 
     private function createNamedArg(string $name, Expr $expr): Arg

--- a/tests/Issues/Issue638/Fixture/name_and_description_order.php.inc
+++ b/tests/Issues/Issue638/Fixture/name_and_description_order.php.inc
@@ -38,10 +38,6 @@ final class NameAndDescriptionOrder extends Command
 {
     private const COMMAND = 'command';
 
-    protected function configure(): void
-    {
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         //...


### PR DESCRIPTION
When `CommandConfigureToAttributeRector` moves `setName()`/`setDescription()`/`setAliases()`/`setHidden()` into the `#[AsCommand]` attribute, the `configure()` method is often left empty (or with only a `parent::configure()` call).

This extends the rule to remove the whole `configure()` method when nothing meaningful remains — either fully empty, or only a `parent::configure()` call left.

```diff
 use Symfony\Component\Console\Command\Command;

-final class SunshineCommand extends Command
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'mautic:fake:command')]
+final class SunshineCommand extends Command
 {
-    protected function configure(): void
-    {
-        $this->setName('mautic:fake:command');
-
-        parent::configure();
-    }
 }
```

The method is **kept** when real leftover calls remain (`addOption()`, `addArgument()`, `setHelp()`, …):

```diff
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'sunshine', aliases: ['first', 'second'])]
 final class OtherCalls extends Command
 {
     public function configure()
     {
-        $this->setName('sunshine')
-            ->setAliases(['first', 'second'])
-            ->addArgument('argument name');
+        $this
+            ->addArgument('argument name');
     }
 }
```