### PR TITLE
[docs] Remove stale "Provide Symfony PHP Container" README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,45 +55,6 @@ return RectorConfig::configure()
 
 That's it! Now you can run the `StringFormTypeToClassRector` and get your form classes converted safely.
 
----
-
-### Provide Symfony PHP Container
-
-Some rules like `AddRouteAnnotationRector` require additional access to your Symfony container. The rule takes container service "router" to load metadata about your routes.
-
-```php
-use Rector\Config\RectorConfig;
-use Rector\Symfony\Bridge\Symfony\Routing\SymfonyRoutesProvider;
-use Rector\Symfony\Configs\Rector\ClassMethod\AddRouteAnnotationRector;
-use Rector\Symfony\Contract\Bridge\Symfony\Routing\SymfonyRoutesProviderInterface;
-
-return RectorConfig::configure()
-    ->withSymfonyContainerPhp(__DIR__ . '/tests/symfony-container.php')
-    ->registerService(SymfonyRoutesProvider::class, SymfonyRoutesProviderInterface::class);
-```
-
-The `tests/symfony-container.php` should provide your dependency injection container. The way you create the container is up to you. It can be as simple as:
-
-```php
-// tests/symfony-container.php
-
-use App\Kernel;
-
-require __DIR__ . '/bootstrap.php';
-
-$appKernel = new Kernel('test', false);
-$appKernel->boot();
-
-return $appKernel->getContainer();
-```
-
-The version of your Symfony can be quite old. Public methods are stable from Symfony 2 to through 6 and the router have not changed much. The `AddRouteAnnotationRector` rule was tested and developed on Symfony 2.8 project.
-
----
-
-> [!NOTE]
-> In this case, container cache PHP file located in `/var/cache/<env>/appProjectContainer.php` is not enough. Why? Few services require Kernel to be set, e.g. routes that are resolved in lazy way. This container file is only dumped without Kernel and [would crash with missing "kernel" error](https://github.com/symfony/symfony/issues/19840). That's why the rule needs full blown container.
-
 <br>
 
 ## Learn Rector Faster


### PR DESCRIPTION
The README documents a setup that no longer works.

## What is stale

```php
use Rector\Symfony\Bridge\Symfony\Routing\SymfonyRoutesProvider;
use Rector\Symfony\Configs\Rector\ClassMethod\AddRouteAnnotationRector;
use Rector\Symfony\Contract\Bridge\Symfony\Routing\SymfonyRoutesProviderInterface;

return RectorConfig::configure()
    ->withSymfonyContainerPhp(__DIR__ . '/tests/symfony-container.php')
    ->registerService(SymfonyRoutesProvider::class, SymfonyRoutesProviderInterface::class);
```

* `SymfonyRoutesProvider` and `SymfonyRoutesProviderInterface` no longer exist in this package. `src/Bridge/` only contains `ControllerMethodAnalyzer`, so this snippet fatals on a missing class.
* `AddRouteAnnotationRector` is deprecated:

  > Too complex and tightly coupled to a project-specific Symfony route setup. Write a local custom rule for this one-time job instead.

* The trailing `> [!NOTE]` about `/var/cache/<env>/appProjectContainer.php` not being enough only made sense as a caveat for that rule.
* The "tested and developed on Symfony 2.8 project" line points at the same deprecated rule.

## What stays

The `Provide Symfony XML Service List` section above it is untouched. `withSymfonyContainerXml()` and `StringFormTypeToClassRector` are both still live.

39 lines removed, docs only, no code change.