### PR TITLE
[Symfony30] Skip OptionNameRector when no option name changes

### DIFF
--- a/rules-tests/Symfony30/Rector/MethodCall/OptionNameRector/Fixture/skip_no_old_option.php.inc
+++ b/rules-tests/Symfony30/Rector/MethodCall/OptionNameRector/Fixture/skip_no_old_option.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony30\Rector\MethodCall\OptionNameRector\Fixture;
+
+use Rector\Symfony\Tests\Symfony30\Rector\MethodCall\OptionNameRector\Source\AbstractType;
+use Symfony\Component\Form\FormBuilder;
+
+class SkipNoOldOption extends AbstractType
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder->add('price1', 'text', array(
+            'label' => 'form.price1',
+            'scale' => 3,
+        ));
+    }
+}

--- a/rules/Symfony30/Rector/MethodCall/OptionNameRector.php
+++ b/rules/Symfony30/Rector/MethodCall/OptionNameRector.php
@@ -87,6 +87,7 @@ CODE_SAMPLE
             return null;
         }
 
+        $hasChanged = false;
         foreach ($optionsArray->items as $arrayItemNode) {
             if (! $arrayItemNode instanceof ArrayItem) {
                 continue;
@@ -96,16 +97,26 @@ CODE_SAMPLE
                 continue;
             }
 
-            $this->processStringKey($arrayItemNode->key);
+            if ($this->processStringKey($arrayItemNode->key)) {
+                $hasChanged = true;
+            }
+        }
+
+        if (! $hasChanged) {
+            return null;
         }
 
         return $node;
     }
 
-    private function processStringKey(String_ $string): void
+    private function processStringKey(String_ $string): bool
     {
         $currentOptionName = $string->value;
+        if (! isset(self::OLD_TO_NEW_OPTION[$currentOptionName])) {
+            return false;
+        }
 
-        $string->value = self::OLD_TO_NEW_OPTION[$currentOptionName] ?? $string->value;
+        $string->value = self::OLD_TO_NEW_OPTION[$currentOptionName];
+        return true;
     }
 }


### PR DESCRIPTION
`OptionNameRector` returned the `MethodCall` node unconditionally, so Rector marked **any** form `add()` call carrying an options array as changed — even when no `precision`/`virtual` option was present.

Now the rule tracks whether a rename actually happened and returns `null` otherwise.

### Before (falsely reported as changed)

```php
$builder->add('price1', 'text', [
    'label' => 'form.price1',
    'scale' => 3, // no old option -> should be left untouched
]);
```

### After

No change — file is skipped.

Added `skip_no_old_option.php.inc` fixture guarding the regression.