### PR TITLE
[Symfony73] Wrap scalar groups option in array in ConstraintOptionsToNamedArgumentsRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector/Fixture/groups_scalar_to_array.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector/Fixture/groups_scalar_to_array.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector\Fixture;
+
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class GroupsScalarToArray
+{
+    public function run()
+    {
+        return new NotBlank(['groups' => 'indexableFieldWithLimits']);
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector\Fixture;
+
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class GroupsScalarToArray
+{
+    public function run()
+    {
+        return new NotBlank(groups: ['indexableFieldWithLimits']);
+    }
+}
+?>

--- a/rules/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector.php
+++ b/rules/Symfony73/Rector/Class_/ConstraintOptionsToNamedArgumentsRector.php
@@ -162,7 +162,14 @@ CODE_SAMPLE
                 }
             }
 
-            $arg = new Arg($item->value);
+            $argValue = $item->value;
+
+            // the "groups" constructor argument is typed as array, so a scalar option must be wrapped
+            if ($keyValue === 'groups' && ! $argValue instanceof Array_) {
+                $argValue = new Array_([new ArrayItem($argValue)]);
+            }
+
+            $arg = new Arg($argValue);
             $arg->name = new Identifier($keyValue);
 
             $namedArgs[] = $arg;


### PR DESCRIPTION
The `groups` constructor argument of Symfony constraints is typed as `array`. When the array option value is a scalar string, the rule incorrectly passed it straight through, producing an invalid named argument.

```diff
-new Assert\NotBlank(['groups' => 'indexableFieldWithLimits']);
+new Assert\NotBlank(groups: ['indexableFieldWithLimits']);
```

Before this fix the rule produced `groups: 'indexableFieldWithLimits'` (scalar), which does not match the `array` parameter type.

Scalar `groups` values are now wrapped in an array.