### PR TITLE
[Twig] Fix truncated Twig_Tests_EnvironmentTest_Extension rename

### DIFF
--- a/config/sets/twig/composer-based.php
+++ b/config/sets/twig/composer-based.php
@@ -239,6 +239,7 @@ return static function (RectorConfig $rectorConfig): void {
         'Twig_TokenParser_Deprecated' => 'Twig\TokenParser\DeprecatedTokenParser',
         'Twig_Util_DeprecationCollector' => 'Twig\Util\DeprecationCollector',
         'Twig_Util_TemplateDirIterator' => 'Twig\Util\TemplateDirIterator',
+        'Twig_Tests_EnvironmentTest_Extension' => 'Twig\Tests\EnvironmentTest\Extension',
     ], 'twig/twig', '>=1.40');
 
     // twig/twig 3.0

--- a/config/sets/twig/twig-underscore-to-namespace.php
+++ b/config/sets/twig/twig-underscore-to-namespace.php
@@ -190,5 +190,5 @@ return RectorConfig::configure()->withConfiguredRule(RenameClassRector::class, [
     'Twig_TokenParser_Deprecated' => 'Twig\\TokenParser\\DeprecatedTokenParser',
     'Twig_Util_DeprecationCollector' => 'Twig\\Util\\DeprecationCollector',
     'Twig_Util_TemplateDirIterator' => 'Twig\\Util\\TemplateDirIterator',
-    'Twig_Tests_EnvironmentTest_Extension' => 'Twig\\Tests\\EnvironmentTest\\Extensio',
+    'Twig_Tests_EnvironmentTest_Extension' => 'Twig\\Tests\\EnvironmentTest\\Extension',
 ]);


### PR DESCRIPTION
The underscore-to-namespace rename map maps `Twig_Tests_EnvironmentTest_Extension` to a truncated class name, so the renamed code points to a class that does not exist:

```diff
-'Twig_Tests_EnvironmentTest_Extension' => 'Twig\Tests\EnvironmentTest\Extensio',
+'Twig_Tests_EnvironmentTest_Extension' => 'Twig\Tests\EnvironmentTest\Extension',
```

```diff
-class SomeExtension extends \Twig\Tests\EnvironmentTest\Extensio
+class SomeExtension extends \Twig\Tests\EnvironmentTest\Extension
```

The entry was also the only one of the 184 renames missing from `config/sets/twig/composer-based.php`, so it is added there as well, under the same `twig/twig >=1.40` constraint as the rest of the namespaced renames.

Follow-up of #1015.