### PR TITLE
[CodeQuality] Re-use existing #[Required] method in ControllerMethodInjectionToConstructorRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/re_use_existing_required_method.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector/Fixture/re_use_existing_required_method.php.inc
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Psr\Log\LoggerInterface;
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Source\ParentControllerWithPrivatePromotedProperty;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Service\Attribute\Required;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ReUseExistingRequiredMethod extends ParentControllerWithPrivatePromotedProperty
+{
+    private TranslatorInterface $translator;
+
+    #[Required]
+    public function autowireTranslator(TranslatorInterface $translator): void
+    {
+        $this->translator = $translator;
+    }
+
+    #[Route('/example', name: 'example')]
+    public function example(LoggerInterface $logger)
+    {
+        $logger->log('level', $this->translator->trans('value'));
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Fixture;
+
+use Psr\Log\LoggerInterface;
+use Rector\Symfony\Tests\CodeQuality\Rector\Class_\ControllerMethodInjectionToConstructorRector\Source\ParentControllerWithPrivatePromotedProperty;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Service\Attribute\Required;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ReUseExistingRequiredMethod extends ParentControllerWithPrivatePromotedProperty
+{
+    private TranslatorInterface $translator;
+    private \Psr\Log\LoggerInterface $logger;
+
+    #[Required]
+    public function autowireTranslator(TranslatorInterface $translator, \Psr\Log\LoggerInterface $logger): void
+    {
+        $this->translator = $translator;
+        $this->logger = $logger;
+    }
+
+    #[Route('/example', name: 'example')]
+    public function example()
+    {
+        $this->logger->log('level', $this->translator->trans('value'));
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
+++ b/rules/CodeQuality/Rector/Class_/ControllerMethodInjectionToConstructorRector.php
@@ -456,12 +456,13 @@ CODE_SAMPLE
      */
     private function addRequiredAutowireClassMethod(Class_ $class, array $propertyMetadatas): void
     {
-        $autowireMethodName = $this->resolveAutowireMethodName($class);
-
-        $autowireClassMethod = $class->getMethod($autowireMethodName);
+        // re-use existing #[Required] method, to keep single injection point
+        $autowireClassMethod = $this->resolveExistingRequiredClassMethod($class);
         $isNewClassMethod = ! $autowireClassMethod instanceof ClassMethod;
 
         if (! $autowireClassMethod instanceof ClassMethod) {
+            $autowireMethodName = $this->resolveAutowireMethodName($class);
+
             $autowireClassMethod = new ClassMethod(new Identifier($autowireMethodName), [
                 'flags' => Modifiers::PUBLIC,
                 'returnType' => new Identifier('void'),
@@ -493,6 +494,45 @@ CODE_SAMPLE
         if ($isNewClassMethod) {
             $class->stmts[] = $autowireClassMethod;
         }
+    }
+
+    /**
+     * Existing #[Required] setter method, or a method named autowire*(), to re-use as injection point
+     */
+    private function resolveExistingRequiredClassMethod(Class_ $class): ?ClassMethod
+    {
+        foreach ($class->getMethods() as $classMethod) {
+            if (! $classMethod->isPublic()) {
+                continue;
+            }
+
+            if ($classMethod->isStatic() || $classMethod->stmts === null) {
+                continue;
+            }
+
+            if ($this->hasRequiredAttribute($classMethod)) {
+                return $classMethod;
+            }
+
+            if (str_starts_with($classMethod->name->toString(), self::AUTOWIRE_METHOD_NAME_PREFIX)) {
+                return $classMethod;
+            }
+        }
+
+        return null;
+    }
+
+    private function hasRequiredAttribute(ClassMethod $classMethod): bool
+    {
+        foreach ($classMethod->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attribute) {
+                if ($this->isName($attribute->name, SymfonyAttribute::REQUIRED)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
When a controller already has an injection method – one with `#[Required]`, or named `autowire*()` – the rule now appends to it, instead of creating a second `autowire<ShortClassName>()` method next to it.

```diff
 final class ReUseExistingRequiredMethod extends ParentControllerWithConstructor
 {
     private TranslatorInterface $translator;
+    private \Psr\Log\LoggerInterface $logger;

     #[Required]
-    public function autowireTranslator(TranslatorInterface $translator): void
+    public function autowireTranslator(TranslatorInterface $translator, \Psr\Log\LoggerInterface $logger): void
     {
         $this->translator = $translator;
+        $this->logger = $logger;
     }

     #[Route('/example', name: 'example')]
-    public function example(LoggerInterface $logger)
+    public function example()
     {
-        $logger->log('level', $this->translator->trans('value'));
+        $this->logger->log('level', $this->translator->trans('value'));
     }
 }
```

Only public, non-static methods with a body are considered. If none is found, a fresh `autowire<ShortClassName>()` method is created as before.
