### PR TITLE
[CodeQuality] Fix InlineClassRoutePrefixRector duplicating route name prefix on attribute routes

### DIFF
--- a/rules-tests/CodeQuality/Rector/Class_/InlineClassRoutePrefixRector/Fixture/with_existing_name2.php.inc
+++ b/rules-tests/CodeQuality/Rector/Class_/InlineClassRoutePrefixRector/Fixture/with_existing_name2.php.inc
@@ -23,7 +23,6 @@ namespace Rector\Symfony\Tests\CodeQuality\Rector\Class_\InlineClassRoutePrefixR
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Routing\Annotation\Route;
 
-#[\Symfony\Component\Routing\Attribute\Route(name: "some_org.")]
 final class WithExistingName2 extends Controller
 {
     #[\Symfony\Component\Routing\Attribute\Route('/city/street', name: 'some_org.some')]

--- a/rules/CodeQuality/Rector/Class_/InlineClassRoutePrefixRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineClassRoutePrefixRector.php
@@ -132,6 +132,7 @@ CODE_SAMPLE
 
         // 2. inline prefix to all method routes
         $hasChanged = false;
+        $classRouteNameInlined = false;
 
         foreach ($node->getMethods() as $classMethod) {
             if ($this->shouldSkipMethod($classMethod)) {
@@ -197,6 +198,10 @@ CODE_SAMPLE
                                 continue;
                             }
 
+                            if (! is_string($classRouteName)) {
+                                continue;
+                            }
+
                             $methodRouteString = $methodRouteArg->value;
                             $methodRouteArg->value = new String_(sprintf(
                                 '%s%s',
@@ -204,6 +209,7 @@ CODE_SAMPLE
                                 $methodRouteString->value
                             ));
 
+                            $classRouteNameInlined = true;
                             $hasChanged = true;
                         }
                     }
@@ -233,6 +239,12 @@ CODE_SAMPLE
                         foreach ($attribute->args as $attributeArgKey => $attributeArg) {
                             // silent or "path"
                             if ($attributeArg->name === null || $attributeArg->name->toString() === self::PATH) {
+                                unset($attribute->args[$attributeArgKey]);
+                                continue;
+                            }
+
+                            // "name" was already inlined into method routes, drop it to avoid a doubled prefix
+                            if ($classRouteNameInlined && $attributeArg->name->toString() === 'name') {
                                 unset($attribute->args[$attributeArgKey]);
                             }
                         }


### PR DESCRIPTION
Fixes rectorphp/rector#9851

On **attribute** routes, `InlineClassRoutePrefixRector` inlined the class-level path into method routes and concatenated the class `name:` prefix onto method route names, but left the class-level `name:` argument in place. Symfony then applied the prefix a second time, so `some_org.some` was registered as `some_org.some_org.some` → `RouteNotFoundException` across the app.

The annotation path already dropped the whole class tag, so only the attribute path was affected.

Now the class-level `name:` arg is removed once it has been inlined into the method names (dropping the whole class attribute if nothing else remains).

```diff
-#[Route("/city", name: "some_org.")]
 final class WithExistingName2 extends Controller
 {
-    #[Route("/street", name: "some")]
+    #[Route('/city/street', name: 'some_org.some')]
     public function some()
     {
     }
 }
```

Class-level `name:` is kept untouched when no method name is concatenated (e.g. methods without a `name:`), so the Symfony-generated prefix still applies once.
