### PR TITLE
chore: Update dispatch build on push to main to rebuild rector-src

### DIFF
--- a/.github/workflows/dispatch_build_scoped_rector.yaml
+++ b/.github/workflows/dispatch_build_scoped_rector.yaml
@@ -3,14 +3,15 @@
 name: Dispatch Build Scoped Rector
 
 on:
-    pull_request:
-        types:
-            - closed
+    push:
+        branches:
+            - main
+    workflow_dispatch: null
 
 jobs:
     dispatch_build_scoped_rector:
-        # only for merged pull requests in this repository, not forks
-        if: github.event.pull_request.merged == true && github.repository == 'rectorphp/rector-symfony'
+        # only for this repository, not forks
+        if: github.repository == 'rectorphp/rector-symfony'
 
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
when on push to main (merged to main), it use rector-src and rebuild scoped build.