### PR TITLE
[CodeQuality] Move version-bonded rules to composer-based set

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -42,6 +42,7 @@ use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
 use Rector\Symfony\CodeQuality\Rector\AttributeGroup\SingleConditionSecurityAttributeToIsGrantedRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\SplitAndSecurityAttributeToIsGrantedRector;
+use Rector\Symfony\CodeQuality\Rector\MethodCall\ParameterBagTypedGetMethodCallRector;
 use Rector\Symfony\JMS\Rector\Class_\AccessTypeAnnotationToAttributeRector;
 use Rector\Symfony\JMS\Rector\Property\AccessorAnnotationToAttributeRector;
 use Rector\Symfony\Symfony25\Rector\MethodCall\AddViolationToBuildViolationRector;
@@ -229,6 +230,9 @@ return static function (RectorConfig $rectorConfig): void {
         // symfony/security-http 5.1
         LogoutHandlerToLogoutEventSubscriberRector::class,
         LogoutSuccessHandlerToLogoutEventSubscriberRector::class,
+
+        // symfony/http-foundation 5.1
+        ParameterBagTypedGetMethodCallRector::class,
 
         // symfony/dependency-injection 5.2
         DefinitionAliasSetPrivateToSetPublicRector::class,

--- a/config/sets/symfony/symfony-code-quality.php
+++ b/config/sets/symfony/symfony-code-quality.php
@@ -3,14 +3,12 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Symfony\CodeQuality\Rector\AttributeGroup\SingleConditionSecurityAttributeToIsGrantedRector;
 use Rector\Symfony\CodeQuality\Rector\BinaryOp\RequestIsMainRector;
 use Rector\Symfony\CodeQuality\Rector\BinaryOp\ResponseStatusCodeRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\InlineClassRoutePrefixRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector;
-use Rector\Symfony\CodeQuality\Rector\Class_\SplitAndSecurityAttributeToIsGrantedRector;
 use Rector\Symfony\CodeQuality\Rector\ClassMethod\ParamTypeFromRouteRequiredRegexRector;
 use Rector\Symfony\CodeQuality\Rector\ClassMethod\RemoveUnusedRequestParamRector;
 use Rector\Symfony\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector;
@@ -19,11 +17,9 @@ use Rector\Symfony\CodeQuality\Rector\MethodCall\LiteralGetToRequestClassConstan
 use Rector\Symfony\CodeQuality\Rector\MethodCall\ParameterBagTypedGetMethodCallRector;
 use Rector\Symfony\CodeQuality\Rector\MethodCall\StringCastDebugResponseRector;
 use Rector\Symfony\CodeQuality\Rector\Trait_\AddTraitGetterReturnTypeBasedOnSetterRequiredRector;
-use Rector\Symfony\Symfony26\Rector\MethodCall\RedirectToRouteRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
-        RedirectToRouteRector::class,
         EventListenerToEventSubscriberRector::class,
         ResponseReturnTypeControllerActionRector::class,
         EventSubscriberMethodReturnVoidRector::class,
@@ -48,9 +44,6 @@ return static function (RectorConfig $rectorConfig): void {
         // routing
         InlineClassRoutePrefixRector::class,
 
-        // narrow attributes
-        SingleConditionSecurityAttributeToIsGrantedRector::class,
-        SplitAndSecurityAttributeToIsGrantedRector::class,
         AddTraitGetterReturnTypeBasedOnSetterRequiredRector::class,
     ]);
 };

--- a/config/sets/symfony/symfony-code-quality.php
+++ b/config/sets/symfony/symfony-code-quality.php
@@ -14,7 +14,6 @@ use Rector\Symfony\CodeQuality\Rector\ClassMethod\RemoveUnusedRequestParamRector
 use Rector\Symfony\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerActionRector;
 use Rector\Symfony\CodeQuality\Rector\MethodCall\AssertSameResponseCodeWithDebugContentsRector;
 use Rector\Symfony\CodeQuality\Rector\MethodCall\LiteralGetToRequestClassConstantRector;
-use Rector\Symfony\CodeQuality\Rector\MethodCall\ParameterBagTypedGetMethodCallRector;
 use Rector\Symfony\CodeQuality\Rector\MethodCall\StringCastDebugResponseRector;
 use Rector\Symfony\CodeQuality\Rector\Trait_\AddTraitGetterReturnTypeBasedOnSetterRequiredRector;
 
@@ -35,7 +34,6 @@ return static function (RectorConfig $rectorConfig): void {
 
         // request method
         RequestIsMainRector::class,
-        ParameterBagTypedGetMethodCallRector::class,
 
         // tests
         AssertSameResponseCodeWithDebugContentsRector::class,

--- a/rules/CodeQuality/Rector/MethodCall/ParameterBagTypedGetMethodCallRector.php
+++ b/rules/CodeQuality/Rector/MethodCall/ParameterBagTypedGetMethodCallRector.php
@@ -13,17 +13,24 @@ use PHPStan\Type\ObjectType;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\Enum\SymfonyClass;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\Symfony\Tests\CodeQuality\Rector\MethodCall\ParameterBagTypedGetMethodCallRector\ParameterBagTypedGetMethodCallRectorTest
  */
-final class ParameterBagTypedGetMethodCallRector extends AbstractRector
+final class ParameterBagTypedGetMethodCallRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly ValueResolver $valueResolver
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        return new ComposerPackageConstraint('symfony/http-foundation', '>=5.1');
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
These rules are version-bonded via `ComposerPackageConstraintInterface` and belong in `composer-based.php` under their Symfony version, yet were duplicated in `symfony-code-quality.php`. Moves each to a single set matching its composer bond.

| Rule | Constraint |
| --- | --- |
| `SingleConditionSecurityAttributeToIsGrantedRector` | `symfony/security-http >=6.2` |
| `SplitAndSecurityAttributeToIsGrantedRector` | `symfony/security-http >=6.2` |
| `RedirectToRouteRector` | `symfony/framework-bundle >=2.6` |
| `ParameterBagTypedGetMethodCallRector` | `symfony/http-foundation >=5.1` (interface added) |

`ParameterBagTypedGetMethodCallRector` had no version bond; it now implements `ComposerPackageConstraintInterface` since it relies on `ParameterBag::getBoolean()` on the `InputBag`-based query bag (Symfony 5.1+).
