### PR TITLE
[Configs] Add EnableValidationAttributesRector

### DIFF
--- a/config/sets/symfony/configs.php
+++ b/config/sets/symfony/configs.php
@@ -10,6 +10,7 @@ use Rector\Symfony\Configs\Rector\Closure\ServiceArgsToServiceNamedArgRector;
 use Rector\Symfony\Configs\Rector\Closure\ServiceSetStringNameToClassNameRector;
 use Rector\Symfony\Configs\Rector\Closure\ServiceSettersToSettersAutodiscoveryRector;
 use Rector\Symfony\Configs\Rector\Closure\ServiceTagsToDefaultsAutoconfigureRector;
+use Rector\Symfony\Configs\Rector\MethodCall\EnableValidationAttributesRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
@@ -20,5 +21,6 @@ return static function (RectorConfig $rectorConfig): void {
         ServiceTagsToDefaultsAutoconfigureRector::class,
         RemoveConstructorAutowireServiceRector::class,
         FromServicePublicToDefaultsPublicRector::class,
+        EnableValidationAttributesRector::class,
     ]);
 };

--- a/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/EnableValidationAttributesRectorTest.php
+++ b/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/EnableValidationAttributesRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Configs\Rector\MethodCall\EnableValidationAttributesRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EnableValidationAttributesRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/Fixture/enable_attributes.php.inc
+++ b/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/Fixture/enable_attributes.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Symfony\Tests\Configs\Rector\MethodCall\EnableValidationAttributesRector\Fixture;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('framework', [
+    'secret' => '%secret_key%',
+    'form' => null,
+    'validation' => [
+        'enable_attributes' => false,
+    ],
+]);
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Configs\Rector\MethodCall\EnableValidationAttributesRector\Fixture;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('framework', [
+    'secret' => '%secret_key%',
+    'form' => null,
+    'validation' => [
+        'enable_attributes' => true,
+    ],
+]);
+
+?>

--- a/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/Fixture/skip_already_enabled.php.inc
+++ b/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/Fixture/skip_already_enabled.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Symfony\Tests\Configs\Rector\MethodCall\EnableValidationAttributesRector\Fixture;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('framework', [
+    'validation' => [
+        'enable_attributes' => true,
+    ],
+]);

--- a/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/Fixture/skip_another_extension.php.inc
+++ b/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/Fixture/skip_another_extension.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Symfony\Tests\Configs\Rector\MethodCall\EnableValidationAttributesRector\Fixture;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('twig', [
+    'validation' => [
+        'enable_attributes' => false,
+    ],
+]);

--- a/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/Fixture/skip_missing_validation.php.inc
+++ b/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/Fixture/skip_missing_validation.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\Symfony\Tests\Configs\Rector\MethodCall\EnableValidationAttributesRector\Fixture;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @var ContainerBuilder $container */
+$container->loadFromExtension('framework', [
+    'secret' => '%secret_key%',
+]);

--- a/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/config/configured_rule.php
+++ b/rules-tests/Configs/Rector/MethodCall/EnableValidationAttributesRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Configs\Rector\MethodCall\EnableValidationAttributesRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(EnableValidationAttributesRector::class);
+};

--- a/rules/Configs/Rector/MethodCall/EnableValidationAttributesRector.php
+++ b/rules/Configs/Rector/MethodCall/EnableValidationAttributesRector.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Configs\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use Rector\PhpParser\Node\Value\ValueResolver;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Symfony\Tests\Configs\Rector\MethodCall\EnableValidationAttributesRector\EnableValidationAttributesRectorTest
+ */
+final class EnableValidationAttributesRector extends AbstractRector
+{
+    public function __construct(
+        private readonly ValueResolver $valueResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Enable "framework.validation.enable_attributes" config, to load validation rules from attributes',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$container->loadFromExtension('framework', [
+    'validation' => [
+        'enable_attributes' => false,
+    ],
+]);
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$container->loadFromExtension('framework', [
+    'validation' => [
+        'enable_attributes' => true,
+    ],
+]);
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node->name, 'loadFromExtension')) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+        if (count($args) < 2) {
+            return null;
+        }
+
+        if (! $this->valueResolver->isValue($args[0]->value, 'framework')) {
+            return null;
+        }
+
+        $configArray = $args[1]->value;
+        if (! $configArray instanceof Array_) {
+            return null;
+        }
+
+        $validationArrayItem = $this->matchArrayItemByKey($configArray, 'validation');
+        if (! $validationArrayItem instanceof ArrayItem) {
+            return null;
+        }
+
+        if (! $validationArrayItem->value instanceof Array_) {
+            return null;
+        }
+
+        $enableAttributesArrayItem = $this->matchArrayItemByKey($validationArrayItem->value, 'enable_attributes');
+        if (! $enableAttributesArrayItem instanceof ArrayItem) {
+            return null;
+        }
+
+        if (! $this->valueResolver->isFalse($enableAttributesArrayItem->value)) {
+            return null;
+        }
+
+        $enableAttributesArrayItem->value = new ConstFetch(new Name('true'));
+
+        return $node;
+    }
+
+    private function matchArrayItemByKey(Array_ $array, string $keyName): ?ArrayItem
+    {
+        foreach ($array->items as $arrayItem) {
+            if (! $arrayItem instanceof ArrayItem) {
+                continue;
+            }
+
+            if (! $arrayItem->key instanceof Expr) {
+                continue;
+            }
+
+            if (! $this->valueResolver->isValue($arrayItem->key, $keyName)) {
+                continue;
+            }
+
+            return $arrayItem;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Adds `EnableValidationAttributesRector` to the `configs` set.

When validation metadata is moved from `loadValidatorMetadata()` to attributes (see `LoadValidatorMetadataToAttributeRector`), the framework config must load them. This rule flips the config value:

```diff
 $container->loadFromExtension('framework', [
     'secret' => '%secret_key%',
     'validation' => [
-        'enable_attributes' => false,
+        'enable_attributes' => true,
     ],
 ]);
```

Scope:

* matches `$container->loadFromExtension('framework', [...])` array config only
* only flips an existing `false` value, does not add a missing key
