### PR TITLE
[composer-based] Bond AddViolationToBuildViolationRector to symfony/validator 2.5

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -42,6 +42,7 @@ use Rector\Renaming\ValueObject\RenameProperty;
 use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
 use Rector\Symfony\CodeQuality\Rector\AttributeGroup\SingleConditionSecurityAttributeToIsGrantedRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\SplitAndSecurityAttributeToIsGrantedRector;
+use Rector\Symfony\Symfony25\Rector\MethodCall\AddViolationToBuildViolationRector;
 use Rector\Symfony\Symfony42\Rector\New_\RootNodeTreeBuilderRector;
 use Rector\Symfony\Symfony42\Rector\New_\StringToArrayArgumentProcessRector;
 use Rector\Symfony\Symfony43\Rector\ClassMethod\EventDispatcherParentConstructRector;
@@ -90,6 +91,9 @@ return static function (RectorConfig $rectorConfig): void {
     // each of these rules declares the exact Symfony package and the version its target API was added in,
     // @see ComposerPackageConstraintInterface
     $rectorConfig->rules([
+        // symfony/validator 2.5
+        AddViolationToBuildViolationRector::class,
+
         // symfony/config 4.2
         RootNodeTreeBuilderRector::class,
 

--- a/rules/Symfony25/Rector/MethodCall/AddViolationToBuildViolationRector.php
+++ b/rules/Symfony25/Rector/MethodCall/AddViolationToBuildViolationRector.php
@@ -13,6 +13,8 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,8 +23,13 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\Symfony\Tests\Symfony25\Rector\MethodCall\AddViolationToBuildViolationRector\AddViolationToBuildViolationRectorTest
  */
-final class AddViolationToBuildViolationRector extends AbstractRector
+final class AddViolationToBuildViolationRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('symfony/validator', '>=2.5');
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/tests/ComposerBased/Fixture/version_bound_violation_builder.php.inc
+++ b/tests/ComposerBased/Fixture/version_bound_violation_builder.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\ComposerBased\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class VersionBoundViolationBuilder extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        $this->context->addViolationAt('property', 'The value {{ value }} is invalid.', [
+            '{{ value }}' => $value,
+        ]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\ComposerBased\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class VersionBoundViolationBuilder extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        $this->context->buildViolation('The value {{ value }} is invalid.')->atPath('property')->setParameter('{{ value }}', $value)->addViolation();
+    }
+}
+
+?>


### PR DESCRIPTION
`AddViolationToBuildViolationRector` rewrites `ExecutionContextInterface::addViolationAt()` into the `buildViolation()` fluent builder:

```diff
-$this->context->addViolationAt('property', 'The value {{ value }} is invalid.', [
-    '{{ value }}' => $value,
-]);
+$this->context->buildViolation('The value {{ value }} is invalid.')
+    ->atPath('property')
+    ->setParameter('{{ value }}', $value)
+    ->addViolation();
```

That builder arrived in the validator component in **2.5**, so the rule can declare the constraint itself:

```php
public function provideComposerPackageConstraint(): ComposerPackageConstraint
{
    return new ComposerPackageConstraint('symfony/validator', '>=2.5');
}
```

and be registered once in the composer-based set, instead of relying on the Symfony 2.5 version set to be picked up on a direct upgrade from an older version.

**`symfony/validator`, not `symfony/symfony`** — a project installing the split components, which is nearly all of them today, carries no `symfony/symfony` to match against. Same package the neighbouring `ValidatorBuilderEnableAnnotationMappingRector` binds to.

A fixture in `tests/ComposerBased/Fixture/` covers it through the set itself, so the rule being dropped from the list would fail a test rather than pass quietly.
