### PR TITLE
[Symfony44] Skip custom isGranted() service calls in controllers in AuthorizationCheckerIsGrantedExtractorRector

### DIFF
--- a/rules-tests/Symfony44/Rector/MethodCall/AuthorizationCheckerIsGrantedExtractorRector/Fixture/skip_custom_permission_service_in_controller.php.inc
+++ b/rules-tests/Symfony44/Rector/MethodCall/AuthorizationCheckerIsGrantedExtractorRector/Fixture/skip_custom_permission_service_in_controller.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\MethodCall\AuthorizationCheckerIsGrantedExtractorRector\Fixture;
+
+use Rector\Symfony\Tests\Symfony44\Rector\MethodCall\AuthorizationCheckerIsGrantedExtractorRector\Source\DifferentClass;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+class SkipCustomPermissionServiceInController extends AbstractController
+{
+    public function __construct(
+        private DifferentClass $security
+    ) {
+    }
+
+    public function someMethod()
+    {
+        if ($this->security->isGranted(['ROLE_USER', 'ROLE_ADMIN'])) {
+
+        }
+    }
+}

--- a/rules/Symfony44/Rector/MethodCall/AuthorizationCheckerIsGrantedExtractorRector.php
+++ b/rules/Symfony44/Rector/MethodCall/AuthorizationCheckerIsGrantedExtractorRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
 use PHPStan\Type\ObjectType;
 use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -96,8 +97,13 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): MethodCall|BooleanOr|null
     {
-        if ($this->controllerAnalyzer->isInsideController($node)) {
-            return $this->processControllerMethods($node);
+        // native AbstractController::isGranted() call, any other object must be resolved by its type
+        if ($node->var instanceof Variable && $this->isName($node->var, 'this')) {
+            if ($this->controllerAnalyzer->isInsideController($node)) {
+                return $this->processControllerMethods($node);
+            }
+
+            return null;
         }
 
         $objectType = $this->nodeTypeResolver->getType($node->var);


### PR DESCRIPTION
`refactor()` short-circuited on `isInsideController()`, and `processControllerMethods()` only verified the *method name* — never the caller type. So any `isGranted([...])` call inside an `AbstractController` matched, including calls on a project's own permission service.

Found on Mautic, where `\Mautic\CoreBundle\Security\Permissions\CorePermissions::isGranted()` takes an array with `MATCH_ALL` semantics, so splitting it into `||` changes behavior:

```diff
 class SomeController extends AbstractController
 {
     public function __construct(
         private CorePermissions $security
     ) {
     }

     public function run()
     {
-        if ($this->security->isGranted('a') || $this->security->isGranted('b')) {
+        if ($this->security->isGranted(['a', 'b'])) {
         }
     }
 }
```

Now the controller shortcut only applies to `$this->isGranted()`; every other object goes through the existing `AuthorizationCheckerInterface` type check, so `$this->authorizationChecker->isGranted([...])` inside a controller still gets refactored:

```diff
 class SomeController extends AbstractController
 {
     public function run()
     {
-        if ($this->isGranted(['ROLE_USER', 'ROLE_ADMIN'])) {
+        if ($this->isGranted('ROLE_USER') || $this->isGranted('ROLE_ADMIN')) {
         }
     }
 }
```
