### PR TITLE
[Symfony44] Fix duplicated return in ConsoleExecuteReturnIntRector on trailing comment

### DIFF
--- a/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_trailing_comment_after_return.php.inc
+++ b/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_trailing_comment_after_return.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipTrailingCommentAfterReturnCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('Finished!');
+        return 0; // no error
+    }
+}

--- a/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/trailing_comment_after_return.php.inc
+++ b/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/trailing_comment_after_return.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class TrailingCommentAfterReturnCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Finished!');
+        return 0; // no error
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class TrailingCommentAfterReturnCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('Finished!');
+        return 0; // no error
+    }
+}
+
+?>

--- a/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\IntegerType;
@@ -184,14 +185,21 @@ CODE_SAMPLE
 
     private function processReturn0ToMethod(ClassMethod $classMethod): void
     {
-        $lastKey = array_key_last((array) $classMethod->stmts);
+        $stmts = (array) $classMethod->stmts;
+
+        // trailing comments are parsed as Nop stmts, skip them to get the real last stmt
+        while ($stmts !== [] && end($stmts) instanceof Nop) {
+            array_pop($stmts);
+        }
+
+        $lastKey = array_key_last($stmts);
 
         $return = new Return_(new \PhpParser\Node\Scalar\Int_(0));
-        if ($lastKey !== null && (isset($classMethod->stmts[$lastKey]) && $this->terminatedNodeAnalyzer->isAlwaysTerminated(
+        if ($lastKey !== null && $this->terminatedNodeAnalyzer->isAlwaysTerminated(
             $classMethod,
-            $classMethod->stmts[$lastKey],
+            $stmts[$lastKey],
             $return
-        ))) {
+        )) {
             return;
         }
 


### PR DESCRIPTION
`ConsoleExecuteReturnIntRector` appended a second `return 0;` when the last statement of `execute()` carried a trailing comment.

## Before

```diff
 final class SomeCommand extends Command
 {
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('Finished!');
         return 0; // no error
+        return 0;
     }
 }
```

## After

```diff
 final class SomeCommand extends Command
 {
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('Finished!');
         return 0; // no error
     }
 }
```

## Why

php-parser stores a trailing comment on a synthetic `Nop` statement appended after the real one:

```
Stmt\Expression   // $output->writeln(...)
Stmt\Return_      // return 0;
Stmt\Nop          // holds "// no error"
```

`processReturn0ToMethod()` took `array_key_last()` of the statements and handed that `Nop` to `TerminatedNodeAnalyzer::isAlwaysTerminated()`. A `Nop` is not a terminating node, so the method looked unterminated and a second `return 0;` was added.

The fix skips trailing `Nop` statements before the termination check. A comment placed *above* the return was never affected — it attaches to the `Return_` node itself.

Two fixtures added: one for the return type still being added correctly, one skip fixture for an already typed method.