### PR TITLE
[Symfony30] Skip methods without return in GetRequestRector

### DIFF
--- a/rules-tests/Symfony30/Rector/ClassMethod/GetRequestRector/Fixture/fixture.php.inc
+++ b/rules-tests/Symfony30/Rector/ClassMethod/GetRequestRector/Fixture/fixture.php.inc
@@ -12,7 +12,7 @@ class ClassWithNamedService extends Controller
      */
     public function someAction()
     {
-        $this->getRequest()->getSomething();
+        return $this->getRequest()->getSomething();
     }
 }
 
@@ -32,7 +32,7 @@ class ClassWithNamedService extends Controller
      */
     public function someAction(\Symfony\Component\HttpFoundation\Request $request)
     {
-        $request->getSomething();
+        return $request->getSomething();
     }
 }
 

--- a/rules-tests/Symfony30/Rector/ClassMethod/GetRequestRector/Fixture/fixture2.php.inc
+++ b/rules-tests/Symfony30/Rector/ClassMethod/GetRequestRector/Fixture/fixture2.php.inc
@@ -13,7 +13,7 @@ final class ClassWithParameterPresent extends Controller
      */
     public function someAction(Request $request)
     {
-        $this->getRequest()->getSomething();
+        return $this->getRequest()->getSomething();
     }
 }
 
@@ -34,7 +34,7 @@ final class ClassWithParameterPresent extends Controller
      */
     public function someAction(Request $request, \Symfony\Component\HttpFoundation\Request $mainRequest)
     {
-        $mainRequest->getSomething();
+        return $mainRequest->getSomething();
     }
 }
 

--- a/rules-tests/Symfony30/Rector/ClassMethod/GetRequestRector/Fixture/skip_public_setter_without_return.php.inc
+++ b/rules-tests/Symfony30/Rector/ClassMethod/GetRequestRector/Fixture/skip_public_setter_without_return.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony30\Rector\ClassMethod\GetRequestRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class SkipPublicSetterWithoutReturn extends Controller
+{
+    /**
+     * @Route("/some-action", name="some_action")
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        parent::setContainer($container);
+
+        $this->getRequest()->getSomething();
+    }
+}

--- a/rules-tests/Symfony30/Rector/ClassMethod/GetRequestRector/Fixture/with_fqn_route.php.inc
+++ b/rules-tests/Symfony30/Rector/ClassMethod/GetRequestRector/Fixture/with_fqn_route.php.inc
@@ -11,7 +11,7 @@ final class WithFqnRoute extends Controller
      */
     public function someAction()
     {
-        $this->getRequest()->getSomething();
+        return $this->getRequest()->getSomething();
     }
 }
 
@@ -30,7 +30,7 @@ final class WithFqnRoute extends Controller
      */
     public function someAction(\Symfony\Component\HttpFoundation\Request $request)
     {
-        $request->getSomething();
+        return $request->getSomething();
     }
 }
 

--- a/rules/Symfony30/Rector/ClassMethod/GetRequestRector.php
+++ b/rules/Symfony30/Rector/ClassMethod/GetRequestRector.php
@@ -56,7 +56,7 @@ class SomeController
 {
     public function someAction()
     {
-        $this->getRequest()->...();
+        return $this->getRequest()->getContent();
     }
 }
 CODE_SAMPLE
@@ -68,7 +68,7 @@ class SomeController
 {
     public function someAction(Request $request)
     {
-        $request->...();
+        return $request->getContent();
     }
 }
 CODE_SAMPLE
@@ -133,6 +133,11 @@ CODE_SAMPLE
         }
 
         if (! $this->controllerMethodAnalyzer->isAction($classMethod)) {
+            return false;
+        }
+
+        // an action always returns a response; without any return, this is a setter/hook method
+        if ($this->betterNodeFinder->findReturnsScoped($classMethod) === []) {
             return false;
         }
 


### PR DESCRIPTION
A `@Route`-annotated public method that never returns anything is not a controller action - it is a setter or framework hook. `setContainer()` is the typical case: it is public, can carry a route docblock inherited from a sloppy base class, and adding a `Request` parameter there breaks the parent signature.

Skip such methods.

```diff
 final class SomeController extends Controller
 {
     /**
      * @Route("/some-action", name="some_action")
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setContainer(ContainerInterface $container = null)
     {
         parent::setContainer($container);

         $this->getRequest()->getSomething();
     }
 }
```

Methods that do return keep being refactored as before:

```diff
 final class SomeController extends Controller
 {
     /**
      * @Route("/some-action", name="some_action")
      */
-    public function someAction()
+    public function someAction(\Symfony\Component\HttpFoundation\Request $request)
     {
-        return $this->getRequest()->getSomething();
+        return $request->getSomething();
     }
 }
```