### PR TITLE
[Symfony 2.8] Add rename of Simple(Pre|Form)AuthenticatorInterface from Core to Http namespace

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -397,6 +397,13 @@ return static function (RectorConfig $rectorConfig): void {
         ),
     ], 'symfony/routing', '>=2.8');
 
+    // symfony/symfony 2.8
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameClassRector::class, [
+        // @see https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#security
+        'Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface' => 'Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface',
+        'Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface' => 'Symfony\Component\Security\Http\Authentication\SimpleFormAuthenticatorInterface',
+    ], 'symfony/symfony', '>=2.8');
+
     // symfony/bridge-swift-mailer 3.0
     $rectorConfig->ruleWithConfigurationComposerVersionBound(RenameClassRector::class, [
         // swift mailer


### PR DESCRIPTION
Symfony 2.8 deprecated the `Simple*AuthenticatorInterface` interfaces in the `Security\Core` namespace and moved them to `Security\Http`. They were removed later, so the rename is a required upgrade step.

Added to `composer-based.php`, bonded to `symfony/symfony >=2.8`.

```diff
-use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
+use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface;

-use Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface;
+use Symfony\Component\Security\Http\Authentication\SimpleFormAuthenticatorInterface;
```

Ref: https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#security
