### PR TITLE
[Symfony44] Add try/catch fixtures with statements before the return

### DIFF
--- a/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_try_catch_return_with_stmts_before_return.php.inc
+++ b/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_try_catch_return_with_stmts_before_return.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipTryCatchReturnWithStmtsBeforeReturn extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $output->writeln('working');
+            return 0;
+        } catch (\Exception $exception) {
+            $output->writeln($exception->getMessage());
+            return 1;
+        }
+    }
+}

--- a/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/try_catch_return_with_stmts_before_return.php.inc
+++ b/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/try_catch_return_with_stmts_before_return.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class TryCatchReturnWithStmtsBeforeReturnCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $output->writeln('working');
+            return 0;
+        } catch (\Exception $exception) {
+            $output->writeln($exception->getMessage());
+            return 1;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class TryCatchReturnWithStmtsBeforeReturnCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $output->writeln('working');
+            return 0;
+        } catch (\Exception $exception) {
+            $output->writeln($exception->getMessage());
+            return 1;
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
Follow-up to rectorphp/rector-src#8260, which is now merged.

`ConsoleExecuteReturnIntRector` appended a second, unreachable `return 0;` after a `try`/`catch` whose branches did real work before returning:

```diff
     public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $output->writeln('working');
             return 0;
         } catch (\Exception $exception) {
             $output->writeln($exception->getMessage());
             return 1;
         }
+        return 0;
     }
```

The cause was in `TerminatedNodeAnalyzer`, which bailed out whenever the second-to-last statement of a branch was not itself a terminator. The existing `skip_try_catch_return.php.inc` did not catch it, as its branches are bare `return`s with no preceding statement.

No rule change is needed here, the fix comes from rector-src. This only pins the behaviour:

- `try_catch_return_with_stmts_before_return.php.inc` — return type is added, no extra `return 0;`
- `skip_try_catch_return_with_stmts_before_return.php.inc` — already typed `: int`, nothing changes at all

Both fail against the pre-#8260 analyzer with exactly the `+ return 0;` above, and pass against current `dev-main`.