### PR TITLE
[Sets] Ignore the deprecated set objects in TwigSetProvider

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -89,5 +89,11 @@ parameters:
             path: src/ValueObjectFactory/ServiceMapFactory.php
             message: '#"@simplexml_load_string\(\$fileContents\)" is forbidden to use#'
 
-
-
+        # the set objects are deprecated in favor of the ComposerPackageConstraintInterface, but Twig is still
+        # resolved through a composer-triggered set
+        # @see https://github.com/rectorphp/rector-src/pull/8296
+        -
+            message: '#deprecated (class|interface) Rector\\Set\\#'
+            path: src/Set/SetProvider/TwigSetProvider.php
+            # the deprecation is not released yet, so the errors are not reported here yet either
+            reportUnmatched: false


### PR DESCRIPTION
Prepares for rectorphp/rector-src#8296, which deprecates the set objects in favor of bonding rules with `ComposerPackageConstraintInterface`.

Twig is still resolved through a composer-triggered set, so `TwigSetProvider` keeps implementing `SetProviderInterface` and instantiating `ComposerTriggeredSet` until its rules carry their own `twig/twig` constraint. Without this, the downstream PHPStan job of rector-src fails the moment the deprecation lands:

```
Class Rector\Symfony\Set\SetProvider\TwigSetProvider implements deprecated interface Rector\Set\Contract\SetProviderInterface
Instantiation of deprecated class Rector\Set\ValueObject\ComposerTriggeredSet
```

```neon
-
    message: '#deprecated (class|interface) Rector\\Set\\#'
    path: src/Set/SetProvider/TwigSetProvider.php
    # the deprecation is not released yet, so the errors are not reported here yet either
    reportUnmatched: false
```

`reportUnmatched: false` is what makes this mergeable in either order — the entry holds both now, where the installed rector-src has no deprecation and the pattern matches nothing, and after #8296 is released.
