### PR TITLE
[CodeQuality] Skip event and session params in ControllerMethodInjectionToConstructorRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/skip_event_subscriber_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/skip_event_subscriber_method.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class SkipEventSubscriberMethod extends AbstractController implements EventSubscriberInterface
+{
+    public function onRequest(RequestEvent $requestEvent): void
+    {
+        $controller = $requestEvent->getRequest()->attributes->get('_controller');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => 'onRequest',
+        ];
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/skip_session_interface.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/skip_session_interface.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class SkipSessionInterface extends AbstractController
+{
+    #[Route('/some-action', name: 'some_action')]
+    public function someAction(SessionInterface $session)
+    {
+        $session->invalidate();
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
+++ b/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
@@ -183,6 +183,10 @@ CODE_SAMPLE
                         new ObjectType(SymfonyClass::USER_INTERFACE),
                         new ObjectType('DateTimeInterface'),
                         new ObjectType(SymfonyClass::UUID),
+                        // event listener method, not a controller action
+                        new ObjectType(SymfonyClass::EVENT),
+                        // request-scoped, must stay in the action method
+                        new ObjectType(SymfonyClass::SESSION_INTERFACRE),
                     ]
                 )) {
                     continue;

--- a/src/Enum/SymfonyClass.php
+++ b/src/Enum/SymfonyClass.php
@@ -20,6 +20,8 @@ final class SymfonyClass
 
     public const string EVENT_DISPATCHER_INTERFACE = 'Symfony\Contracts\EventDispatcher\EventDispatcherInterface';
 
+    public const string EVENT = 'Symfony\Contracts\EventDispatcher\Event';
+
     public const string VALIDATOR_INTERFACE = 'Symfony\Component\Validator\Validator\ValidatorInterface';
 
     public const string LOGGER_INTERFACE = 'Psr\Log\LoggerInterface';


### PR DESCRIPTION
Two params must never be moved to the constructor:

* **`Symfony\Contracts\EventDispatcher\Event` subtypes** - an event subscriber method living inside a controller is not an action, the event is passed by the dispatcher
* **`SessionInterface`** - request-scoped, must stay in the action method signature

Both skips are type-based, so any subtype is covered (e.g. `RequestEvent extends KernelEvent extends Event`).

## Before/after

Reported from Mautic's `SecurityController`, which implements `EventSubscriberInterface`:

```diff
-final class SecurityController extends CommonController implements EventSubscriberInterface
-{
-    public function onRequest(RequestEvent $requestEvent): void
-    {
-        $controller = $requestEvent->getRequest()->attributes->get('_controller');
-    }
-}
+// unchanged
```

Previously the rule turned `RequestEvent $requestEvent` into a constructor dependency, breaking the listener.

Same for session:

```diff
 final class SomeController extends AbstractController
 {
-    public function __construct(
-        private readonly SessionInterface $session
-    ) {
-    }
-
-    public function someAction()
+    public function someAction(SessionInterface $session)
     {
-        $this->session->invalidate();
+        $session->invalidate();
     }
 }
```

Covered by 2 new fixtures.