### PR TITLE
[Symfony 7.3] Gate GetFiltersAndFunctionsToAsTwigAttributeRector on symfony/twig-bridge 7.3, not twig alone

### DIFF
--- a/config/sets/symfony/composer-based.php
+++ b/config/sets/symfony/composer-based.php
@@ -330,7 +330,7 @@ return static function (RectorConfig $rectorConfig): void {
         // symfony/validator 8.1
         ConstraintValidatorValidateToValidateInContextRector::class,
 
-        // twig/twig 3.21
+        // twig/twig 3.21 + symfony/twig-bridge 7.3
         GetFiltersAndFunctionsToAsTwigAttributeRector::class,
 
         // jms/serializer 3.14

--- a/rules-tests/Symfony73/Rector/Class_/GetFiltersAndFunctionsToAsTwigAttributeRector/config/composer.json
+++ b/rules-tests/Symfony73/Rector/Class_/GetFiltersAndFunctionsToAsTwigAttributeRector/config/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "twig/twig": "^3.21"
+        "twig/twig": "^3.21",
+        "symfony/twig-bridge": "^7.3"
     }
 }

--- a/rules/Symfony73/Rector/Class_/GetFiltersAndFunctionsToAsTwigAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/GetFiltersAndFunctionsToAsTwigAttributeRector.php
@@ -27,9 +27,14 @@ final class GetFiltersAndFunctionsToAsTwigAttributeRector extends AbstractRector
     ) {
     }
 
-    public function provideComposerPackageConstraint(): ComposerPackageConstraint
+    public function provideComposerPackageConstraint(): array
     {
-        return new ComposerPackageConstraint('twig/twig', '>=3.21');
+        // the #[AsTwig*] attributes exist in twig/twig 3.21, but Symfony only autoregisters extension-less
+        // classes from them in symfony/twig-bridge 7.3; without both, the stripped TwigExtension is silently lost
+        return [
+            new ComposerPackageConstraint('twig/twig', '>=3.21'),
+            new ComposerPackageConstraint('symfony/twig-bridge', '>=7.3'),
+        ];
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/rules/Symfony73/Rector/Class_/GetFiltersAndFunctionsToAsTwigAttributeRector.php
+++ b/rules/Symfony73/Rector/Class_/GetFiltersAndFunctionsToAsTwigAttributeRector.php
@@ -27,6 +27,9 @@ final class GetFiltersAndFunctionsToAsTwigAttributeRector extends AbstractRector
     ) {
     }
 
+    /**
+     * @return ComposerPackageConstraint[]
+     */
     public function provideComposerPackageConstraint(): array
     {
         // the #[AsTwig*] attributes exist in twig/twig 3.21, but Symfony only autoregisters extension-less


### PR DESCRIPTION
Fixes [rectorphp/rector#9856](https://github.com/rectorphp/rector/issues/9856).

## Problem

`GetFiltersAndFunctionsToAsTwigAttributeRector` was bonded to `twig/twig >=3.21` only. But the attributes it introduces (`#[AsTwigFilter]`, `#[AsTwigFunction]`, `#[AsTwigTest]`) are autoregistered by Symfony only from **7.3** (`symfony/twig-bridge`). On Symfony 6.4 with twig 3.28, the twig constraint passes, the rule strips `TwigExtension` + `getFilters()`/`getFunctions()`, and every filter/function silently disappears.

```php
// Symfony 6.4, twig 3.28 -> rule wrongly applied, filters lost
class AppExtension extends AbstractExtension
{
    public function getFilters(): array
    {
        return [new TwigFilter('foo', [$this, 'foo'])];
    }
}
```

## Fix

Gate on **both** packages, so the rule runs only where the attributes actually work:

```php
public function provideComposerPackageConstraint(): array
{
    return [
        new ComposerPackageConstraint('twig/twig', '>=3.21'),
        new ComposerPackageConstraint('symfony/twig-bridge', '>=7.3'),
    ];
}
```

## Depends on

Multiple-constraint support: rectorphp/rector-src#8355. CI here stays red until that merges into `rector-src` `main` (pulled as `dev-main`).
