### PR TITLE
[composer-based] Register LoadValidatorMetadataToAttributeRector in the composer-based set

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -41,6 +41,7 @@ use Rector\Renaming\ValueObject\RenameClassConstFetch;
 use Rector\Renaming\ValueObject\RenameProperty;
 use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
 use Rector\Symfony\CodeQuality\Rector\AttributeGroup\SingleConditionSecurityAttributeToIsGrantedRector;
+use Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\SplitAndSecurityAttributeToIsGrantedRector;
 use Rector\Symfony\Symfony25\Rector\MethodCall\AddViolationToBuildViolationRector;
 use Rector\Symfony\Symfony25\Rector\MethodCall\MaxLengthSymfonyFormOptionToAttrRector;
@@ -246,6 +247,7 @@ return static function (RectorConfig $rectorConfig): void {
         ReflectionExtractorEnableMagicCallExtractorRector::class,
 
         // symfony/validator 5.2
+        LoadValidatorMetadataToAttributeRector::class,
         ValidatorBuilderEnableAnnotationMappingRector::class,
 
         // symfony/framework-bundle 5.3


### PR DESCRIPTION
`LoadValidatorMetadataToAttributeRector` already declares its constraint:

```php
public function provideComposerPackageConstraint(): ComposerPackageConstraint
{
    return new ComposerPackageConstraint('symfony/validator', '>=5.2');
}
```

...but it was only reachable through `symfony-code-quality.php`, so the composer-based set never picked it up. It was the only interface-bonded rule left outside that set.

```diff
         // symfony/validator 5.2
+        LoadValidatorMetadataToAttributeRector::class,
         ValidatorBuilderEnableAnnotationMappingRector::class,
```

It stays registered in `symfony-code-quality.php` as well — nothing removed.

## What the rule does

```diff
 use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Constraints as Assert;

 class SomeEntity
 {
+    #[Assert\NotBlank]
     private $name;

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank());
-    }
 }
```

On a project below `symfony/validator` 5.2 the rule is now skipped rather than emitting attributes the installed validator cannot read.
