### PR TITLE
[CodeQuality] Skip type-guarded classes + unique autowire method name in ControllerMethodInjectionToConstructorRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/child_of_parent_with_private_promoted_property.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/child_of_parent_with_private_promoted_property.php.inc
@@ -38,7 +38,7 @@ final class ChildOfParentWithPrivatePromotedProperty extends ParentControllerWit
         $this->logger->log('level', 'value');
     }
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Psr\Log\LoggerInterface $logger): void
+    public function autowireChildOfParentWithPrivatePromotedProperty(\Psr\Log\LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/parent_constructor_multiple_services.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/parent_constructor_multiple_services.php.inc
@@ -41,7 +41,7 @@ final class ParentConstructorMultipleServices extends ParentControllerWithPrivat
         $this->logger->log('level', $this->translator->trans('value'));
     }
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Psr\Log\LoggerInterface $logger, \Symfony\Contracts\Translation\TranslatorInterface $translator): void
+    public function autowireParentConstructorMultipleServices(\Psr\Log\LoggerInterface $logger, \Symfony\Contracts\Translation\TranslatorInterface $translator): void
     {
         $this->logger = $logger;
         $this->translator = $translator;

--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/parent_with_autowire_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/parent_with_autowire_method.php.inc
@@ -38,7 +38,7 @@ final class ParentWithAutowireMethod extends ParentControllerWithAutowireMethod
         $this->logger->log('level', 'value');
     }
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowireServices(\Psr\Log\LoggerInterface $logger): void
+    public function autowireParentWithAutowireMethod(\Psr\Log\LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/FixtureTypeGuarded/non_guarded_controller.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/FixtureTypeGuarded/non_guarded_controller.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\FixtureTypeGuarded;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+class NonGuardedController extends AbstractController
+{
+    #[Route('/some-action', name: 'some_action')]
+    public function someAction(LoggerInterface $logger)
+    {
+        $logger->log('level', 'value');
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\FixtureTypeGuarded;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+class NonGuardedController extends AbstractController
+{
+    public function __construct(private readonly \Psr\Log\LoggerInterface $logger)
+    {
+    }
+    #[Route('/some-action', name: 'some_action')]
+    public function someAction()
+    {
+        $this->logger->log('level', 'value');
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/FixtureTypeGuarded/skip_type_guarded_controller.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/FixtureTypeGuarded/skip_type_guarded_controller.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\FixtureTypeGuarded;
+
+use Psr\Log\LoggerInterface;
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Source\AbstractCustomController;
+use Symfony\Component\Routing\Annotation\Route;
+
+class SkipTypeGuardedController extends AbstractCustomController
+{
+    #[Route('/some-action', name: 'some_action')]
+    public function someAction(LoggerInterface $logger)
+    {
+        $logger->log('level', 'value');
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Source/AbstractCustomController.php
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Source/AbstractCustomController.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Source;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+abstract class AbstractCustomController extends AbstractController
+{
+}

--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/TypeGuardedTest.php
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/TypeGuardedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class TypeGuardedTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/FixtureTypeGuarded');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/type_guarded_rule.php';
+    }
+}

--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/config/type_guarded_rule.php
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/config/type_guarded_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector;
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Source\AbstractCustomController;
+
+return RectorConfig::configure()
+    ->withRules([ControllerMethodInjectionToConstructorRector::class])
+    ->withTypeGuardedClasses([AbstractCustomController::class]);

--- a/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
+++ b/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
@@ -177,6 +177,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // removing action params would break child classes of user-guarded classes
+        if ($this->parentClassMethodTypeOverrideGuard->isTypeGuardedClass($node)) {
+            return null;
+        }
+
         $propertyMetadatas = [];
 
         $constructParamVariables = [];

--- a/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
+++ b/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
@@ -53,12 +53,7 @@ final class ControllerMethodInjectionToConstructorRector extends AbstractRector
      */
     private const array COMMON_ENTITY_CONTAINS_SUBNAMESPACES = ["\\Entity\\", "\\Document\\", "\\Model\\"];
 
-    private const string AUTOWIRE_METHOD_NAME = 'autowire';
-
-    /**
-     * Used when a parent class already defines autowire(), to avoid overriding it
-     */
-    private const string FALLBACK_AUTOWIRE_METHOD_NAME = 'autowireServices';
+    private const string AUTOWIRE_METHOD_NAME_PREFIX = 'autowire';
 
     public function __construct(
         private readonly ControllerAnalyzer $controllerAnalyzer,
@@ -75,7 +70,7 @@ final class ControllerMethodInjectionToConstructorRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Change Symfony controller method injection to direct constructor dependency, to separate params and services clearly. If a parent class has a constructor, use #[Required] autowire() method instead, to avoid repeating all parent params',
+            'Change Symfony controller method injection to direct constructor dependency, to separate params and services clearly. If a parent class has a constructor, use #[Required] autowire<ShortClassName>() method instead, to avoid repeating all parent params',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
@@ -145,7 +140,7 @@ final class SomeController extends SomeParentControllerWithConstructor
     }
 
     #[Required]
-    public function autowire(SomeService $someService): void
+    public function autowireSomeController(SomeService $someService): void
     {
         $this->someService = $someService;
     }
@@ -500,20 +495,14 @@ CODE_SAMPLE
         }
     }
 
+    /**
+     * Suffix with the short class name, to keep the method unique in case of inheritance
+     */
     private function resolveAutowireMethodName(Class_ $class): string
     {
-        $classReflection = $this->reflectionResolver->resolveClassReflection($class);
-        if (! $classReflection instanceof ClassReflection) {
-            return self::AUTOWIRE_METHOD_NAME;
-        }
+        $shortClassName = $class->name instanceof Identifier ? $class->name->toString() : '';
 
-        foreach ($classReflection->getParents() as $parentClassReflection) {
-            if ($parentClassReflection->hasNativeMethod(self::AUTOWIRE_METHOD_NAME)) {
-                return self::FALLBACK_AUTOWIRE_METHOD_NAME;
-            }
-        }
-
-        return self::AUTOWIRE_METHOD_NAME;
+        return self::AUTOWIRE_METHOD_NAME_PREFIX . ucfirst($shortClassName);
     }
 
     private function hasParentConstructor(Class_ $class): bool


### PR DESCRIPTION
Two changes to `ControllerMethodInjectionToConstructorRector`.

## 1. Skip `->withTypeGuardedClasses([])`

Removing action method params changes the method signature. If the controller is - or extends - a class listed in `->withTypeGuardedClasses([])`, that is a breaking change for its child classes, so the rule leaves such classes untouched. Same guard as `ResponseReturnTypeControllerActionRector` already uses; final classes are never guarded, as they cannot be extended.

```php
return RectorConfig::configure()
    ->withRules([ControllerMethodInjectionToConstructorRector::class])
    ->withTypeGuardedClasses([AbstractCustomController::class]);
```

```diff
 class SomeController extends AbstractCustomController
 {
-    public function someAction(LoggerInterface $logger)
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public function someAction()
     {
-        $logger->log('level', 'value');
+        $this->logger->log('level', 'value');
     }
 }
```

With `AbstractCustomController` type-guarded, the change above is skipped. Non-guarded controllers still change as before.

## 2. `autowire<ShortClassName>()` method name

The added `#[Required]` method is now named after the class, so it never collides with an `autowire()` in a parent or sibling class. Replaces the previous `autowire()` / `autowireServices()` fallback pair.

```diff
 final class SomeController extends SomeParentControllerWithConstructor
 {
+    private SomeService $someService;
+
     #[Route('/some-path', name: 'some_name')]
-    public function someAction(SomeService $someService)
+    public function someAction()
     {
-        $data = $someService->getData();
+        $data = $this->someService->getData();
     }
+
+    #[Required]
+    public function autowireSomeController(SomeService $someService): void
+    {
+        $this->someService = $someService;
+    }
 }
```
