### PR TITLE
[composer-based] Bond RedirectToRouteRector to symfony/framework-bundle 2.6

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -43,6 +43,7 @@ use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
 use Rector\Symfony\CodeQuality\Rector\AttributeGroup\SingleConditionSecurityAttributeToIsGrantedRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\SplitAndSecurityAttributeToIsGrantedRector;
 use Rector\Symfony\Symfony25\Rector\MethodCall\AddViolationToBuildViolationRector;
+use Rector\Symfony\Symfony26\Rector\MethodCall\RedirectToRouteRector;
 use Rector\Symfony\Symfony42\Rector\New_\RootNodeTreeBuilderRector;
 use Rector\Symfony\Symfony42\Rector\New_\StringToArrayArgumentProcessRector;
 use Rector\Symfony\Symfony43\Rector\ClassMethod\EventDispatcherParentConstructRector;
@@ -94,6 +95,9 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         // symfony/validator 2.5
         AddViolationToBuildViolationRector::class,
+
+        // symfony/framework-bundle 2.6
+        RedirectToRouteRector::class,
 
         // symfony/config 4.2
         RootNodeTreeBuilderRector::class,

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/RedirectToRouteRectorTest.php
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/RedirectToRouteRectorTest.php
@@ -25,4 +25,9 @@ final class RedirectToRouteRectorTest extends AbstractRectorTestCase
     {
         return __DIR__ . '/config/configured_rule.php';
     }
+
+    protected function provideComposerJsonFilePath(): string
+    {
+        return __DIR__ . '/config/composer.json';
+    }
 }

--- a/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/config/composer.json
+++ b/rules-tests/Symfony26/Rector/MethodCall/RedirectToRouteRector/config/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "symfony/framework-bundle": "^2.6"
+    }
+}

--- a/rules/Symfony26/Rector/MethodCall/RedirectToRouteRector.php
+++ b/rules/Symfony26/Rector/MethodCall/RedirectToRouteRector.php
@@ -10,17 +10,26 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\TypeAnalyzer\ControllerAnalyzer;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
+ * @changelog https://github.com/symfony/symfony/blob/2.6/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+ *
  * @see \Rector\Symfony\Tests\Symfony26\Rector\MethodCall\RedirectToRouteRector\RedirectToRouteRectorTest
  */
-final class RedirectToRouteRector extends AbstractRector
+final class RedirectToRouteRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly ControllerAnalyzer $controllerAnalyzer
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('symfony/framework-bundle', '>=2.6');
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
Reopens #990 without the dependency change. `composer.json` is untouched here.

`RedirectToRouteRector` rewrites the redirect helper pair into the shorter route helper:

```diff
 final class SomeController extends AbstractController
 {
     public function someAction()
     {
-        return $this->redirect($this->generateUrl('something', ['id' => $id]));
+        return $this->redirectToRoute('something', ['id' => $id]);
     }
 }
```

`Controller::redirectToRoute()` was added in symfony/framework-bundle 2.6, so the rule declares that package constraint and joins the composer-based set:

```php
public function provideComposerPackageConstraint(): ComposerPackageConstraint
{
    return new ComposerPackageConstraint('symfony/framework-bundle', '>=2.6');
}
```

A project on an older framework-bundle now gets the rule skipped instead of a call to a method that does not exist yet.

## Testing a rule bonded to a package we cannot install

`ComposerPackageConstraintFilter` resolves the constraint against the installed packages, and `RectorNodeTraverser` applies it unconditionally — including during the rule's own test run. `symfony/framework-bundle` is not installed here, so the rule was filtered out and all 5 fixtures failed.

Adding it to `require-dev` is not an option: it does not resolve at any major against the current constraints. `^8.1` conflicts with `symfony/console < 8.1` while `rector/rector-src` pins `symfony/console ^6.4.24`; `^7.4` needs `dependency-injection`/`routing` at `^7.4`, currently `^6.4`; `^6.4` needs `http-kernel ^6.4` and `config ^6.1|^7.0`, currently `^7.4` and `^8.1`.

rectorphp/rector-src#8264 added a hook for exactly this, and the test points at a standalone `composer.json`:

```php
protected function provideComposerJsonFilePath(): string
{
    return __DIR__ . '/config/composer.json';
}
```

```json
{
    "require": {
        "symfony/framework-bundle": "^2.6"
    }
}
```

That hook is merged, so the suite is green on the current `rector/rector-src` dev-main — 584 tests, including the 7 `RedirectToRouteRector` cases. ECS, PHPStan, class-leak, Finalize Classes and Composer Validate pass as well.
