### PR TITLE
[CodeQuality] Skip non-constant constraint args in LoadValidatorMetadataToAttributeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_arrow_function_property_constraint.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_arrow_function_property_constraint.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Fixture;
+
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+final class SkipArrowFunctionPropertyConstraint
+{
+    private $city;
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->addPropertyConstraint('city', new Callback([
+            'callback' => fn (): bool => true,
+        ]));
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_closure_constraint.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_closure_constraint.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Fixture;
+
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+final class SkipClosureConstraint
+{
+    private $slotName;
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        // a closure is not a constant expression, an attribute cannot hold it
+        $metadata->addConstraint(new Callback(
+            function (self $self, ExecutionContextInterface $context): void {
+                $context->buildViolation('nope')
+                    ->atPath('slotName')
+                    ->addViolation();
+            },
+        ));
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_method_call_constraint_option.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_method_call_constraint_option.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Source\TypeList;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+final class SkipMethodCallConstraintOption
+{
+    private $type;
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->addPropertyConstraint('type', new Choice(choices: (new TypeList())->getChoices()));
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_static_call_constraint_option.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_static_call_constraint_option.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Source\TypeList;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+final class SkipStaticCallConstraintOption
+{
+    private $type;
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->addPropertyConstraint('type', new Choice([
+            'choices' => TypeList::provideChoices(),
+        ]));
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Source/TypeList.php
+++ b/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Source/TypeList.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Source;
+
+final class TypeList
+{
+    /**
+     * @return string[]
+     */
+    public function getChoices(): array
+    {
+        return ['first', 'second'];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function provideChoices(): array
+    {
+        return ['first', 'second'];
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace Rector\Symfony\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\ArrowFunction;
-use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
-use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
+use Rector\Symfony\NodeAnalyzer\ValidatorAssert\ConstantExpressionAnalyzer;
 use Rector\Symfony\NodeAnalyzer\ValidatorAssert\ConstraintAttributeTargetAnalyzer;
 use Rector\Symfony\NodeAnalyzer\ValidatorAssert\MetadataConstraintResolver;
 use Rector\Symfony\NodeFactory\ValidatorAssert\ConstraintAttributeGroupFactory;
@@ -38,7 +36,7 @@ final class LoadValidatorMetadataToAttributeRector extends AbstractRector implem
         private readonly MetadataConstraintResolver $metadataConstraintResolver,
         private readonly ConstraintAttributeTargetAnalyzer $constraintAttributeTargetAnalyzer,
         private readonly ConstraintAttributeGroupFactory $constraintAttributeGroupFactory,
-        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ConstantExpressionAnalyzer $constantExpressionAnalyzer,
     ) {
     }
 
@@ -239,9 +237,8 @@ CODE_SAMPLE
 
     private function resolveConstraintClass(New_ $new): ?string
     {
-        // an attribute argument must be a constant expression, a closure like new Assert\Callback(function () {...})
-        // would make the class unparsable
-        if ($this->betterNodeFinder->hasInstancesOf($new->getArgs(), [Closure::class, ArrowFunction::class])) {
+        // e.g. new Assert\Callback(function () {...}) has no constant expression form, the attribute would not parse
+        if (! $this->constantExpressionAnalyzer->areArgsConstant($new->args)) {
             return null;
         }
 

--- a/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Rector\Symfony\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
+use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\NodeAnalyzer\ValidatorAssert\ConstraintAttributeTargetAnalyzer;
 use Rector\Symfony\NodeAnalyzer\ValidatorAssert\MetadataConstraintResolver;
@@ -35,6 +38,7 @@ final class LoadValidatorMetadataToAttributeRector extends AbstractRector implem
         private readonly MetadataConstraintResolver $metadataConstraintResolver,
         private readonly ConstraintAttributeTargetAnalyzer $constraintAttributeTargetAnalyzer,
         private readonly ConstraintAttributeGroupFactory $constraintAttributeGroupFactory,
+        private readonly BetterNodeFinder $betterNodeFinder,
     ) {
     }
 
@@ -235,6 +239,12 @@ CODE_SAMPLE
 
     private function resolveConstraintClass(New_ $new): ?string
     {
+        // an attribute argument must be a constant expression, a closure like new Assert\Callback(function () {...})
+        // would make the class unparsable
+        if ($this->betterNodeFinder->hasInstancesOf($new->getArgs(), [Closure::class, ArrowFunction::class])) {
+            return null;
+        }
+
         $constraintClass = $this->getName($new->class);
         if (! is_string($constraintClass)) {
             return null;

--- a/src/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzer.php
+++ b/src/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzer.php
@@ -30,6 +30,7 @@ use PhpParser\Node\VariadicPlaceholder;
  * a variable - makes the attribute a parse error.
  *
  * @see https://www.php.net/manual/en/language.attributes.syntax.php
+ * @see \Rector\Symfony\Tests\NodeAnalyzer\ValidatorAssert\ConstantExpressionAnalyzerTest
  */
 final class ConstantExpressionAnalyzer
 {

--- a/src/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzer.php
+++ b/src/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzer.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\NodeAnalyzer\ValidatorAssert;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\BinaryOp;
+use PhpParser\Node\Expr\BitwiseNot;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Expr\UnaryMinus;
+use PhpParser\Node\Expr\UnaryPlus;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\Float_;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\MagicConst;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\VariadicPlaceholder;
+
+/**
+ * An attribute argument must be a constant expression, so anything evaluated at runtime - a closure, a method call,
+ * a variable - makes the attribute a parse error.
+ *
+ * @see https://www.php.net/manual/en/language.attributes.syntax.php
+ */
+final class ConstantExpressionAnalyzer
+{
+    /**
+     * @param array<Arg|VariadicPlaceholder> $args
+     */
+    public function areArgsConstant(array $args): bool
+    {
+        foreach ($args as $arg) {
+            // a first-class callable, e.g. new Assert\Callback(...)
+            if (! $arg instanceof Arg) {
+                return false;
+            }
+
+            if (! $this->isConstant($arg->value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isConstant(Expr $expr): bool
+    {
+        if ($expr instanceof String_ || $expr instanceof Int_ || $expr instanceof Float_ || $expr instanceof MagicConst) {
+            return true;
+        }
+
+        if ($expr instanceof ConstFetch) {
+            return true;
+        }
+
+        if ($expr instanceof ClassConstFetch) {
+            return $expr->class instanceof Name;
+        }
+
+        if ($expr instanceof Array_) {
+            return $this->areArrayItemsConstant($expr);
+        }
+
+        // new is allowed in an attribute argument since PHP 8.1, e.g. #[Assert\All(new Assert\NotBlank())]
+        if ($expr instanceof New_) {
+            return $expr->class instanceof Name && $this->areArgsConstant($expr->args);
+        }
+
+        if ($expr instanceof BinaryOp) {
+            return $this->isConstant($expr->left) && $this->isConstant($expr->right);
+        }
+
+        if ($expr instanceof UnaryMinus || $expr instanceof UnaryPlus || $expr instanceof BitwiseNot || $expr instanceof BooleanNot) {
+            return $this->isConstant($expr->expr);
+        }
+
+        if ($expr instanceof Ternary) {
+            if (! $this->isConstant($expr->cond)) {
+                return false;
+            }
+
+            if ($expr->if instanceof Expr && ! $this->isConstant($expr->if)) {
+                return false;
+            }
+
+            return $this->isConstant($expr->else);
+        }
+
+        if ($expr instanceof ArrayDimFetch) {
+            if (! $expr->dim instanceof Expr) {
+                return false;
+            }
+
+            return $this->isConstant($expr->var) && $this->isConstant($expr->dim);
+        }
+
+        return false;
+    }
+
+    private function areArrayItemsConstant(Array_ $array): bool
+    {
+        foreach ($array->items as $arrayItem) {
+            if (! $arrayItem instanceof ArrayItem) {
+                return false;
+            }
+
+            if ($arrayItem->key instanceof Expr && ! $this->isConstant($arrayItem->key)) {
+                return false;
+            }
+
+            if (! $this->isConstant($arrayItem->value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzerTest.php
+++ b/tests/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzerTest.php
@@ -53,7 +53,7 @@ final class ConstantExpressionAnalyzerTest extends TestCase
 
     private function parseNew(string $newExpression): New_
     {
-        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $parser = new ParserFactory()->createForNewestSupportedVersion();
 
         $stmts = $parser->parse('<?php ' . $newExpression . ';');
         $this->assertIsArray($stmts);

--- a/tests/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzerTest.php
+++ b/tests/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\NodeAnalyzer\ValidatorAssert;
+
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Rector\Symfony\NodeAnalyzer\ValidatorAssert\ConstantExpressionAnalyzer;
+
+final class ConstantExpressionAnalyzerTest extends TestCase
+{
+    private ConstantExpressionAnalyzer $constantExpressionAnalyzer;
+
+    protected function setUp(): void
+    {
+        $this->constantExpressionAnalyzer = new ConstantExpressionAnalyzer();
+    }
+
+    #[DataProvider('provideData')]
+    public function test(string $newExpression, bool $expectedAreArgsConstant): void
+    {
+        $new = $this->parseNew($newExpression);
+
+        $this->assertSame($expectedAreArgsConstant, $this->constantExpressionAnalyzer->areArgsConstant($new->args));
+    }
+
+    /**
+     * @return iterable<array{string, bool}>
+     */
+    public static function provideData(): iterable
+    {
+        yield ['new NotBlank()', true];
+        yield ["new NotBlank(message: 'City is empty')", true];
+        yield ["new Choice(['choices' => ['first', 'second']])", true];
+        yield ['new Choice(choices: SomeClass::CHOICES)', true];
+        yield ['new All(new NotBlank())', true];
+        yield ['new Length(min: 1 + 2)', true];
+        yield ['new Length(min: -1)', true];
+        yield ["new Regex('#' . self::PATTERN . '#')", true];
+
+        yield ['new Choice(choices: (new TypeList())->getChoices())', false];
+        yield ['new Choice(choices: TypeList::provideChoices())', false];
+        yield ['new Choice(choices: array_keys(self::CHOICES))', false];
+        yield ['new Callback(function () {})', false];
+        yield ['new Callback(fn () => true)', false];
+        yield ["new Choice(['choices' => \$choices])", false];
+        yield ['new All(new Choice(choices: TypeList::provideChoices()))', false];
+    }
+
+    private function parseNew(string $newExpression): New_
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+
+        $stmts = $parser->parse('<?php ' . $newExpression . ';');
+        $this->assertIsArray($stmts);
+
+        $expression = $stmts[0] ?? null;
+        $this->assertInstanceOf(Expression::class, $expression);
+        $this->assertInstanceOf(New_::class, $expression->expr);
+
+        return $expression->expr;
+    }
+}


### PR DESCRIPTION
An attribute argument must be a constant expression. When a constraint carried something evaluated at runtime — a closure, a method call, a variable — moving it to an attribute produced a file PHP cannot even parse.

Before:

```php
public static function loadValidatorMetadata(ClassMetadata $metadata): void
{
    $metadata->addConstraint(new Callback(
        function (self $self, ExecutionContextInterface $context): void {
            $context->buildViolation('nope')
                ->atPath('slotName')
                ->addViolation();
        },
    ));

    $metadata->addPropertyConstraint('type', new Choice(choices: (new TypeList())->getChoices()));
}
```

Broken output, now fixed:

```diff
+#[\Symfony\Component\Validator\Constraints\Callback(function (self $self, ExecutionContextInterface $context): void {
+    $context->buildViolation('nope')
+        ->atPath('slotName')
+        ->addViolation();
+})]
 final class SomeClass
 {
+    #[\Symfony\Component\Validator\Constraints\Choice(choices: (new TypeList())->getChoices())]
     private $type;
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        ...
-    }
 }
```

Such constraints are now left in `loadValidatorMetadata()`.

A new `ConstantExpressionAnalyzer` decides what may become an attribute argument. It whitelists what PHP accepts — scalars, constants, class constants, arrays, `new` (allowed in an attribute argument since PHP 8.1, so nested constraints like `new Assert\All(new Assert\NotBlank())` keep working), unary and binary operations, ternary, array dim fetch — and rejects everything else.
