### PR TITLE
[Symfony72] Fix PushRequestToRequestStackConstructorRector leaving pushed request undefined

### DIFF
--- a/rules-tests/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector/Fixture/statements_between_new_and_push.php.inc
+++ b/rules-tests/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector/Fixture/statements_between_new_and_push.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony72\Rector\StmtsAwareInterface\PushRequestToRequestStackConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class StatementsBetweenNewAndPush extends TestCase
+{
+    public function testThis()
+    {
+        $requestStack = new RequestStack();
+        $request = new Request();
+        $request->setLocale('fr');
+        $requestStack->push($request);
+    }
+}
+
+?>
+-----
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Symfony72\Rector\StmtsAwareInterface\PushRequestToRequestStackConstructorRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class StatementsBetweenNewAndPush extends TestCase
+{
+    public function testThis()
+    {
+        $request = new Request();
+        $request->setLocale('fr');
+        $requestStack = new RequestStack([$request]);
+    }
+}
+
+?>

--- a/rules/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector.php
+++ b/rules/Symfony72/Rector/StmtsAwareInterface/PushRequestToRequestStackConstructorRector.php
@@ -101,6 +101,7 @@ CODE_SAMPLE
         }
 
         // keep every "new RequestStack()" per variable name, to append the request pushed on that very variable
+        // stored as [statement key, New_], so the assignment can be moved down to the push() position
         $requestStackNewsByVariableName = [];
         $hasChanged = false;
 
@@ -117,7 +118,7 @@ CODE_SAMPLE
 
                 $emptyRequestStackNew = $this->matchEmptyRequestStackNew($assign->expr);
                 if ($emptyRequestStackNew instanceof New_) {
-                    $requestStackNewsByVariableName[$assign->var->name] = $emptyRequestStackNew;
+                    $requestStackNewsByVariableName[$assign->var->name] = [$key, $emptyRequestStackNew];
                 }
 
                 continue;
@@ -141,17 +142,24 @@ CODE_SAMPLE
             }
 
             $variableName = $pushMethodCall->var->name;
-            $requestStackNew = $requestStackNewsByVariableName[$variableName] ?? null;
-            if (! $requestStackNew instanceof New_) {
+            $requestStackNewData = $requestStackNewsByVariableName[$variableName] ?? null;
+            if ($requestStackNewData === null) {
                 continue;
             }
+
+            [$assignKey, $requestStackNew] = $requestStackNewData;
 
             $array = new Array_([new ArrayItem($pushMethodCall->getArgs()[0]->value)]);
             $requestStackNew->args[] = new Arg($array);
             $requestStackNew->setAttribute(AttributeKey::ORIGINAL_NODE, null);
 
+            // move the "new RequestStack([...])" assignment down to the push() position, so any statements
+            // between them - including the ones defining the pushed request - stay before it
+            $node->stmts[$key] = $node->stmts[$assignKey];
+            unset($node->stmts[$assignKey]);
+
             // the constructor takes a single array of requests, so no further push can be merged
-            unset($requestStackNewsByVariableName[$variableName], $node->stmts[$key]);
+            unset($requestStackNewsByVariableName[$variableName]);
 
             $hasChanged = true;
         }


### PR DESCRIPTION
Fixes rectorphp/rector#9849

The rule merged `$stack->push($request)` into `new RequestStack([$request])` **at the `new` keyword's position** and only deleted the `push()` line. Any statements between the two — including the ones that define and configure the pushed variable — were left after the merged line, so the argument was used before it existed.

Fix: move the `new RequestStack([...])` assignment down to the `push()` position instead of mutating it in place. Statements between stay before it.

```diff
 $requestStack = new RequestStack();
 $request = new Request();
 $request->setLocale('fr');
-$requestStack->push($request);
+$requestStack = new RequestStack([$request]);
```

Before this fix the (broken) output was:

```php
$requestStack = new RequestStack([$request]); // $request not yet defined
$request = new Request();
$request->setLocale('fr');
```

Added fixture `statements_between_new_and_push.php.inc` covering the case.