### PR TITLE
[Symfony72] Match push() to its own RequestStack variable in PushRequestToRequestStackConstructorRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "rector/jack": "^0.5",
         "rector/rector-src": "dev-main",
         "rector/swiss-knife": "^2.4",
-        "rector/type-perfect": "^2.1",
         "symfony/config": "^6.4",
         "symfony/dependency-injection": "^6.4",
         "symfony/http-kernel": "^7.4",
@@ -29,7 +28,7 @@
         "symplify/phpstan-rules": "^14.10",
         "symplify/vendor-patches": "^11.5",
         "tomasvotruba/class-leak": "^2.1",
-        "tomasvotruba/type-coverage": "^2.2",
+        "tomasvotruba/type-coverage": "^2.3",
         "tomasvotruba/unused-public": "^2.2",
         "tracy/tracy": "^2.12"
     },

--- a/config/sets/twig/twig20.php
+++ b/config/sets/twig/twig20.php
@@ -6,10 +6,10 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return RectorConfig::configure()->withConfiguredRule(RenameClassRector::class, [
-    #filters
+    # filters
     # @see https://twig.symfony.com/doc/1.x/deprecated.html
     'Twig_SimpleFilter' => 'Twig_Filter',
-    #functions
+    # functions
     # @see https://twig.symfony.com/doc/1.x/deprecated.html
     'Twig_SimpleFunction' => 'Twig_Function',
     # @see https://github.com/bolt/bolt/pull/6596

--- a/config/sets/twig/twig30.php
+++ b/config/sets/twig/twig30.php
@@ -16,4 +16,3 @@ return static function (RectorConfig $rectorConfig): void {
         new AddReturnTypeDeclaration('Twig\Extension\ExtensionInterface', 'getFunctions', new ArrayType(new MixedType(), new MixedType())),
     ]);
 };
-

--- a/rules-tests/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector/Fixture/two_request_stacks.php.inc
+++ b/rules-tests/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector/Fixture/two_request_stacks.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony72\Rector\StmtsAwareInterface\PushRequestToRequestStackConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class TwoRequestStacks extends TestCase
+{
+    public function testThis()
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create('/first'));
+
+        $anotherRequestStack = new RequestStack();
+        $anotherRequestStack->push(Request::create('/second'));
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony72\Rector\StmtsAwareInterface\PushRequestToRequestStackConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class TwoRequestStacks extends TestCase
+{
+    public function testThis()
+    {
+        $requestStack = new RequestStack([Request::create('/first')]);
+
+        $anotherRequestStack = new RequestStack([Request::create('/second')]);
+    }
+}
+
+?>

--- a/rules-tests/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector/Fixture/two_request_stacks_with_statements_between.php.inc
+++ b/rules-tests/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector/Fixture/two_request_stacks_with_statements_between.php.inc
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony72\Rector\StmtsAwareInterface\PushRequestToRequestStackConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class TwoRequestStacksWithStatementsBetween extends TestCase
+{
+    public function testThis()
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request([], [
+            'editorState' => ['pages' => []],
+        ]));
+
+        $model = $this->getModel($requestStack);
+        $this->assertNotNull($model);
+
+        $requestStackNoEditor = new RequestStack();
+        $requestStackNoEditor->push(new Request([], [
+            'customMjml' => '<mjml/>',
+        ]));
+
+        $modelNoEditor = $this->getModel($requestStackNoEditor);
+        $this->assertNotNull($modelNoEditor);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony72\Rector\StmtsAwareInterface\PushRequestToRequestStackConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class TwoRequestStacksWithStatementsBetween extends TestCase
+{
+    public function testThis()
+    {
+        $requestStack = new RequestStack([new Request([], [
+            'editorState' => ['pages' => []],
+        ])]);
+
+        $model = $this->getModel($requestStack);
+        $this->assertNotNull($model);
+
+        $requestStackNoEditor = new RequestStack([new Request([], [
+            'customMjml' => '<mjml/>',
+        ])]);
+
+        $modelNoEditor = $this->getModel($requestStackNoEditor);
+        $this->assertNotNull($modelNoEditor);
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
@@ -157,7 +157,7 @@ CODE_SAMPLE
 
     private function replaceTemplateAnnotation(
         ClassMethod $classMethod,
-        DoctrineAnnotationTagValueNode | Attribute | null $classTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute|null $classTagValueNodeOrAttribute
     ): bool {
         if (! $classMethod->isPublic()) {
             return false;
@@ -182,7 +182,7 @@ CODE_SAMPLE
 
     private function refactorClassMethod(
         ClassMethod $classMethod,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
     ): bool {
         $hasThisRenderOrReturnsResponse = $this->hasLastReturnResponse($classMethod);
 
@@ -257,7 +257,7 @@ CODE_SAMPLE
 
     private function refactorReturn(
         Return_ $return,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
         bool $hasThisRenderOrReturnsResponse,
         ClassMethod $classMethod
     ): bool {
@@ -298,7 +298,7 @@ CODE_SAMPLE
         bool $hasThisRenderOrReturnsResponse,
         MethodCall $thisRenderMethodCall,
         ClassMethod $classMethod,
-        DoctrineAnnotationTagValueNode | Attribute $doctrineTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute $doctrineTagValueNodeOrAttribute
     ): bool {
         /** @var Expr $lastReturnExpr */
         $lastReturnExpr = $return->expr;
@@ -339,7 +339,7 @@ CODE_SAMPLE
 
     private function removeDoctrineAnnotationTagValueNode(
         Class_|ClassMethod $node,
-        DoctrineAnnotationTagValueNode | Attribute $doctrineTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute $doctrineTagValueNodeOrAttribute
     ): void {
         if ($doctrineTagValueNodeOrAttribute instanceof DoctrineAnnotationTagValueNode) {
             $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
@@ -369,7 +369,7 @@ CODE_SAMPLE
      */
     private function refactorStmtsAwareNode(
         Node $stmtsAware,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
         bool $hasThisRenderOrReturnsResponse,
         ClassMethod $classMethod
     ): bool {

--- a/rules/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector.php
+++ b/rules/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector.php
@@ -50,7 +50,7 @@ final class EventListenerToEventSubscriberRector extends AbstractRector
     /**
      * @var EventNameToClassAndConstant[]
      */
-    private array $eventNamesToClassConstants = [];
+    private readonly array $eventNamesToClassConstants;
 
     public function __construct(
         private readonly ListenerServiceDefinitionProvider $listenerServiceDefinitionProvider,

--- a/rules/Symfony52/Rector/MethodCall/DefinitionAliasSetPrivateToSetPublicRector.php
+++ b/rules/Symfony52/Rector/MethodCall/DefinitionAliasSetPrivateToSetPublicRector.php
@@ -23,7 +23,7 @@ final class DefinitionAliasSetPrivateToSetPublicRector extends AbstractRector
     /**
      * @var ObjectType[]
      */
-    private array $definitionObjectTypes = [];
+    private readonly array $definitionObjectTypes;
 
     public function __construct(
         private readonly ValueResolver $valueResolver

--- a/rules/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector.php
+++ b/rules/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector.php
@@ -7,10 +7,12 @@ namespace Rector\Symfony\Symfony72\Rector\StmtsAwareInterface;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Enum\NodeGroup;
@@ -91,7 +93,8 @@ CODE_SAMPLE
             return null;
         }
 
-        $requestStack = null;
+        // keep every "new RequestStack()" per variable name, to append the request pushed on that very variable
+        $requestStackNewsByVariableName = [];
         $hasChanged = false;
 
         foreach ($node->stmts as $key => $stmt) {
@@ -99,22 +102,51 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $requestStack instanceof New_) {
-                $requestStack = $this->matchRequestStackAssignExpr($stmt);
-            } elseif ($stmt->expr instanceof MethodCall) {
-                $pushMethodCall = $stmt->expr;
-
-                if ($this->isName($pushMethodCall->name, 'push')) {
-                    // possibly request stack push
-                    $array = new Array_([new ArrayItem($pushMethodCall->getArgs()[0]->value)]);
-                    $requestStack->args[] = new Arg($array);
-
-                    $requestStack->setAttribute(AttributeKey::ORIGINAL_NODE, null);
-                    $hasChanged = true;
-
-                    unset($node->stmts[$key]);
+            if ($stmt->expr instanceof Assign) {
+                $assign = $stmt->expr;
+                if (! $assign->var instanceof Variable || ! is_string($assign->var->name)) {
+                    continue;
                 }
+
+                $emptyRequestStackNew = $this->matchEmptyRequestStackNew($assign->expr);
+                if ($emptyRequestStackNew instanceof New_) {
+                    $requestStackNewsByVariableName[$assign->var->name] = $emptyRequestStackNew;
+                }
+
+                continue;
             }
+
+            if (! $stmt->expr instanceof MethodCall) {
+                continue;
+            }
+
+            $pushMethodCall = $stmt->expr;
+            if (! $this->isName($pushMethodCall->name, 'push')) {
+                continue;
+            }
+
+            if ($pushMethodCall->getArgs() === []) {
+                continue;
+            }
+
+            if (! $pushMethodCall->var instanceof Variable || ! is_string($pushMethodCall->var->name)) {
+                continue;
+            }
+
+            $variableName = $pushMethodCall->var->name;
+            $requestStackNew = $requestStackNewsByVariableName[$variableName] ?? null;
+            if (! $requestStackNew instanceof New_) {
+                continue;
+            }
+
+            $array = new Array_([new ArrayItem($pushMethodCall->getArgs()[0]->value)]);
+            $requestStackNew->args[] = new Arg($array);
+            $requestStackNew->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+
+            // the constructor takes a single array of requests, so no further push can be merged
+            unset($requestStackNewsByVariableName[$variableName], $node->stmts[$key]);
+
+            $hasChanged = true;
         }
 
         if ($hasChanged) {
@@ -124,28 +156,21 @@ CODE_SAMPLE
         return null;
     }
 
-    private function matchRequestStackAssignExpr(Expression $expression): ?New_
+    private function matchEmptyRequestStackNew(Expr $expr): ?New_
     {
-        // 1. find new RequestStack assign
-        if (! $expression->expr instanceof Assign) {
+        if (! $expr instanceof New_) {
             return null;
         }
 
-        $assign = $expression->expr;
-        if (! $assign->expr instanceof New_) {
-            return null;
-        }
-
-        $new = $assign->expr;
-        if (! $this->isName($new->class, SymfonyClass::REQUEST_STACK)) {
+        if (! $this->isName($expr->class, SymfonyClass::REQUEST_STACK)) {
             return null;
         }
 
         // skip if already some args are filled
-        if ($new->getArgs() !== []) {
+        if ($expr->getArgs() !== []) {
             return null;
         }
 
-        return $new;
+        return $expr;
     }
 }

--- a/src/NodeAnalyzer/FormAddMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/FormAddMethodCallAnalyzer.php
@@ -10,16 +10,16 @@ use PHPStan\Type\ObjectType;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class FormAddMethodCallAnalyzer
+final readonly class FormAddMethodCallAnalyzer
 {
     /**
      * @var ObjectType[]
      */
-    private array $formObjectTypes = [];
+    private array $formObjectTypes;
 
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeTypeResolver $nodeTypeResolver,
+        private NodeNameResolver $nodeNameResolver
     ) {
         $this->formObjectTypes = [
             new ObjectType('Symfony\Component\Form\FormBuilderInterface'),

--- a/src/NodeFactory/Annotations/AnnotationOrAttributeValueResolver.php
+++ b/src/NodeFactory/Annotations/AnnotationOrAttributeValueResolver.php
@@ -15,7 +15,7 @@ use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 final readonly class AnnotationOrAttributeValueResolver
 {
     public function resolve(
-        DoctrineAnnotationTagValueNode | Attribute $tagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $tagValueNodeOrAttribute,
         string $desiredKey
     ): mixed {
         if ($tagValueNodeOrAttribute instanceof DoctrineAnnotationTagValueNode) {

--- a/src/NodeFactory/ThisRenderFactory.php
+++ b/src/NodeFactory/ThisRenderFactory.php
@@ -40,7 +40,7 @@ final readonly class ThisRenderFactory
 
     public function create(
         ?Return_ $return,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
         ClassMethod $classMethod
     ): MethodCall {
         $renderArguments = $this->resolveRenderArguments($return, $templateTagValueNodeOrAttribute, $classMethod);
@@ -53,7 +53,7 @@ final readonly class ThisRenderFactory
      */
     private function resolveRenderArguments(
         ?Return_ $return,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
         ClassMethod $classMethod
     ): array {
         $templateNameString = $this->resolveTemplateName($classMethod, $templateTagValueNodeOrAttribute);
@@ -70,7 +70,7 @@ final readonly class ThisRenderFactory
 
     private function resolveTemplateName(
         ClassMethod $classMethod,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute
     ): string {
         $template = $this->annotationOrAttributeValueResolver->resolve($templateTagValueNodeOrAttribute, 'template');
         if (is_string($template)) {
@@ -82,7 +82,7 @@ final readonly class ThisRenderFactory
 
     private function resolveParametersExpr(
         ?Return_ $return,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute
     ): ?Expr {
         $vars = [];
 

--- a/src/TypeAnalyzer/ContainerAwareAnalyzer.php
+++ b/src/TypeAnalyzer/ContainerAwareAnalyzer.php
@@ -9,15 +9,15 @@ use PHPStan\Type\ObjectType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\Symfony\Enum\SymfonyClass;
 
-final class ContainerAwareAnalyzer
+final readonly class ContainerAwareAnalyzer
 {
     /**
      * @var ObjectType[]
      */
-    private array $getMethodAwareObjectTypes = [];
+    private array $getMethodAwareObjectTypes;
 
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
+        private NodeTypeResolver $nodeTypeResolver,
     ) {
         $this->getMethodAwareObjectTypes = [
             new ObjectType(SymfonyClass::ABSTRACT_CONTROLLER),


### PR DESCRIPTION
When a test method created more than one `RequestStack`, every `push()` call was merged into the **first** `new RequestStack()` — the rule kept a single `New_` node and never compared the pushed variable name.

Now each `new RequestStack()` is tracked per variable name, so a `push()` is merged into the assignment of that same variable. Once a stack receives its request, further pushes on it are left alone (the constructor takes a single array).

```diff
 public function testThis()
 {
-    $requestStack = new RequestStack();
-    $requestStack->push(Request::create('/first'));
+    $requestStack = new RequestStack([Request::create('/first')]);

-    $anotherRequestStack = new RequestStack();
-    $anotherRequestStack->push(Request::create('/second'));
+    $anotherRequestStack = new RequestStack([Request::create('/second')]);
 }
```

Before this change the second block was emitted as:

```php
$requestStack = new RequestStack([Request::create('/first')], [Request::create('/second')]);
$anotherRequestStack = new RequestStack();
```

Also skips non-`Variable` assign targets/callers instead of assuming a plain variable.