### PR TITLE
[CodeQuality] Skip constraint without own constructor in LoadValidatorMetadataToAttributeRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_constraint_without_own_constructor.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_constraint_without_own_constructor.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Fixture;
+
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Source\UniqueUserAlias;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+final class SkipConstraintWithoutOwnConstructor
+{
+    private $alias;
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->addConstraint(new UniqueUserAlias([
+            'field'   => 'alias',
+            'message' => 'mautic.lead.list.alias.unique',
+        ]));
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Source/UniqueUserAlias.php
+++ b/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Source/UniqueUserAlias.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Source;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Custom constraint that configures itself through properties, without a constructor of its own
+ */
+#[Attribute]
+final class UniqueUserAlias extends Constraint
+{
+    public $message = 'This alias is already in use.';
+
+    public $field = '';
+
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+
+    public function getDefaultOption(): string
+    {
+        return 'field';
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\Property;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\NodeAnalyzer\ValidatorAssert\ConstantExpressionAnalyzer;
 use Rector\Symfony\NodeAnalyzer\ValidatorAssert\ConstraintAttributeTargetAnalyzer;
+use Rector\Symfony\NodeAnalyzer\ValidatorAssert\ConstraintConstructorAnalyzer;
 use Rector\Symfony\NodeAnalyzer\ValidatorAssert\MetadataConstraintResolver;
 use Rector\Symfony\NodeFactory\ValidatorAssert\ConstraintAttributeGroupFactory;
 use Rector\Symfony\ValueObject\ValidatorAssert\ClassMethodAndConstraint;
@@ -37,6 +38,7 @@ final class LoadValidatorMetadataToAttributeRector extends AbstractRector implem
         private readonly ConstraintAttributeTargetAnalyzer $constraintAttributeTargetAnalyzer,
         private readonly ConstraintAttributeGroupFactory $constraintAttributeGroupFactory,
         private readonly ConstantExpressionAnalyzer $constantExpressionAnalyzer,
+        private readonly ConstraintConstructorAnalyzer $constraintConstructorAnalyzer,
     ) {
     }
 
@@ -244,6 +246,11 @@ CODE_SAMPLE
 
         $constraintClass = $this->getName($new->class);
         if (! is_string($constraintClass)) {
+            return null;
+        }
+
+        // e.g. new UniqueUserAlias(['field' => 'alias']) - the options have no matching constructor arguments
+        if ($new->args !== [] && ! $this->constraintConstructorAnalyzer->hasOwnConstructor($constraintClass)) {
             return null;
         }
 

--- a/src/NodeAnalyzer/ValidatorAssert/ConstraintConstructorAnalyzer.php
+++ b/src/NodeAnalyzer/ValidatorAssert/ConstraintConstructorAnalyzer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\NodeAnalyzer\ValidatorAssert;
+
+use PHPStan\Reflection\ReflectionProvider;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * A constraint that adds no constructor of its own inherits the one from Symfony\Component\Validator\Constraint,
+ * which takes the options array as a whole. Its options are plain properties, so there are no named arguments to
+ * move them to.
+ */
+final readonly class ConstraintConstructorAnalyzer
+{
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function hasOwnConstructor(string $constraintClass): bool
+    {
+        if (! $this->reflectionProvider->hasClass($constraintClass)) {
+            return false;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($constraintClass);
+        if (! $classReflection->hasConstructor()) {
+            return false;
+        }
+
+        $extendedMethodReflection = $classReflection->getConstructor();
+
+        return $extendedMethodReflection->getDeclaringClass()
+            ->getName() !== Constraint::class;
+    }
+}

--- a/tests/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzerTest.php
+++ b/tests/NodeAnalyzer/ValidatorAssert/ConstantExpressionAnalyzerTest.php
@@ -53,7 +53,8 @@ final class ConstantExpressionAnalyzerTest extends TestCase
 
     private function parseNew(string $newExpression): New_
     {
-        $parser = new ParserFactory()->createForNewestSupportedVersion();
+        $parser = new ParserFactory()
+            ->createForNewestSupportedVersion();
 
         $stmts = $parser->parse('<?php ' . $newExpression . ';');
         $this->assertIsArray($stmts);


### PR DESCRIPTION
Follow-up to #1000.

A constraint that adds no constructor of its own inherits `Constraint::__construct(mixed $options = null, ?array $groups = null, mixed $payload = null)` and configures itself through public properties. Turning its options array into named arguments produces an attribute with parameters that do not exist:

```php
#[\Attribute]
final class UniqueUserAlias extends Constraint
{
    public $message = 'This alias is already in use.';

    public $field = '';

    public function getTargets(): string
    {
        return self::CLASS_CONSTRAINT;
    }

    public function getDefaultOption(): string
    {
        return 'field';
    }
}
```

```diff
+#[\Mautic\LeadBundle\Form\Validator\Constraints\UniqueUserAlias(field: 'alias', message: 'mautic.lead.list.alias.unique')]
 final class SomeClass
 {
     private $alias;
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new UniqueUserAlias([
-            'field'   => 'alias',
-            'message' => 'mautic.lead.list.alias.unique',
-        ]));
-    }
 }
```

Such a constraint is now left in `loadValidatorMetadata()`. The new `ConstraintConstructorAnalyzer` checks the constraint declares a constructor below `Symfony\Component\Validator\Constraint`, so the Symfony constraints and any custom one with its own constructor keep converting.

The last commit fixes a method chaining indentation ECS error that came in with #1000.
