### PR TITLE
[deps] Bump symfony/config to ^8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "rector/jack": "^1.0",
         "rector/rector-src": "dev-main",
         "rector/swiss-knife": "^2.4",
-        "symfony/config": "^6.4",
+        "symfony/config": "^8.1",
         "symfony/dependency-injection": "^6.4",
         "symfony/http-kernel": "^7.4",
         "symfony/routing": "^6.4",


### PR DESCRIPTION
Fixes rector-src build failure on dependency resolution:

```
- rector/rector-src dev-main requires symfony/filesystem ^8.1
- symfony/config[6.4.x] require symfony/filesystem ^5.4|^6.0|^7.0
- You can only install one version of a package
```

`symfony/config` was the only dev dependency capping `symfony/filesystem` below ^8.1.

```diff
-        "symfony/config": "^6.4",
+        "symfony/config": "^8.1",
```

Dev-only dependency; `Symfony\Component\Config` is referenced in rules as a string type name only, no API usage.