### PR TITLE
[Symfony 7.3] Restore merged AsTwig attribute rules as deprecated

### DIFF
--- a/rules/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/GetFiltersToAsTwigFilterAttributeRector.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Symfony73\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
+use Rector\Exception\ShouldNotHappenException;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @deprecated Handling getFilters() alone leaves the sibling getFunctions()/getTests() methods behind and can produce
+ *             a half-converted extension. Use the GetFiltersAndFunctionsToAsTwigAttributeRector rule instead, that
+ *             converts all the get methods at once.
+ */
+final class GetFiltersToAsTwigFilterAttributeRector extends AbstractRector implements DeprecatedInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes getFilters() in TwigExtension to #[AsTwigFilter] marker attribute above local class method',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Twig\Extension\AbstractExtension;
+use Twig\Environment;
+
+class SomeClass extends AbstractExtension
+{
+    public function getFilters()
+    {
+        return [
+            new \Twig\TwigFilter('filter_name', [$this, 'localMethod', 'needs_environment' => true]),
+        ];
+    }
+
+    public function localMethod(Environment $env, $value)
+    {
+        return $value;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Twig\Extension\AbstractExtension;
+use Twig\Attribute\AsTwigFilter;
+use Twig\Environment;
+
+class SomeClass extends AbstractExtension
+{
+    #[AsTwigFilter('filter_name', needsEnvironment: true)]
+    public function localMethod(Environment $env, $value)
+    {
+        return $value;
+    }
+}
+CODE_SAMPLE
+                )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Class_
+    {
+        throw new ShouldNotHappenException(sprintf(
+            '"%s" is deprecated, as it converts getFilters() only and leaves getFunctions()/getTests() behind. Use "%s" instead.',
+            self::class,
+            GetFiltersAndFunctionsToAsTwigAttributeRector::class
+        ));
+    }
+}

--- a/rules/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/GetFunctionsToAsTwigFunctionAttributeRector.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Symfony73\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use Rector\Configuration\Deprecation\Contract\DeprecatedInterface;
+use Rector\Exception\ShouldNotHappenException;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @deprecated Handling getFunctions() alone leaves the sibling getFilters()/getTests() methods behind and can produce
+ *             a half-converted extension. Use the GetFiltersAndFunctionsToAsTwigAttributeRector rule instead, that
+ *             converts all the get methods at once.
+ */
+final class GetFunctionsToAsTwigFunctionAttributeRector extends AbstractRector implements DeprecatedInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Changes getFunctions() in TwigExtension to #[AsTwigFunction] marker attribute above local class method',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Twig\Extension\AbstractExtension;
+use Twig\Environment;
+
+class SomeClass extends AbstractExtension
+{
+    public function getFunctions()
+    {
+        return [
+            new \Twig\TwigFunction('function_name', [$this, 'localMethod', 'needs_environment' => true]),
+        ];
+    }
+
+    public function localMethod(Environment $env, $value)
+    {
+        return $value;
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Twig\Extension\AbstractExtension;
+use Twig\Attribute\AsTwigFunction;
+use Twig\Environment;
+
+class SomeClass extends AbstractExtension
+{
+    #[AsTwigFunction(name: 'function_name', needsEnvironment: true)]
+    public function localMethod(Environment $env, $value)
+    {
+        return $value;
+    }
+}
+CODE_SAMPLE
+                )]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Class_
+    {
+        throw new ShouldNotHappenException(sprintf(
+            '"%s" is deprecated, as it converts getFunctions() only and leaves getFilters()/getTests() behind. Use "%s" instead.',
+            self::class,
+            GetFiltersAndFunctionsToAsTwigAttributeRector::class
+        ));
+    }
+}


### PR DESCRIPTION
PR #1027 merged `GetFiltersToAsTwigFilterAttributeRector` and `GetFunctionsToAsTwigFunctionAttributeRector` into a single `GetFiltersAndFunctionsToAsTwigAttributeRector`, but removed the old classes outright. Anyone referencing them in their own `rector.php` gets a hard "class not found" crash with no hint where the rule went.

This restores both classes as deprecated stubs that point to the replacement.

## What the deprecated rule does

Running either of the old rules now fails fast with a pointer:

```
"Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector" is deprecated,
as it converts getFilters() only and leaves getFunctions()/getTests() behind.
Use "Rector\Symfony\Symfony73\Rector\Class_\GetFiltersAndFunctionsToAsTwigAttributeRector" instead.
```

## Why they were merged

Converting one `get*()` method in isolation leaves a half-converted extension behind:

```diff
 use Twig\Extension\AbstractExtension;
+use Twig\Attribute\AsTwigFilter;

 class SomeExtension extends AbstractExtension
 {
-    public function getFilters()
-    {
-        return [new TwigFilter('filter_name', [$this, 'someFilter'])];
-    }
-
     public function getFunctions()
     {
         return [new TwigFunction('function_name', [$this, 'someFunction'])];
     }

+    #[AsTwigFilter('filter_name')]
     public function someFilter($value)
     {
         return $value;
     }
 }
```

The merged rule converts filters, functions and tests in one pass instead.

## Notes

* Follows the same deprecation shape as the SwiftMailer rules in #1026 — `DeprecatedInterface` + `ShouldNotHappenException` in `refactor()`.
* Not re-registered in any set; `composer-based.php` keeps the merged rule only.
