### PR TITLE
[Symfony 7.3] Keep extends AbstractExtension in AsTwigFilter/AsTwigFunction rules

### DIFF
--- a/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/is_safe.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/is_safe.php.inc
@@ -29,7 +29,7 @@ namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterA
 
 use Twig\Extension\AbstractExtension;
 
-final class IsSafe
+final class IsSafe extends AbstractExtension
 {
     #[\Twig\Attribute\AsTwigFilter(name: 'some_filter', isSafe: ['html'])]
     public function someFilter($value)

--- a/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/some_get_filters.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/some_get_filters.php.inc
@@ -27,7 +27,7 @@ namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterA
 
 use Twig\Extension\AbstractExtension;
 
-final class SomeGetFilter
+final class SomeGetFilter extends AbstractExtension
 {
     #[\Twig\Attribute\AsTwigFilter(name: 'some_filter')]
     public function someFilter($value)

--- a/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/with_first_class_callable_filter.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/with_first_class_callable_filter.php.inc
@@ -39,7 +39,7 @@ namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterA
 
 use Twig\Extension\AbstractExtension;
 
-final class WithFirstClassCallableFilter
+final class WithFirstClassCallableFilter extends AbstractExtension
 {
     #[\Twig\Attribute\AsTwigFilter(name: 'some_filter')]
     public function someFilter($value)

--- a/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/with_options_argument.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector/Fixture/with_options_argument.php.inc
@@ -80,7 +80,7 @@ use Twig\Environment;
 use Twig\Node\Node;
 use Twig\Extension\AbstractExtension;
 
-final class WithOptionsParameter
+final class WithOptionsParameter extends AbstractExtension
 {
     #[\Twig\Attribute\AsTwigFilter(name: 'with_environment', needsEnvironment: true)]
     public function withEnvironment(Environment $env, $value)

--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/some_get_functions.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/some_get_functions.php.inc
@@ -39,7 +39,7 @@ namespace Rector\Symfony\Tests\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunct
 
 use Twig\Extension\AbstractExtension;
 
-final class SomeGetFunctions
+final class SomeGetFunctions extends AbstractExtension
 {
     #[\Twig\Attribute\AsTwigFunction(name: 'some_function')]
     public function someFunction($value)

--- a/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/with_options_argument.php.inc
+++ b/rules-tests/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector/Fixture/with_options_argument.php.inc
@@ -68,7 +68,7 @@ use Twig\Environment;
 use Twig\Node\Node;
 use Twig\Extension\AbstractExtension;
 
-final class WithOptionsParameter
+final class WithOptionsParameter extends AbstractExtension
 {
     #[\Twig\Attribute\AsTwigFunction(name: 'with_environment', needsEnvironment: true)]
     public function withEnvironment(Environment $env, $value)

--- a/rules/Symfony73/GetMethodToAsTwigAttributeTransformer.php
+++ b/rules/Symfony73/GetMethodToAsTwigAttributeTransformer.php
@@ -221,13 +221,7 @@ final readonly class GetMethodToAsTwigAttributeTransformer
 
         $this->returnEmptyArrayMethodRemover->removeClassMethodIfArrayEmpty($class, $returnArray, $methodName);
 
-        // a kept built-in override leaves the array non-empty, so the class still needs the parent extension
-        if ($returnArray->items === []
-            && $class->extends instanceof FullyQualified
-            && $class->extends->toString() === TwigClass::TWIG_EXTENSION) {
-            $class->extends = null;
-        }
-
+        // "extends AbstractExtension" is kept on purpose, as it can be required by tests or other code
         return true;
     }
 

--- a/rules/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector.php
@@ -59,10 +59,11 @@ class SomeClass extends AbstractExtension
 CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
+use Twig\Extension\AbstractExtension;
 use Twig\Attribute\AsTwigFunction;
 use Twig\Environment;
 
-class SomeClass
+class SomeClass extends AbstractExtension
 {
     #[AsTwigFunction(name: 'function_name', needsEnvironment: true)]
     public function localMethod(Environment $env, $value)


### PR DESCRIPTION
`GetFiltersToAsTwigFilterAttributeRector` and `GetFunctionsToAsTwigFunctionAttributeRector` removed `extends AbstractExtension` once the last item was converted to an attribute.

That is risky: the parent class can still be relied on elsewhere, e.g. by tests asserting the class is a Twig extension, or by service registration checks. Removing it breaks such code, even though nothing in the class itself needs it anymore.

Now the parent class is kept:

```diff
 use Twig\Extension\AbstractExtension;
+use Twig\Attribute\AsTwigFunction;
 use Twig\Environment;

-class SomeClass extends AbstractExtension
+class SomeClass extends AbstractExtension
 {
-    public function getFunctions()
-    {
-        return [
-            new \Twig\TwigFunction('function_name', [$this, 'localMethod', 'needs_environment' => true]),
-        ];
-    }
-
+    #[AsTwigFunction(name: 'function_name', needsEnvironment: true)]
     public function localMethod(Environment $env, $value)
     {
         return $value;
     }
 }
```

Removing the parent class can be handled separately by a dedicated rule, where the "is it still used?" question is answered on its own.
