### PR TITLE
[Symfony34] Skip ContainerGetNameToTypeInTestsRector when named service has no matching FQCN service

### DIFF
--- a/rules-tests/Symfony34/Rector/Closure/ContainerGetNameToTypeInTestsRector/Fixture/skip_named_service_without_fqcn_service.php.inc
+++ b/rules-tests/Symfony34/Rector/Closure/ContainerGetNameToTypeInTestsRector/Fixture/skip_named_service_without_fqcn_service.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Symfony\Tests\Symfony34\Rector\Closure\ContainerGetNameToTypeInTestsRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class SkipNamedServiceWithoutFqcnService extends TestCase
+{
+    public function run()
+    {
+        /** @var ContainerInterface $container */
+        $container = $this->getContainer();
+        $rule = $container->get('rule.engine.payment.options');
+    }
+}

--- a/rules-tests/Symfony34/Rector/Closure/ContainerGetNameToTypeInTestsRector/xml/services.xml
+++ b/rules-tests/Symfony34/Rector/Closure/ContainerGetNameToTypeInTestsRector/xml/services.xml
@@ -3,5 +3,11 @@
     <services>
         <!-- ->register(id, class) -->
         <service id="some_name" class="App\Some\Type"></service>
+        <!-- explicit FQCN service, so the named service maps to an existing type service -->
+        <service id="App\Some\Type" alias="some_name" public="true"></service>
+
+        <!-- two named services share one class, no FQCN service registered for it -->
+        <service id="rule.engine.payment.options" class="App\RuleEngine\Rules\MoleculeRule"></service>
+        <service id="rule.engine.delivery.options" class="App\RuleEngine\Rules\MoleculeRule"></service>
     </services>
 </container>

--- a/rules/Symfony34/Rector/Closure/ContainerGetNameToTypeInTestsRector.php
+++ b/rules/Symfony34/Rector/Closure/ContainerGetNameToTypeInTestsRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
 use Rector\Rector\AbstractRector;
+use Rector\Symfony\DataProvider\ServiceMapProvider;
 use Rector\Symfony\NodeAnalyzer\ServiceTypeMethodCallResolver;
 use Rector\VersionBonding\Contract\ComposerPackageConstraintInterface;
 use Rector\VersionBonding\ValueObject\ComposerPackageConstraint;
@@ -27,6 +28,7 @@ final class ContainerGetNameToTypeInTestsRector extends AbstractRector implement
     public function __construct(
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly ServiceTypeMethodCallResolver $serviceTypeMethodCallResolver,
+        private readonly ServiceMapProvider $serviceMapProvider,
     ) {
     }
 
@@ -112,7 +114,14 @@ CODE_SAMPLE
             return null;
         }
 
-        $classConstFetch = new ClassConstFetch(new FullyQualified($serviceType->getClassName()), 'class');
+        // only replace when the resolved class is itself a registered service id (real service or alias),
+        // otherwise the named service maps to a class that has no matching FQCN service and the call breaks
+        $className = $serviceType->getClassName();
+        if (! $this->serviceMapProvider->provide()->hasService($className)) {
+            return null;
+        }
+
+        $classConstFetch = new ClassConstFetch(new FullyQualified($className), 'class');
         $node->args[0] = new Arg($classConstFetch);
 
         return $node;


### PR DESCRIPTION
Fixes rectorphp/rector#9839

`ContainerGetNameToTypeInTestsRector` replaced any named service reference with its class FQCN, even when no service is registered under that FQCN. When two named services share one class, the produced `get(SomeClass::class)` call points to a service id that does not exist and breaks at runtime.

Now the rule only replaces when the resolved class is itself a registered service id in the container (a real service or an alias) — the same signal that makes `'twig'` → `Twig\Environment::class` valid.

### Skipped (no FQCN service registered)

Given two named services sharing one class:

```xml
<service id="rule.engine.payment.options" class="App\RuleEngine\Rules\MoleculeRule"/>
<service id="rule.engine.delivery.options" class="App\RuleEngine\Rules\MoleculeRule"/>
```

```php
// unchanged - App\RuleEngine\Rules\MoleculeRule is not a service id
$rule = $container->get('rule.engine.payment.options');
```

### Still applied (explicit FQCN service exists)

```diff
-$someClass = $container->get('some_name');
+$someClass = $container->get(\App\Some\Type::class);
```
