### PR TITLE
[Symfony44] Skip (int) cast on match return in ConsoleExecuteReturnIntRector

### DIFF
--- a/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_match_return_int.php.inc
+++ b/rules-tests/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_match_return_int.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony44\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipMatchReturnInt extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return match ($input->getArgument('type')) {
+            'a' => 0,
+            default => 1,
+        };
+    }
+}

--- a/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/Symfony44/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -161,7 +161,7 @@ CODE_SAMPLE
 
         if ($expr instanceof Expr) {
             $returnedType = $this->getType($expr);
-            if ($returnedType instanceof IntegerType) {
+            if ($returnedType->isInteger()->yes()) {
                 return true;
             }
         }
@@ -237,7 +237,7 @@ CODE_SAMPLE
         }
 
         $staticType = $this->getType($return->expr);
-        if (! $staticType instanceof IntegerType) {
+        if (! $staticType->isInteger()->yes()) {
             $return->expr = new Int_($return->expr);
         }
     }


### PR DESCRIPTION
`ConsoleExecuteReturnIntRector` added a redundant `(int)` cast to an `execute()` method that already returned `int`, when the return expression was a `match`.

**Before:**

```diff
 public function execute(InputInterface $input, OutputInterface $output): int
 {
-    return match ($input->getArgument('type')) {
+    return (int) match ($input->getArgument('type')) {
         'a' => 0,
         default => 1,
     };
 }
```

**Cause**

`getType()` on a `match` expression returns a `UnionType` of `ConstantIntegerType`s (`0|1`), not an `IntegerType` instance. Both int checks in the rule used `instanceof IntegerType`, so the union fell through to the cast branch.

**Fix**

Use `Type::isInteger()->yes()` instead of `instanceof IntegerType`. That also covers int ranges and unions of int constants coming from other expressions.

Added fixture `skip_match_return_int.php.inc`.