### PR TITLE
Remove StructArmed

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -36,10 +36,6 @@ jobs:
                         name: 'Tests'
                         run: vendor/bin/phpunit
 
-                    -
-                        name: 'Run StructArmed'
-                        run: vendor/bin/structarmed analyze
-
         name: ${{ matrix.actions.name }}
 
         runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
         "ext-xml": "*"
     },
     "require-dev": {
-        "boundwize/structarmed": "^0.14",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-deprecation-rules": "^2.0",

--- a/rules-tests/Symfony73/Rector/Class_/CommandHelpToAttributeRector/Fixture/remove_configure_with_parent_call.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/CommandHelpToAttributeRector/Fixture/remove_configure_with_parent_call.php.inc
@@ -6,10 +6,12 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 
 #[AsCommand(name: 'some_name')]
-final class AddHelpToAttributeCommand extends Command
+final class RemoveConfigureWithParentCall extends Command
 {
     public function configure()
     {
+        parent::configure();
+
         $this->setHelp('Some help text');
     }
 }
@@ -26,7 +28,7 @@ use Symfony\Component\Console\Command\Command;
 #[AsCommand(name: 'some_name', help: <<<'TXT'
 Some help text
 TXT)]
-final class AddHelpToAttributeCommand extends Command
+final class RemoveConfigureWithParentCall extends Command
 {
 }
 

--- a/rules/Symfony73/Rector/Class_/CommandHelpToAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/CommandHelpToAttributeRector.php
@@ -10,8 +10,10 @@ use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
@@ -142,11 +144,52 @@ CODE_SAMPLE
 
         $asCommandAttribute->args[] = new Arg($wrappedHelpString, false, false, [], new Identifier('help'));
 
-        if ($configureClassMethod->stmts === []) {
-            unset($configureClassMethod);
+        // remove now empty configure() method, only a possible parent::configure() call left
+        if ($this->isEmptyConfigureClassMethod($configureClassMethod)) {
+            foreach ($node->stmts as $key => $classStmt) {
+                if ($classStmt === $configureClassMethod) {
+                    unset($node->stmts[$key]);
+                    break;
+                }
+            }
         }
 
         return $node;
+    }
+
+    private function isEmptyConfigureClassMethod(ClassMethod $classMethod): bool
+    {
+        foreach ((array) $classMethod->stmts as $stmt) {
+            if ($this->isParentConfigureCall($stmt)) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isParentConfigureCall(Stmt $stmt): bool
+    {
+        if (! $stmt instanceof Expression) {
+            return false;
+        }
+
+        if (! $stmt->expr instanceof StaticCall) {
+            return false;
+        }
+
+        $staticCall = $stmt->expr;
+        if (! $staticCall->class instanceof Name) {
+            return false;
+        }
+
+        if (! $staticCall->class->isSpecialClassName() || $staticCall->class->toString() !== 'parent') {
+            return false;
+        }
+
+        return $this->isName($staticCall->name, CommandMethodName::CONFIGURE);
     }
 
     /**

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Boundwize\StructArmed\Architecture;
-use Boundwize\StructArmed\Preset\Preset;
-
-return Architecture::define()
-    ->withPreset(Preset::PSR4());


### PR DESCRIPTION
Removes the `boundwize/structarmed` dev dependency, its config file, and the CI step.

## Changes

- **composer.json** — drop `boundwize/structarmed` from `require-dev`
- **structarmed.php** — delete config file
- **.github/workflows/code_analysis.yaml** — remove `Run StructArmed` step