### PR TITLE
[Symfony61] Remove empty configure() method even with empty body

### DIFF
--- a/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/empty_configure_body.php.inc
+++ b/rules-tests/Symfony61/Rector/Class_/CommandConfigureToAttributeRector/Fixture/empty_configure_body.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttributeRector\Fixture;
+
+final class EmptyConfigureBody extends \Symfony\Component\Console\Command\Command
+{
+    protected function configure(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Class_\CommandConfigureToAttributeRector\Fixture;
+
+final class EmptyConfigureBody extends \Symfony\Component\Console\Command\Command
+{
+}
+
+?>

--- a/rules/Symfony61/Rector/Class_/CommandConfigureToAttributeRector.php
+++ b/rules/Symfony61/Rector/Class_/CommandConfigureToAttributeRector.php
@@ -142,14 +142,6 @@ CODE_SAMPLE),
             }
         }
 
-        if (! $asCommandAttribute instanceof Attribute) {
-            $asCommandAttributeGroup = $this->phpAttributeGroupFactory->createFromClass(SymfonyAttribute::AS_COMMAND);
-
-            $asCommandAttribute = $asCommandAttributeGroup->attrs[0];
-
-            $node->attrGroups[] = $asCommandAttributeGroup;
-        }
-
         $existingAttributeNames = array_map(
             function (Arg $arg): string {
                 Assert::isInstanceOf($arg->name, Identifier::class);
@@ -170,7 +162,21 @@ CODE_SAMPLE),
             $attributeArgs[] = $this->createNamedArg($attributeName, $resolvedExpr);
         }
 
-        $asCommandAttribute->args = $attributeArgs;
+        // only create/update the attribute when there is something to fill it with,
+        // to avoid adding an empty #[AsCommand] to an already empty configure()
+        if ($attributeArgs !== []) {
+            if (! $asCommandAttribute instanceof Attribute) {
+                $asCommandAttributeGroup = $this->phpAttributeGroupFactory->createFromClass(
+                    SymfonyAttribute::AS_COMMAND
+                );
+
+                $asCommandAttribute = $asCommandAttributeGroup->attrs[0];
+
+                $node->attrGroups[] = $asCommandAttributeGroup;
+            }
+
+            $asCommandAttribute->args = $attributeArgs;
+        }
 
         // remove left overs
         foreach ((array) $configureClassMethod->stmts as $key => $stmt) {


### PR DESCRIPTION
Follow-up to #965.

`CommandConfigureToAttributeRector` now removes the `configure()` method when it has an empty body — and, importantly, no longer adds a useless empty `#[AsCommand]` attribute when there is nothing to move into it.

```diff
 final class EmptyConfigureBody extends \Symfony\Component\Console\Command\Command
 {
-    protected function configure(): void
-    {
-    }
 }
```

Previously an already-empty `configure()` would have gained a bogus `#[AsCommand]` with no arguments. The attribute is now only created/updated when there is at least one resolved argument (`name`, `description`, `aliases`, `hidden`).

Non-empty `configure()` bodies are untouched — the method is kept when real leftover calls remain (`addOption()`, `addArgument()`, `setHelp()`, …).