### PR TITLE
[CodeQuality] Move RequestIsMainRector to composer-based version-bonded set

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -40,6 +40,7 @@ use Rector\Renaming\ValueObject\RenameClassConstFetch;
 use Rector\Renaming\ValueObject\RenameProperty;
 use Rector\StaticTypeMapper\ValueObject\Type\SimpleStaticType;
 use Rector\Symfony\CodeQuality\Rector\AttributeGroup\SingleConditionSecurityAttributeToIsGrantedRector;
+use Rector\Symfony\CodeQuality\Rector\BinaryOp\RequestIsMainRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\SplitAndSecurityAttributeToIsGrantedRector;
 use Rector\Symfony\CodeQuality\Rector\MethodCall\ParameterBagTypedGetMethodCallRector;
@@ -256,6 +257,9 @@ return static function (RectorConfig $rectorConfig): void {
 
         // symfony/framework-bundle 5.3
         KernelTestCaseContainerPropertyDeprecationRector::class,
+
+        // symfony/http-kernel 5.3
+        RequestIsMainRector::class,
 
         // symfony/dependency-injection 6.0
         ContainerInterfaceServiceToServiceContainerRector::class,

--- a/config/sets/symfony/symfony-code-quality.php
+++ b/config/sets/symfony/symfony-code-quality.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Symfony\CodeQuality\Rector\BinaryOp\RequestIsMainRector;
 use Rector\Symfony\CodeQuality\Rector\BinaryOp\ResponseStatusCodeRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\EventListenerToEventSubscriberRector;
 use Rector\Symfony\CodeQuality\Rector\Class_\EventSubscriberMethodReturnVoidRector;
@@ -28,9 +27,6 @@ return static function (RectorConfig $rectorConfig): void {
 
         // controller
         LoadValidatorMetadataToAttributeRector::class,
-
-        // request method
-        RequestIsMainRector::class,
 
         // tests
         AssertSameResponseCodeWithDebugContentsRector::class,

--- a/rules/CodeQuality/Rector/BinaryOp/RequestIsMainRector.php
+++ b/rules/CodeQuality/Rector/BinaryOp/RequestIsMainRector.php
@@ -13,17 +13,25 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
 use Rector\Symfony\Enum\SymfonyClass;
+use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
+use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see \Rector\Symfony\Tests\CodeQuality\Rector\BinaryOp\RequestIsMainRector\RequestIsMainRectorTest
  */
-final class RequestIsMainRector extends AbstractRector
+final class RequestIsMainRector extends AbstractRector implements ComposerPackageConstraintInterface
 {
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider
     ) {
+    }
+
+    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    {
+        // isMainRequest()/MAIN_REQUEST added in Symfony 5.3
+        return new ComposerPackageConstraint('symfony/http-kernel', '>=5.3');
     }
 
     public function getRuleDefinition(): RuleDefinition


### PR DESCRIPTION
`RequestIsMainRector` rewrites the old master/main request comparison to `$request->isMainRequest()`:

```diff
-return $request->getRequestType() === HttpKernel::MAIN_REQUEST;
+return $request->isMainRequest();
```

That target API — `HttpKernelInterface::MAIN_REQUEST` and `isMainRequest()` — was **added in Symfony 5.3** (replacing `MASTER_REQUEST` / `isMasterRequest()`). On older projects the rule would rewrite to a method that does not exist yet.

So this bonds the rule to its version:

- `RequestIsMainRector` now implements `ComposerPackageConstraintInterface`, returning `ComposerPackageConstraint('symfony/http-kernel', '>=5.3')`
- moved out of the plain `symfony-code-quality` set into the version-bonded `composer-based` set

The rule only runs when the analysed project actually has symfony/http-kernel 5.3+.