### PR TITLE
[ComposerBased] Add JMS attribute rules to set, bond three attribute rules to package versions

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -107,7 +107,6 @@ use Rector\Symfony\Symfony73\Rector\Class_\CommandDefaultNameAndDescriptionToAsC
 use Rector\Symfony\Symfony73\Rector\Class_\CommandHelpToAttributeRector;
 use Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector;
 use Rector\Symfony\Symfony73\Rector\Class_\GetFiltersAndFunctionsToAsTwigAttributeRector;
-use Rector\Symfony\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector;
 use Rector\Symfony\Symfony80\Rector\Class_\RemoveEraseCredentialsRector;
 use Rector\Symfony\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector;
 use Rector\Symfony\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector;
@@ -296,7 +295,6 @@ return static function (RectorConfig $rectorConfig): void {
         // symfony/console 7.3
         CommandDefaultNameAndDescriptionToAsCommandAttributeRector::class,
         CommandHelpToAttributeRector::class,
-        InvokableCommandInputAttributeRector::class,
 
         // symfony/security-core 7.3
         AddVoteArgumentToVoteOnAttributeRector::class,

--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -42,6 +42,8 @@ use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
 use Rector\Symfony\CodeQuality\Rector\AttributeGroup\SingleConditionSecurityAttributeToIsGrantedRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\SplitAndSecurityAttributeToIsGrantedRector;
+use Rector\Symfony\JMS\Rector\Class_\AccessTypeAnnotationToAttributeRector;
+use Rector\Symfony\JMS\Rector\Property\AccessorAnnotationToAttributeRector;
 use Rector\Symfony\Symfony25\Rector\MethodCall\AddViolationToBuildViolationRector;
 use Rector\Symfony\Symfony25\Rector\MethodCall\MaxLengthSymfonyFormOptionToAttrRector;
 use Rector\Symfony\Symfony26\Rector\MethodCall\RedirectToRouteRector;
@@ -105,6 +107,7 @@ use Rector\Symfony\Symfony73\Rector\Class_\CommandDefaultNameAndDescriptionToAsC
 use Rector\Symfony\Symfony73\Rector\Class_\CommandHelpToAttributeRector;
 use Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector;
 use Rector\Symfony\Symfony73\Rector\Class_\GetFiltersAndFunctionsToAsTwigAttributeRector;
+use Rector\Symfony\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector;
 use Rector\Symfony\Symfony80\Rector\Class_\RemoveEraseCredentialsRector;
 use Rector\Symfony\Symfony81\Rector\MethodCall\ConstraintValidatorValidateToValidateInContextRector;
 use Rector\Symfony\Symfony81\Rector\MethodCall\RenameCopyOnWindowsOptionToFollowSymlinksRector;
@@ -293,6 +296,7 @@ return static function (RectorConfig $rectorConfig): void {
         // symfony/console 7.3
         CommandDefaultNameAndDescriptionToAsCommandAttributeRector::class,
         CommandHelpToAttributeRector::class,
+        InvokableCommandInputAttributeRector::class,
 
         // symfony/security-core 7.3
         AddVoteArgumentToVoteOnAttributeRector::class,
@@ -318,6 +322,10 @@ return static function (RectorConfig $rectorConfig): void {
 
         // twig/twig 3.21
         GetFiltersAndFunctionsToAsTwigAttributeRector::class,
+
+        // jms/serializer 3.14
+        AccessTypeAnnotationToAttributeRector::class,
+        AccessorAnnotationToAttributeRector::class,
     ]);
 
     // shared types used by the configuration below

--- a/rules-tests/JMS/Rector/Class_/AccessTypeAnnotationToAttributeRector/AccessTypeAnnotationToAttributeRectorTest.php
+++ b/rules-tests/JMS/Rector/Class_/AccessTypeAnnotationToAttributeRector/AccessTypeAnnotationToAttributeRectorTest.php
@@ -25,4 +25,9 @@ final class AccessTypeAnnotationToAttributeRectorTest extends AbstractRectorTest
     {
         return __DIR__ . '/config/configured_rule.php';
     }
+
+    protected function provideComposerJsonFilePath(): string
+    {
+        return __DIR__ . '/config/composer.json';
+    }
 }

--- a/rules-tests/JMS/Rector/Class_/AccessTypeAnnotationToAttributeRector/config/composer.json
+++ b/rules-tests/JMS/Rector/Class_/AccessTypeAnnotationToAttributeRector/config/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "jms/serializer": "^3.14"
+    }
+}

--- a/rules-tests/JMS/Rector/Property/AccessorAnnotationToAttributeRector/AccessorAnnotationToAttributeRectorTest.php
+++ b/rules-tests/JMS/Rector/Property/AccessorAnnotationToAttributeRector/AccessorAnnotationToAttributeRectorTest.php
@@ -25,4 +25,9 @@ final class AccessorAnnotationToAttributeRectorTest extends AbstractRectorTestCa
     {
         return __DIR__ . '/config/configured_rule.php';
     }
+
+    protected function provideComposerJsonFilePath(): string
+    {
+        return __DIR__ . '/config/composer.json';
+    }
 }

--- a/rules-tests/JMS/Rector/Property/AccessorAnnotationToAttributeRector/config/composer.json
+++ b/rules-tests/JMS/Rector/Property/AccessorAnnotationToAttributeRector/config/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "jms/serializer": "^3.14"
+    }
+}

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/InvokableCommandInputAttributeRectorTest.php
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/InvokableCommandInputAttributeRectorTest.php
@@ -25,4 +25,9 @@ final class InvokableCommandInputAttributeRectorTest extends AbstractRectorTestC
     {
         return __DIR__ . '/config/configured_rule.php';
     }
+
+    protected function provideComposerJsonFilePath(): string
+    {
+        return __DIR__ . '/config/composer.json';
+    }
 }

--- a/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/config/composer.json
+++ b/rules-tests/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector/config/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "symfony/console": "^7.3"
+    }
+}

--- a/rules/JMS/Rector/Class_/AccessTypeAnnotationToAttributeRector.php
+++ b/rules/JMS/Rector/Class_/AccessTypeAnnotationToAttributeRector.php
@@ -14,6 +14,8 @@ use Rector\Php80\ValueObject\AnnotationToAttribute;
 use Rector\PhpAttribute\GenericAnnotationToAttributeConverter;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\Enum\JMSAnnotation;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -22,12 +24,17 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\Symfony\Tests\JMS\Rector\Class_\AccessTypeAnnotationToAttributeRector\AccessTypeAnnotationToAttributeRectorTest
  */
-final class AccessTypeAnnotationToAttributeRector extends AbstractRector
+final class AccessTypeAnnotationToAttributeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly GenericAnnotationToAttributeConverter $genericAnnotationToAttributeConverter
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('jms/serializer', '>=3.14');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/JMS/Rector/Property/AccessorAnnotationToAttributeRector.php
+++ b/rules/JMS/Rector/Property/AccessorAnnotationToAttributeRector.php
@@ -14,19 +14,26 @@ use Rector\PhpAttribute\GenericAnnotationToAttributeConverter;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\Enum\JMSAnnotation;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\Symfony\Tests\JMS\Rector\Property\AccessorAnnotationToAttributeRector\AccessorAnnotationToAttributeRectorTest
  */
-final class AccessorAnnotationToAttributeRector extends AbstractRector
+final class AccessorAnnotationToAttributeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly DocBlockUpdater $docBlockUpdater,
         private readonly ValueResolver $valueResolver,
         private readonly GenericAnnotationToAttributeConverter $genericAnnotationToAttributeConverter
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('jms/serializer', '>=3.14');
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/InvokableCommandInputAttributeRector.php
@@ -27,6 +27,8 @@ use Rector\Symfony\Symfony73\NodeTransformer\CommandUnusedInputOutputRemover;
 use Rector\Symfony\Symfony73\NodeTransformer\ConsoleOptionAndArgumentMethodCallVariableReplacer;
 use Rector\Symfony\Symfony73\NodeTransformer\OutputInputSymfonyStyleReplacer;
 use Rector\ValueObject\MethodName;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -38,7 +40,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see \Rector\Symfony\Tests\Symfony73\Rector\Class_\InvokableCommandInputAttributeRector\InvokableCommandInputAttributeRectorTest
  */
-final class InvokableCommandInputAttributeRector extends AbstractRector
+final class InvokableCommandInputAttributeRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     private const array MIGRATED_CONFIGURE_CALLS = ['addArgument', 'addOption'];
 
@@ -51,6 +53,11 @@ final class InvokableCommandInputAttributeRector extends AbstractRector
         private readonly OutputInputSymfonyStyleReplacer $outputInputSymfonyStyleReplacer,
         private readonly CommandUnusedInputOutputRemover $commandUnusedInputOutputRemover
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('symfony/console', '>=7.3');
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
Two JMS attribute-migration rules were missing from the composer-based Symfony set, and three attribute rules declared no `ComposerPackageConstraintInterface` at all. This adds the bonding to all three, and registers the two JMS rules in the set.

Versions were verified against the upstream tags, not guessed — see **Version sources** below.

## `AccessorAnnotationToAttributeRector` — `jms/serializer >=3.14`

```diff
 use JMS\Serializer\Annotation\Accessor;

 class User
 {
-    /**
-     * @Accessor("getValue")
-     */
+    #[Accessor(getter: 'getValue')]
     private $value;
 }
```

## `AccessTypeAnnotationToAttributeRector` — `jms/serializer >=3.14`

```diff
 use JMS\Serializer\Annotation\AccessType;

-/**
- * @AccessType("public_method")
- */
+#[AccessType(type: 'public_method')]
 class User
 {
 }
```

## `InvokableCommandInputAttributeRector` — `symfony/console >=7.3`, bonded but **not** registered

This rule gets the version constraint, but is deliberately left out of the composer-based set — the transformation is still too risky to hand to everyone running the set unattended:

```diff
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Argument;
+use Symfony\Component\Console\Option;

 #[AsCommand(name: 'some_name')]
-final class SomeCommand extends Command
+final class SomeCommand
 {
-    public function configure()
-    {
-        $this->addArgument('argument', InputArgument::REQUIRED, 'Argument description');
-        $this->addOption('option', 'o', InputOption::VALUE_NONE, 'Option description');
-    }
-
-    public function execute(InputInterface $input, OutputInterface $output)
-    {
-        $someArgument = $input->getArgument('argument');
-        $someOption = $input->getOption('option');
+    public function __invoke(
+        #[Argument(name: 'argument', description: 'Argument description')]
+        string $argument,
+        #[Option(name: 'option', shortcut: 'o', mode: Option::VALUE_NONE, description: 'Option description')]
+        bool $option = false,
+    ) {
+        $someArgument = $argument;
+        $someOption = $option;

         // ...

         return Command::SUCCESS;
     }
 }
```

It stays opt-in via a direct `$rectorConfig->rule()` call, and now correctly skips itself on `symfony/console` below 7.3.

## Version sources

* `symfony/console` — `Attribute/Argument.php` is absent at tag `v7.2.0` and present at `v7.3.0`.
* `jms/serializer` — `Accessor.php` and `AccessType.php` gain their `#[\Attribute(...)]` declaration between tags `3.13.0` and `3.14.0`, from schmittjoh/serializer#1332 and #1337 (merged 1–5 Aug 2021, released in 3.14.0 on 6 Aug 2021).

## Notes

* Both JMS rules stay registered in `config/sets/jms/annotations-to-attributes.php` as well, so the standalone JMS set keeps working for non-Symfony users.
* Each of the three rule tests gained a `config/composer.json` plus a `provideComposerJsonFilePath()` override, matching the existing bonded rules — neither package is in `require-dev`, so the version is read from the test's own `composer.json`. Verified the gate is live: dropping the JMS test constraint to `^3.13` makes both fixtures fail, as expected.
