### PR TITLE
[Symfony42] Update Cookie fixture after NewToStaticCallRector config removal

### DIFF
--- a/config/sets/symfony/symfony4/symfony42/symfony42-http-foundation.php
+++ b/config/sets/symfony/symfony4/symfony42/symfony42-http-foundation.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 use Rector\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector;
 use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
 use Rector\Config\RectorConfig;
-use Rector\Transform\Rector\New_\NewToStaticCallRector;
-use Rector\Transform\ValueObject\NewToStaticCall;
 use Rector\ValueObject\MethodName;
 
 return static function (RectorConfig $rectorConfig): void {

--- a/tests/Set/Symfony42/Fixture/replace_new_cookie_and_create_parameter_value.php.inc
+++ b/tests/Set/Symfony42/Fixture/replace_new_cookie_and_create_parameter_value.php.inc
@@ -29,7 +29,7 @@ class ReplaceNewCookieAndCreateParameterValue
     {
         $cookie = Cookie::create('name', 'value', 0, '/', null, false, true, false, \Symfony\Component\HttpFoundation\Cookie::SAMESITE_NONE);
 
-        return \Symfony\Component\HttpFoundation\Cookie::create('name', 'value', 0, '/', null, false, true, false, \Symfony\Component\HttpFoundation\Cookie::SAMESITE_NONE);
+        return new Cookie('name', 'value', 0, '/', null, null, true, false, \Symfony\Component\HttpFoundation\Cookie::SAMESITE_NONE);
     }
 }
 


### PR DESCRIPTION
`8fcf5083` ("no value in static") removed the `NewToStaticCallRector` `Cookie` → `Cookie::create()` config from `symfony42-http-foundation.php`, but the fixture still expected the static call. The Symfony42 set test has failed on `main` since, which also fails every open `rector-src` PR (it pulls `rector-symfony` as `dev-main`).

Expected output updated to what the set now produces - `new Cookie()` stays, only the argument default values change:

```diff
-        return \Symfony\Component\HttpFoundation\Cookie::create('name', 'value', 0, '/', null, false, true, false, \Symfony\Component\HttpFoundation\Cookie::SAMESITE_NONE);
+        return new Cookie('name', 'value', 0, '/', null, null, true, false, \Symfony\Component\HttpFoundation\Cookie::SAMESITE_NONE);
```