### PR TITLE
Drop rector/type-perfect, its rules ship in tomasvotruba/type-coverage 2.3 now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "rector/jack": "^0.5",
         "rector/rector-src": "dev-main",
         "rector/swiss-knife": "^2.4",
-        "rector/type-perfect": "^2.1",
         "symfony/config": "^6.4",
         "symfony/dependency-injection": "^6.4",
         "symfony/http-kernel": "^7.4",
@@ -29,7 +28,7 @@
         "symplify/phpstan-rules": "^14.10",
         "symplify/vendor-patches": "^11.5",
         "tomasvotruba/class-leak": "^2.1",
-        "tomasvotruba/type-coverage": "^2.2",
+        "tomasvotruba/type-coverage": "^2.3",
         "tomasvotruba/unused-public": "^2.2",
         "tracy/tracy": "^2.12"
     },

--- a/config/sets/twig/twig20.php
+++ b/config/sets/twig/twig20.php
@@ -6,10 +6,10 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return RectorConfig::configure()->withConfiguredRule(RenameClassRector::class, [
-    #filters
+    # filters
     # @see https://twig.symfony.com/doc/1.x/deprecated.html
     'Twig_SimpleFilter' => 'Twig_Filter',
-    #functions
+    # functions
     # @see https://twig.symfony.com/doc/1.x/deprecated.html
     'Twig_SimpleFunction' => 'Twig_Function',
     # @see https://github.com/bolt/bolt/pull/6596

--- a/config/sets/twig/twig30.php
+++ b/config/sets/twig/twig30.php
@@ -16,4 +16,3 @@ return static function (RectorConfig $rectorConfig): void {
         new AddReturnTypeDeclaration('Twig\Extension\ExtensionInterface', 'getFunctions', new ArrayType(new MixedType(), new MixedType())),
     ]);
 };
-

--- a/rules/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
+++ b/rules/CodeQuality/Rector/ClassMethod/TemplateAnnotationToThisRenderRector.php
@@ -157,7 +157,7 @@ CODE_SAMPLE
 
     private function replaceTemplateAnnotation(
         ClassMethod $classMethod,
-        DoctrineAnnotationTagValueNode | Attribute | null $classTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute|null $classTagValueNodeOrAttribute
     ): bool {
         if (! $classMethod->isPublic()) {
             return false;
@@ -182,7 +182,7 @@ CODE_SAMPLE
 
     private function refactorClassMethod(
         ClassMethod $classMethod,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
     ): bool {
         $hasThisRenderOrReturnsResponse = $this->hasLastReturnResponse($classMethod);
 
@@ -257,7 +257,7 @@ CODE_SAMPLE
 
     private function refactorReturn(
         Return_ $return,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
         bool $hasThisRenderOrReturnsResponse,
         ClassMethod $classMethod
     ): bool {
@@ -298,7 +298,7 @@ CODE_SAMPLE
         bool $hasThisRenderOrReturnsResponse,
         MethodCall $thisRenderMethodCall,
         ClassMethod $classMethod,
-        DoctrineAnnotationTagValueNode | Attribute $doctrineTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute $doctrineTagValueNodeOrAttribute
     ): bool {
         /** @var Expr $lastReturnExpr */
         $lastReturnExpr = $return->expr;
@@ -339,7 +339,7 @@ CODE_SAMPLE
 
     private function removeDoctrineAnnotationTagValueNode(
         Class_|ClassMethod $node,
-        DoctrineAnnotationTagValueNode | Attribute $doctrineTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute $doctrineTagValueNodeOrAttribute
     ): void {
         if ($doctrineTagValueNodeOrAttribute instanceof DoctrineAnnotationTagValueNode) {
             $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
@@ -369,7 +369,7 @@ CODE_SAMPLE
      */
     private function refactorStmtsAwareNode(
         Node $stmtsAware,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
         bool $hasThisRenderOrReturnsResponse,
         ClassMethod $classMethod
     ): bool {

--- a/rules/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector.php
+++ b/rules/CodeQuality/Rector/Class_/EventListenerToEventSubscriberRector.php
@@ -50,7 +50,7 @@ final class EventListenerToEventSubscriberRector extends AbstractRector
     /**
      * @var EventNameToClassAndConstant[]
      */
-    private array $eventNamesToClassConstants = [];
+    private readonly array $eventNamesToClassConstants;
 
     public function __construct(
         private readonly ListenerServiceDefinitionProvider $listenerServiceDefinitionProvider,

--- a/rules/Symfony52/Rector/MethodCall/DefinitionAliasSetPrivateToSetPublicRector.php
+++ b/rules/Symfony52/Rector/MethodCall/DefinitionAliasSetPrivateToSetPublicRector.php
@@ -23,7 +23,7 @@ final class DefinitionAliasSetPrivateToSetPublicRector extends AbstractRector
     /**
      * @var ObjectType[]
      */
-    private array $definitionObjectTypes = [];
+    private readonly array $definitionObjectTypes;
 
     public function __construct(
         private readonly ValueResolver $valueResolver

--- a/src/NodeAnalyzer/FormAddMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/FormAddMethodCallAnalyzer.php
@@ -10,16 +10,16 @@ use PHPStan\Type\ObjectType;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
-final class FormAddMethodCallAnalyzer
+final readonly class FormAddMethodCallAnalyzer
 {
     /**
      * @var ObjectType[]
      */
-    private array $formObjectTypes = [];
+    private array $formObjectTypes;
 
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
-        private readonly NodeNameResolver $nodeNameResolver
+        private NodeTypeResolver $nodeTypeResolver,
+        private NodeNameResolver $nodeNameResolver
     ) {
         $this->formObjectTypes = [
             new ObjectType('Symfony\Component\Form\FormBuilderInterface'),

--- a/src/NodeFactory/Annotations/AnnotationOrAttributeValueResolver.php
+++ b/src/NodeFactory/Annotations/AnnotationOrAttributeValueResolver.php
@@ -15,7 +15,7 @@ use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 final readonly class AnnotationOrAttributeValueResolver
 {
     public function resolve(
-        DoctrineAnnotationTagValueNode | Attribute $tagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $tagValueNodeOrAttribute,
         string $desiredKey
     ): mixed {
         if ($tagValueNodeOrAttribute instanceof DoctrineAnnotationTagValueNode) {

--- a/src/NodeFactory/ThisRenderFactory.php
+++ b/src/NodeFactory/ThisRenderFactory.php
@@ -40,7 +40,7 @@ final readonly class ThisRenderFactory
 
     public function create(
         ?Return_ $return,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
         ClassMethod $classMethod
     ): MethodCall {
         $renderArguments = $this->resolveRenderArguments($return, $templateTagValueNodeOrAttribute, $classMethod);
@@ -53,7 +53,7 @@ final readonly class ThisRenderFactory
      */
     private function resolveRenderArguments(
         ?Return_ $return,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute,
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute,
         ClassMethod $classMethod
     ): array {
         $templateNameString = $this->resolveTemplateName($classMethod, $templateTagValueNodeOrAttribute);
@@ -70,7 +70,7 @@ final readonly class ThisRenderFactory
 
     private function resolveTemplateName(
         ClassMethod $classMethod,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute
     ): string {
         $template = $this->annotationOrAttributeValueResolver->resolve($templateTagValueNodeOrAttribute, 'template');
         if (is_string($template)) {
@@ -82,7 +82,7 @@ final readonly class ThisRenderFactory
 
     private function resolveParametersExpr(
         ?Return_ $return,
-        DoctrineAnnotationTagValueNode | Attribute $templateTagValueNodeOrAttribute
+        DoctrineAnnotationTagValueNode|Attribute $templateTagValueNodeOrAttribute
     ): ?Expr {
         $vars = [];
 

--- a/src/TypeAnalyzer/ContainerAwareAnalyzer.php
+++ b/src/TypeAnalyzer/ContainerAwareAnalyzer.php
@@ -9,15 +9,15 @@ use PHPStan\Type\ObjectType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\Symfony\Enum\SymfonyClass;
 
-final class ContainerAwareAnalyzer
+final readonly class ContainerAwareAnalyzer
 {
     /**
      * @var ObjectType[]
      */
-    private array $getMethodAwareObjectTypes = [];
+    private array $getMethodAwareObjectTypes;
 
     public function __construct(
-        private readonly NodeTypeResolver $nodeTypeResolver,
+        private NodeTypeResolver $nodeTypeResolver,
     ) {
         $this->getMethodAwareObjectTypes = [
             new ObjectType(SymfonyClass::ABSTRACT_CONTROLLER),


### PR DESCRIPTION
PHPStan job started failing on every branch:

```
In Autowiring.php line 54:
  Multiple services of type Rector\TypePerfect\Reflection\MethodNodeAnalyser
  found: 0861, 0915
```

`tomasvotruba/type-coverage` 2.3.0 absorbed type-perfect — it autoloads `Rector\TypePerfect\` and registers `packages/type-perfect/config/extension.neon` as a PHPStan extension. With `rector/type-perfect` still required, `phpstan/extension-installer` includes both configs and every type-perfect service is registered twice.

Its README says the same: *"Migrating from `rector/type-perfect`? Remove it from your `composer.json`, the rules live here now."*

So:
- remove `rector/type-perfect` from require-dev
- bump `tomasvotruba/type-coverage` to `^2.3`

`phpstan.neon` needs no change — the `type_perfect:` parameters are read by the bundled config.

Rector + ECS applied on top (`readonly` promotion and union/comment spacing from newer tool versions).