### PR TITLE
[Symfony 6.1] Add RouteRequirementStringToConstantRector

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -89,6 +89,7 @@ use Rector\Symfony\Symfony52\Rector\StaticCall\BinaryFileResponseCreateToNewInst
 use Rector\Symfony\Symfony53\Rector\StaticPropertyFetch\KernelTestCaseContainerPropertyDeprecationRector;
 use Rector\Symfony\Symfony60\Rector\FuncCall\ContainerInterfaceServiceToServiceContainerRector;
 use Rector\Symfony\Symfony60\Rector\MethodCall\GetHelperControllerToServiceRector;
+use Rector\Symfony\Symfony61\Rector\Attribute\RouteRequirementStringToConstantRector;
 use Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector;
 use Rector\Symfony\Symfony61\Rector\Class_\CommandPropertyToAttributeRector;
 use Rector\Symfony\Symfony61\Rector\Class_\MagicClosureTwigExtensionToNativeMethodsRector;
@@ -261,6 +262,9 @@ return static function (RectorConfig $rectorConfig): void {
         // symfony/console 6.1
         CommandConfigureToAttributeRector::class,
         CommandPropertyToAttributeRector::class,
+
+        // symfony/routing 6.1
+        RouteRequirementStringToConstantRector::class,
 
         // symfony/twig-bridge 6.1
         MagicClosureTwigExtensionToNativeMethodsRector::class,

--- a/rules-tests/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector/Fixture/skip_unknown_requirement.php.inc
+++ b/rules-tests/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector/Fixture/skip_unknown_requirement.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Attribute\RouteRequirementStringToConstantRector\Fixture;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+final class SkipUnknownRequirement
+{
+    #[Route('/detail/{slug}', requirements: [
+        'slug' => '[a-z]{3}',
+    ])]
+    public function detail()
+    {
+    }
+}

--- a/rules-tests/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector/Fixture/uuid_requirement.php.inc
+++ b/rules-tests/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector/Fixture/uuid_requirement.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Attribute\RouteRequirementStringToConstantRector\Fixture;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+final class UuidRequirement
+{
+    #[Route('/detail/{id}', requirements: [
+        'id' => '[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}',
+    ])]
+    public function detail()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Attribute\RouteRequirementStringToConstantRector\Fixture;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+final class UuidRequirement
+{
+    #[Route('/detail/{id}', requirements: [
+        'id' => \Symfony\Component\Routing\Requirement\Requirement::UUID_V4,
+    ])]
+    public function detail()
+    {
+    }
+}
+
+?>

--- a/rules-tests/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector/RouteRequirementStringToConstantRectorTest.php
+++ b/rules-tests/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector/RouteRequirementStringToConstantRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony61\Rector\Attribute\RouteRequirementStringToConstantRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RouteRequirementStringToConstantRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/rules-tests/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector/config/configured_rule.php
+++ b/rules-tests/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Symfony61\Rector\Attribute\RouteRequirementStringToConstantRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(RouteRequirementStringToConstantRector::class);
+};

--- a/rules/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector.php
+++ b/rules/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Symfony\Symfony61\Rector\Attribute;
 
+use PhpParser\Node\Identifier;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Attribute;
@@ -26,10 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RouteRequirementStringToConstantRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
-    /**
-     * @var string
-     */
-    private const REQUIREMENT_CLASS = 'Symfony\Component\Routing\Requirement\Requirement';
+    private const string REQUIREMENT_CLASS = 'Symfony\Component\Routing\Requirement\Requirement';
 
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
@@ -137,7 +135,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (! $arg->name instanceof Node\Identifier) {
+            if (! $arg->name instanceof Identifier) {
                 continue;
             }
 

--- a/rules/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector.php
+++ b/rules/Symfony61/Rector/Attribute/RouteRequirementStringToConstantRector.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Symfony61\Rector\Attribute;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\Rector\AbstractRector;
+use Rector\Symfony\Enum\SymfonyAnnotation;
+use Rector\Symfony\Enum\SymfonyAttribute;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Covers:
+ * - https://github.com/symfony/symfony/blob/6.1/UPGRADE-6.1.md#routing
+ *
+ * @see \Rector\Symfony\Tests\Symfony61\Rector\Attribute\RouteRequirementStringToConstantRector\RouteRequirementStringToConstantRectorTest
+ */
+final class RouteRequirementStringToConstantRector extends AbstractRector implements ComposerPackageConstraintInterface
+{
+    /**
+     * @var string
+     */
+    private const REQUIREMENT_CLASS = 'Symfony\Component\Routing\Requirement\Requirement';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('symfony/routing', '>=6.1');
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace regex string in #[Route] requirements with a Requirement constant',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+use Symfony\Component\Routing\Attribute\Route;
+
+final class SomeController
+{
+    #[Route('/detail/{id}', requirements: [
+        'id' => '[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}',
+    ])]
+    public function detail()
+    {
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
+
+final class SomeController
+{
+    #[Route('/detail/{id}', requirements: [
+        'id' => Requirement::UUID_V4,
+    ])]
+    public function detail()
+    {
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Attribute::class];
+    }
+
+    /**
+     * @param Attribute $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isNames($node->name, [SymfonyAttribute::ROUTE, SymfonyAnnotation::ROUTE])) {
+            return null;
+        }
+
+        $requirementsArray = $this->resolveRequirementsArray($node);
+        if (! $requirementsArray instanceof Array_) {
+            return null;
+        }
+
+        $constantNamesByValue = $this->resolveConstantNamesByValue();
+        if ($constantNamesByValue === []) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($requirementsArray->items as $arrayItem) {
+            if (! $arrayItem->value instanceof String_) {
+                continue;
+            }
+
+            $constantName = $constantNamesByValue[$arrayItem->value->value] ?? null;
+            if ($constantName === null) {
+                continue;
+            }
+
+            $arrayItem->value = $this->nodeFactory->createClassConstFetch(self::REQUIREMENT_CLASS, $constantName);
+            $hasChanged = true;
+        }
+
+        if (! $hasChanged) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function resolveRequirementsArray(Attribute $attribute): ?Array_
+    {
+        foreach ($attribute->args as $arg) {
+            if (! $arg instanceof Arg) {
+                continue;
+            }
+
+            if (! $arg->name instanceof Node\Identifier) {
+                continue;
+            }
+
+            if (! $this->isName($arg->name, 'requirements')) {
+                continue;
+            }
+
+            if (! $arg->value instanceof Array_) {
+                return null;
+            }
+
+            return $arg->value;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function resolveConstantNamesByValue(): array
+    {
+        if (! $this->reflectionProvider->hasClass(self::REQUIREMENT_CLASS)) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass(self::REQUIREMENT_CLASS);
+
+        $constantNamesByValue = [];
+
+        foreach ($classReflection->getNativeReflection()->getConstants() as $constantName => $constantValue) {
+            // skip enum cases and non-regex constants
+            if (! is_string($constantValue)) {
+                continue;
+            }
+
+            $constantNamesByValue[$constantValue] = $constantName;
+        }
+
+        return $constantNamesByValue;
+    }
+}


### PR DESCRIPTION
Custom rule alternative to #1036 — scoped to `#[Route]` requirements instead of a global `StringToClassConstantRector` configuration.

```diff
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Requirement\Requirement;

 final class SomeController
 {
     #[Route('/detail/{id}', requirements: [
-        'id' => '[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}',
+        'id' => Requirement::UUID_V4,
     ])]
     public function detail()
     {
     }
 }
```

Why a custom rule:

* `StringToClassConstantRector` replaces the regex **anywhere** in the project - in a `preg_match()` call, a validator constraint, a test fixture. Here the replacement only happens inside the `requirements:` argument of `#[Route]`.
* The constant map is read from the installed `Requirement` class via reflection, so each project gets exactly the constants its `symfony/routing` version has - no per-version config blocks (6.1 / 6.2 / 7.3) to keep in sync, and `MONGODB_ID` starts applying automatically once a project is on 7.3.
* Version bonded via `ComposerPackageConstraintInterface` to `symfony/routing >=6.1`, registered once in `config/sets/symfony/composer-based.php`.
