### PR TITLE
[Twig] Move AsTwigFilter/AsTwigFunction attribute rules to the Twig composer-based set

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -105,8 +105,6 @@ use Rector\Symfony\Symfony73\Rector\Class_\AuthorizationCheckerToAccessDecisionM
 use Rector\Symfony\Symfony73\Rector\Class_\CommandDefaultNameAndDescriptionToAsCommandAttributeRector;
 use Rector\Symfony\Symfony73\Rector\Class_\CommandHelpToAttributeRector;
 use Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector;
-use Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector;
-use Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector;
 use Rector\Symfony\Symfony80\Rector\Class_\RemoveEraseCredentialsRector;
 use Rector\Symfony\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector;
 use Rector\Symfony\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector;
@@ -318,10 +316,6 @@ return static function (RectorConfig $rectorConfig): void {
 
         // symfony/validator 8.1
         ConstraintValidatorValidateToValidateInContextRector::class,
-
-        // twig/twig 3.21
-        GetFiltersToAsTwigFilterAttributeRector::class,
-        GetFunctionsToAsTwigFunctionAttributeRector::class,
     ]);
 
     // shared types used by the configuration below

--- a/config/sets/twig/composer-based.php
+++ b/config/sets/twig/composer-based.php
@@ -8,6 +8,8 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector;
+use Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector;
 use Rector\Symfony\Twig134\Rector\Return_\SimpleFunctionAndFilterRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
@@ -26,6 +28,10 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         // twig/twig 1.34
         SimpleFunctionAndFilterRector::class,
+
+        // twig/twig 3.21
+        GetFiltersToAsTwigFilterAttributeRector::class,
+        GetFunctionsToAsTwigFunctionAttributeRector::class,
     ]);
 
     $arrayType = new ArrayType(new MixedType(), new MixedType());


### PR DESCRIPTION
`GetFiltersToAsTwigFilterAttributeRector` and `GetFunctionsToAsTwigFunctionAttributeRector` were registered in the **Symfony** composer-based set, while both are bound to `twig/twig`:

```php
public function provideComposerPackageConstraint(): ComposerPackageConstraint
{
    return new ComposerPackageConstraint('twig/twig', '>=3.21');
}
```

The attributes they add come from Twig itself — Symfony 7.3 only [made them usable in Twig extensions](https://symfony.com/blog/new-in-symfony-7-3-twig-extension-attributes). A project on Twig 3.21 without `symfony/twig-bundle` should still get the rewrite:

```diff
 use Twig\Extension\AbstractExtension;
+use Twig\Attribute\AsTwigFunction;

 class SomeExtension extends AbstractExtension
 {
-    public function getFunctions(): array
-    {
-        return [new TwigFunction('some_function', $this->someFunction(...))];
-    }
-
+    #[AsTwigFunction('some_function')]
     public function someFunction(): string
     {
         return 'result';
     }
 }
```

So both move to `config/sets/twig/composer-based.php`, under a `// twig/twig 3.21` group. No rule behavior changes — the version bond was already correct, only the set registration was in the wrong file.

The rule namespace stays `Symfony73` so the classes and their tests stay where they are.
