### PR TITLE
[CodeQuality] Skip loadValidatorMetadata() containing addConstraint(new Callback())

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_closure_callback_with_movable_constraint.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector/Fixture/skip_closure_callback_with_movable_constraint.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+final class SkipClosureCallbackWithMovableConstraint
+{
+    private $city;
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->addPropertyConstraint('city', new Assert\NotBlank());
+        $metadata->addConstraint(new Callback(
+            function (self $self, ExecutionContextInterface $context): void {
+                $context->buildViolation('nope')
+                    ->atPath('city')
+                    ->addViolation();
+            },
+        ));
+    }
+}

--- a/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector.php
+++ b/rules/CodeQuality/Rector/Class_/LoadValidatorMetadataToAttributeRector.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Rector\Symfony\CodeQuality\Rector\Class_;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
+use PhpParser\NodeFinder;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\NodeAnalyzer\ValidatorAssert\ConstantExpressionAnalyzer;
 use Rector\Symfony\NodeAnalyzer\ValidatorAssert\ConstraintAttributeTargetAnalyzer;
@@ -111,6 +114,12 @@ CODE_SAMPLE
                 return null;
             }
 
+            // a Callback constraint holding a closure cannot be turned into an attribute; moving the
+            // surrounding constraints out would break the validation, so the whole method is left untouched
+            if ($this->hasClosureCallbackConstraint($classStmt)) {
+                return null;
+            }
+
             $hasChanged = false;
 
             foreach ($classStmt->stmts as $classMethodStmtKey => $methodStmt) {
@@ -164,6 +173,32 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function hasClosureCallbackConstraint(ClassMethod $classMethod): bool
+    {
+        $nodeFinder = new NodeFinder();
+
+        foreach ((array) $classMethod->stmts as $methodStmt) {
+            $classConstraintNew = $this->metadataConstraintResolver->resolveClassConstraint($methodStmt);
+            if (! $classConstraintNew instanceof New_) {
+                continue;
+            }
+
+            if (! $this->isName($classConstraintNew->class, 'Symfony\Component\Validator\Constraints\Callback')) {
+                continue;
+            }
+
+            $closure = $nodeFinder->findFirst(
+                $classConstraintNew->args,
+                static fn (Node $node): bool => $node instanceof Closure || $node instanceof ArrowFunction
+            );
+            if ($closure instanceof Node) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function refactorClassConstraint(Class_ $class, New_ $constraintNew): bool


### PR DESCRIPTION
A `Callback` constraint wraps a closure or a method reference. It cannot be expressed as constant attribute arguments, so moving the surrounding constraints out and leaving (or converting) the `Callback` breaks validation.

Now `LoadValidatorMetadataToAttributeRector` leaves the whole `loadValidatorMetadata()` method untouched when it contains `$metadata->addConstraint(new Callback(...))`.

Before this change, a `Callback` class constraint was converted to a class attribute:

```diff
-final class SomeClass
-{
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new Assert\Callback('validatePostalCode'));
-    }
-}
+#[\Symfony\Component\Validator\Constraints\Callback('validatePostalCode')]
+final class SomeClass
+{
+}
```

Now such a method is skipped entirely — no change — including when a movable constraint sits beside the `Callback`:

```php
// left untouched
public static function loadValidatorMetadata(ClassMetadata $metadata): void
{
    $metadata->addPropertyConstraint('city', new Assert\NotBlank());
    $metadata->addConstraint(new Assert\Callback('validateCity'));
}
```