### PR TITLE
[Symfony73] Remove empty configure() method in CommandHelpToAttributeRector

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/CommandHelpToAttributeRector/Fixture/remove_configure_with_parent_call.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/CommandHelpToAttributeRector/Fixture/remove_configure_with_parent_call.php.inc
@@ -6,10 +6,12 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 
 #[AsCommand(name: 'some_name')]
-final class AddHelpToAttributeCommand extends Command
+final class RemoveConfigureWithParentCall extends Command
 {
     public function configure()
     {
+        parent::configure();
+
         $this->setHelp('Some help text');
     }
 }
@@ -26,7 +28,7 @@ use Symfony\Component\Console\Command\Command;
 #[AsCommand(name: 'some_name', help: <<<'TXT'
 Some help text
 TXT)]
-final class AddHelpToAttributeCommand extends Command
+final class RemoveConfigureWithParentCall extends Command
 {
 }
 

--- a/rules/Symfony73/Rector/Class_/CommandHelpToAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/CommandHelpToAttributeRector.php
@@ -10,8 +10,10 @@ use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
@@ -142,11 +144,52 @@ CODE_SAMPLE
 
         $asCommandAttribute->args[] = new Arg($wrappedHelpString, false, false, [], new Identifier('help'));
 
-        if ($configureClassMethod->stmts === []) {
-            unset($configureClassMethod);
+        // remove now empty configure() method, only a possible parent::configure() call left
+        if ($this->isEmptyConfigureClassMethod($configureClassMethod)) {
+            foreach ($node->stmts as $key => $classStmt) {
+                if ($classStmt === $configureClassMethod) {
+                    unset($node->stmts[$key]);
+                    break;
+                }
+            }
         }
 
         return $node;
+    }
+
+    private function isEmptyConfigureClassMethod(ClassMethod $classMethod): bool
+    {
+        foreach ((array) $classMethod->stmts as $stmt) {
+            if ($this->isParentConfigureCall($stmt)) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isParentConfigureCall(Stmt $stmt): bool
+    {
+        if (! $stmt instanceof Expression) {
+            return false;
+        }
+
+        if (! $stmt->expr instanceof StaticCall) {
+            return false;
+        }
+
+        $staticCall = $stmt->expr;
+        if (! $staticCall->class instanceof Name) {
+            return false;
+        }
+
+        if (! $staticCall->class->isSpecialClassName() || $staticCall->class->toString() !== 'parent') {
+            return false;
+        }
+
+        return $this->isName($staticCall->name, CommandMethodName::CONFIGURE);
     }
 
     /**


### PR DESCRIPTION
Once `setHelp()` is moved to the `#[AsCommand]` attribute, the `configure()` method is often left empty. The removal code was a no-op — it `unset()` a local variable instead of removing the method from the class.

Now the empty `configure()` is removed, the same way [#966](https://github.com/rectorphp/rector-symfony/pull/966) does it for `CommandConfigureToAttributeRector`. A leftover `parent::configure()` call counts as empty too.

```diff
 #[AsCommand(name: 'some_name', help: <<<'TXT'
 Some help text
 TXT)]
 final class AddHelpToAttributeCommand extends Command
 {
-    public function configure()
-    {
-    }
 }
```

With a `parent::configure()` left over:

```diff
-#[AsCommand(name: 'some_name')]
+#[AsCommand(name: 'some_name', help: <<<'TXT'
+Some help text
+TXT)]
 final class RemoveConfigureWithParentCall extends Command
 {
-    public function configure()
-    {
-        parent::configure();
-
-        $this->setHelp('Some help text');
-    }
 }
```

A `configure()` with other calls left in it is kept as is.