### PR TITLE
[CodeQuality] Re-use parent protected property in ControllerMethodInjectionToConstructorRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/re_use_parent_protected_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/re_use_parent_protected_property.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Psr\Log\LoggerInterface;
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Source\ParentControllerWithProtectedProperty;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class ReUseParentProtectedProperty extends ParentControllerWithProtectedProperty
+{
+    #[Route('/example', name: 'example')]
+    public function example(LoggerInterface $logger)
+    {
+        $logger->log('level', 'value');
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Psr\Log\LoggerInterface;
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Source\ParentControllerWithProtectedProperty;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class ReUseParentProtectedProperty extends ParentControllerWithProtectedProperty
+{
+    #[Route('/example', name: 'example')]
+    public function example()
+    {
+        $this->logger->log('level', 'value');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Source/ParentControllerWithProtectedProperty.php
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Source/ParentControllerWithProtectedProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Source;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+abstract class ParentControllerWithProtectedProperty extends AbstractController
+{
+    public function __construct(protected LoggerInterface $logger)
+    {
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
+++ b/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
@@ -14,11 +14,13 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeVisitor;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ObjectType;
 use Rector\NodeManipulator\ClassDependencyManipulator;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PostRector\ValueObject\PropertyMetadata;
 use Rector\Rector\AbstractRector;
+use Rector\Reflection\ReflectionResolver;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use Rector\Symfony\Bridge\NodeAnalyzer\ControllerMethodAnalyzer;
 use Rector\Symfony\CodeQuality\NodeAnalyzer\ParamConverterClassesResolver;
@@ -47,7 +49,8 @@ final class ControllerMethodInjectionToConstructorRector extends AbstractRector
         private readonly ClassDependencyManipulator $classDependencyManipulator,
         private readonly StaticTypeMapper $staticTypeMapper,
         private readonly ParamConverterClassesResolver $paramConverterClassesResolver,
-        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard
+        private readonly ParentClassMethodTypeOverrideGuard $parentClassMethodTypeOverrideGuard,
+        private readonly ReflectionResolver $reflectionResolver
     ) {
     }
 
@@ -225,14 +228,20 @@ CODE_SAMPLE
 
                 $paramName = $this->getName($param->var);
                 $paramsToRemove[] = [$classMethod, $key];
-                $propertyMetadatas[$paramName] = new PropertyMetadata($paramName, $paramType);
                 $methodParamNamesToReplace[$classMethod->name->toString()][] = $paramName;
                 $removedMethodArgPositions[$classMethod->name->toString()][] = $key;
+
+                // the parent class already provides the very same service, re-use it instead of adding own one
+                if ($this->hasAccessibleParentProperty($node, $paramName, $paramType)) {
+                    continue;
+                }
+
+                $propertyMetadatas[$paramName] = new PropertyMetadata($paramName, $paramType);
             }
         }
 
         // nothing to move
-        if ($propertyMetadatas === []) {
+        if ($paramsToRemove === []) {
             return null;
         }
 
@@ -345,6 +354,33 @@ CODE_SAMPLE
 
                 return $param->type instanceof FullyQualified && ! $this->isName($param->type, $paramType);
             }
+        }
+
+        return false;
+    }
+
+    /**
+     * Is there a protected/public property of the same name and compatible type in a parent class?
+     */
+    private function hasAccessibleParentProperty(Class_ $class, string $propertyName, ObjectType $objectType): bool
+    {
+        $classReflection = $this->reflectionResolver->resolveClassReflection($class);
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if (! $parentClassReflection->hasNativeProperty($propertyName)) {
+                continue;
+            }
+
+            $nativePropertyReflection = $parentClassReflection->getNativeProperty($propertyName);
+            if ($nativePropertyReflection->isPrivate()) {
+                continue;
+            }
+
+            return $objectType->isSuperTypeOf($nativePropertyReflection->getReadableType())
+                ->yes();
         }
 
         return false;


### PR DESCRIPTION
When a parent controller already exposes the very same service as a `protected`/`public` property, the rule added a duplicate constructor property with the same name — shadowing the parent one.

Now the parent property is re-used: the action param is still removed and its usage rewritten to `$this->...`, but no new constructor dependency is added.

Parent:

```php
abstract class ParentController extends AbstractController
{
    public function __construct(protected LoggerInterface $logger)
    {
    }
}
```

Child:

```diff
 final class SomeController extends ParentController
 {
     #[Route('/example', name: 'example')]
-    public function example(LoggerInterface $logger)
+    public function example()
     {
-        $logger->log('level', 'value');
+        $this->logger->log('level', 'value');
     }
 }
```

A `private` parent property is still not accessible, so that case keeps adding an own dependency (covered by the existing `child_of_parent_with_private_promoted_property` fixture). The re-use also requires the parent property type to be compatible with the param type.
