### PR TITLE
[composer-based] Add AuthorizationCheckerIsGrantedExtractorRector to the composer-based set

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -47,6 +47,7 @@ use Rector\Symfony\Symfony42\Rector\New_\StringToArrayArgumentProcessRector;
 use Rector\Symfony\Symfony43\Rector\ClassMethod\EventDispatcherParentConstructRector;
 use Rector\Symfony\Symfony43\Rector\MethodCall\MakeDispatchFirstArgumentEventRector;
 use Rector\Symfony\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector;
+use Rector\Symfony\Symfony44\Rector\MethodCall\AuthorizationCheckerIsGrantedExtractorRector;
 use Rector\Symfony\Symfony51\Rector\Class_\LogoutHandlerToLogoutEventSubscriberRector;
 use Rector\Symfony\Symfony51\Rector\Class_\LogoutSuccessHandlerToLogoutEventSubscriberRector;
 use Rector\Symfony\Symfony51\Rector\ClassMethod\CommandConstantReturnCodeRector;
@@ -103,6 +104,9 @@ return static function (RectorConfig $rectorConfig): void {
         // symfony/console 4.4 and 5.1
         ConsoleExecuteReturnIntRector::class,
         CommandConstantReturnCodeRector::class,
+
+        // symfony/security-core 4.4
+        AuthorizationCheckerIsGrantedExtractorRector::class,
 
         // symfony/security-http 5.1
         LogoutHandlerToLogoutEventSubscriberRector::class,

--- a/rules/Symfony44/Rector/MethodCall/AuthorizationCheckerIsGrantedExtractorRector.php
+++ b/rules/Symfony44/Rector/MethodCall/AuthorizationCheckerIsGrantedExtractorRector.php
@@ -16,6 +16,8 @@ use Rector\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\Enum\SymfonyClass;
 use Rector\Symfony\TypeAnalyzer\ControllerAnalyzer;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,12 +26,17 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\Symfony\Tests\Symfony44\Rector\MethodCall\AuthorizationCheckerIsGrantedExtractorRector\AuthorizationCheckerIsGrantedExtractorRectorTest
  */
-final class AuthorizationCheckerIsGrantedExtractorRector extends AbstractRector
+final class AuthorizationCheckerIsGrantedExtractorRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly ArgsAnalyzer $argsAnalyzer,
         private readonly ControllerAnalyzer $controllerAnalyzer,
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('symfony/security-core', '>=4.4');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/tests/ComposerBased/Fixture/authorization_checker_is_granted.php.inc
+++ b/tests/ComposerBased/Fixture/authorization_checker_is_granted.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+final class AuthorizationCheckerIsGranted
+{
+    public function __construct(
+        private AuthorizationCheckerInterface $authorizationChecker
+    ) {
+    }
+
+    public function hasAccess(): bool
+    {
+        return $this->authorizationChecker->isGranted(['ROLE_USER', 'ROLE_ADMIN']);
+    }
+}
+
+?>
+-----
+<?php
+
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+final class AuthorizationCheckerIsGranted
+{
+    public function __construct(
+        private AuthorizationCheckerInterface $authorizationChecker
+    ) {
+    }
+
+    public function hasAccess(): bool
+    {
+        return $this->authorizationChecker->isGranted('ROLE_USER') || $this->authorizationChecker->isGranted('ROLE_ADMIN');
+    }
+}
+
+?>


### PR DESCRIPTION
Bonds `AuthorizationCheckerIsGrantedExtractorRector` to `symfony/security-core >=4.4` via `ComposerPackageConstraintInterface`, and registers it in `config/sets/symfony/composer-based.php`.

4.4 is the version that deprecated passing multiple attributes to `AuthorizationCheckerInterface::isGranted()`, see [UPGRADE-4.4.md#security](https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.4.md#security).

`symfony/security-core` is already a registered `ComposerTriggeredSet` package from `>=4.3`, so `SymfonySetProvider` needs no change.

## What the rule does

```diff
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;

 final class SomeController
 {
     public function __construct(
         private AuthorizationCheckerInterface $authorizationChecker
     ) {
     }

     public function hasAccess(): bool
     {
-        return $this->authorizationChecker->isGranted(['ROLE_USER', 'ROLE_ADMIN']);
+        return $this->authorizationChecker->isGranted('ROLE_USER') || $this->authorizationChecker->isGranted('ROLE_ADMIN');
     }
 }
```

Added a `tests/ComposerBased` fixture so the bonding is verified through the set itself, not only through the rule's own test.