### PR TITLE
[ComposerBased] Skip change to iterable on symfony DataMapperInterface on symfony >= 5.3

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -1698,18 +1698,6 @@ return static function (RectorConfig $rectorConfig): void {
             0,
             new StringType()
         ),
-        new AddParamTypeDeclaration(
-            'Symfony\Component\Form\DataMapperInterface',
-            'mapFormsToData',
-            0,
-            $iterableType
-        ),
-        new AddParamTypeDeclaration(
-            'Symfony\Component\Form\DataMapperInterface',
-            'mapDataToForms',
-            1,
-            $iterableType
-        ),
         new AddParamTypeDeclaration('Symfony\Component\Form\Form', 'add', 1, $nullableStringType),
         new AddParamTypeDeclaration('Symfony\Component\Form\Form', 'remove', 0, new StringType()),
         new AddParamTypeDeclaration('Symfony\Component\Form\Form', 'has', 0, new StringType()),
@@ -1763,6 +1751,22 @@ return static function (RectorConfig $rectorConfig): void {
             new StringType()
         ),
     ], 'symfony/form', '>=5.0');
+
+    // symfony/form 5.0, changed back in 5.3
+    $rectorConfig->ruleWithConfigurationComposerVersionBound(AddParamTypeDeclarationRector::class, [
+        new AddParamTypeDeclaration(
+            'Symfony\Component\Form\DataMapperInterface',
+            'mapFormsToData',
+            0,
+            $iterableType
+        ),
+        new AddParamTypeDeclaration(
+            'Symfony\Component\Form\DataMapperInterface',
+            'mapDataToForms',
+            1,
+            $iterableType
+        ),
+    ], 'symfony/form', '>=5.0 <5.3');
 
     // symfony/process 5.0
     $rectorConfig->ruleWithConfigurationComposerVersionBound(AddParamTypeDeclarationRector::class, [

--- a/stubs/Symfony/Component/Form/DataMapperInterface.php
+++ b/stubs/Symfony/Component/Form/DataMapperInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+interface DataMapperInterface
+{
+}

--- a/tests/Issues/Issue9850/Fixture/skip_data_mapper_traversable.php.inc
+++ b/tests/Issues/Issue9850/Fixture/skip_data_mapper_traversable.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bar;
+
+use Symfony\Component\Form\DataMapperInterface;
+use Traversable;
+
+class Foo implements DataMapperInterface
+{
+    public function mapDataToForms($viewData, Traversable $forms): void
+    {
+    }
+
+    public function mapFormsToData(Traversable $forms, &$viewData): void
+    {
+    }
+}

--- a/tests/Issues/Issue9850/Issue9850Test.php
+++ b/tests/Issues/Issue9850/Issue9850Test.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Symfony\Tests\Issues\Issue9850;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Issue9850Test extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/composer_based.php';
+    }
+
+    protected function provideComposerJsonFilePath(): string
+    {
+        return __DIR__ . '/config/composer.json';
+    }
+}

--- a/tests/Issues/Issue9850/config/composer.json
+++ b/tests/Issues/Issue9850/config/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "symfony/form": "^8.1"
+    }
+}

--- a/tests/Issues/Issue9850/config/composer_based.php
+++ b/tests/Issues/Issue9850/config/composer_based.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Composer\InstalledPackageResolver;
+use Rector\Config\RectorConfig;
+use Rector\Util\Reflection\PrivatesAccessor;
+
+return static function (RectorConfig $rectorConfig): void {
+    $privatesAccessor = new PrivatesAccessor();
+    $privatesAccessor->setPrivateProperty(
+        $rectorConfig,
+        'installedPackageResolver',
+        new InstalledPackageResolver(composerJsonFilePath: __DIR__ . '/composer.json')
+    );
+
+    $rectorConfig->sets([__DIR__ . '/../../../../config/sets/symfony/composer-based.php']);
+
+    $privatesAccessor->setPrivateProperty($rectorConfig, 'installedPackageResolver', null);
+};


### PR DESCRIPTION
On symfony 5.0, the param is changed from `Traversable` to `iterable`. 
On symfony 5.3, the param is changed from `iterable` to `Traversable`.

so the original `Traversable` was changed:

`Traversable` - `iterable` - `Traversable`

back and forth never ending.

This PR fix it by avoid change to `iterable` when it already `Traversable` and symfony version is `>=5.3`.

Fixes https://github.com/rectorphp/rector/issues/9850

