### PR TITLE
[Symfony44] Add fixture for block comment with commented-out return in ConsoleExecuteReturnIntRector

### DIFF
--- a/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/return_before_trailing_comment.php.inc
+++ b/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/return_before_trailing_comment.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CheckTablesCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        return 0;
+
+        /*
+
+        comment spam
+
+        return 1;
+*/
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CheckTablesCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return 0;
+
+        /*
+
+        comment spam
+
+        return 1;
+*/
+    }
+}
+
+?>

--- a/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_trailing_comment_after_return.php.inc
+++ b/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_trailing_comment_after_return.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipTrailingCommentAfterReturnCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('Finished!');
+        return 0; // no error
+    }
+}

--- a/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/trailing_comment_after_return.php.inc
+++ b/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/trailing_comment_after_return.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class TrailingCommentAfterReturnCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Finished!');
+        return 0; // no error
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class TrailingCommentAfterReturnCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('Finished!');
+        return 0; // no error
+    }
+}
+
+?>

--- a/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\IntegerType;
@@ -184,14 +185,21 @@ CODE_SAMPLE
 
     private function processReturn0ToMethod(ClassMethod $classMethod): void
     {
-        $lastKey = array_key_last((array) $classMethod->stmts);
+        $stmts = (array) $classMethod->stmts;
+
+        // trailing comments are parsed as Nop stmts, skip them to get the real last stmt
+        while ($stmts !== [] && end($stmts) instanceof Nop) {
+            array_pop($stmts);
+        }
+
+        $lastKey = array_key_last($stmts);
 
         $return = new Return_(new \PhpParser\Node\Scalar\Int_(0));
-        if ($lastKey !== null && (isset($classMethod->stmts[$lastKey]) && $this->terminatedNodeAnalyzer->isAlwaysTerminated(
+        if ($lastKey !== null && $this->terminatedNodeAnalyzer->isAlwaysTerminated(
             $classMethod,
-            $classMethod->stmts[$lastKey],
+            $stmts[$lastKey],
             $return
-        ))) {
+        )) {
             return;
         }
 


### PR DESCRIPTION
Follow-up regression fixture on top of #992.

#992 covers a trailing `//` comment on the same line as the `return`. This adds the other shape that hit the same `Nop` bug: a multi-line block comment after the return, holding commented-out code including its own `return 1;`.

```diff
 class CheckTablesCommand extends Command
 {
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         return 0;
 
         /* comment

         return 1;
 */
     }
 }
```

Only the return type is added; no duplicated `return 0;` is appended after the comment.
